### PR TITLE
Fix buoy calc bug. Dycoms now match scampy

### DIFF
--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -16,13 +16,13 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 6.3536385843055188e+00
-best_mse["updraft_area"] = 2.5438198039492320e+02
-best_mse["updraft_w"] = 1.4580760890721545e-01
-best_mse["updraft_qt"] = 6.2206824225474186e+01
-best_mse["updraft_thetal"] = 6.9045907993199918e+01
-best_mse["u_mean"] = 8.7994360629093563e+01
-best_mse["tke_mean"] = 4.1928585158278855e+00
+best_mse["qt_mean"] = 6.7939652328911526e+00
+best_mse["updraft_area"] = 2.6728907094911216e+02
+best_mse["updraft_w"] = 3.3246977024115265e-01
+best_mse["updraft_qt"] = 6.0684798609715308e+01
+best_mse["updraft_thetal"] = 6.9056681132480222e+01
+best_mse["u_mean"] = 8.7994360629093748e+01
+best_mse["tke_mean"] = 4.1453532207769657e+00
 
 @testset "ARM_SGP" begin
     println("Running ARM_SGP...")

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -16,14 +16,14 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 9.2252903509363715e-02
-best_mse["updraft_area"] = 7.0235539272413644e+02
-best_mse["updraft_w"] = 8.6070840001214961e+01
-best_mse["updraft_qt"] = 5.9331735398681467e+00
-best_mse["updraft_thetal"] = 2.3062107189097777e+01
-best_mse["v_mean"] = 1.2364792615634521e+02
-best_mse["u_mean"] = 5.3488455050251318e+01
-best_mse["tke_mean"] = 3.3051689506631028e+01
+best_mse["qt_mean"] = 8.3714605287379840e-02
+best_mse["updraft_area"] = 7.0261471608838769e+02
+best_mse["updraft_w"] = 8.7816638538794919e+01
+best_mse["updraft_qt"] = 5.9507020645408675e+00
+best_mse["updraft_thetal"] = 2.3060117074268717e+01
+best_mse["v_mean"] = 1.2345803739170998e+02
+best_mse["u_mean"] = 5.3487302586046809e+01
+best_mse["tke_mean"] = 3.2225602904370149e+01
 
 @testset "Bomex" begin
     println("Running Bomex...")

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -16,15 +16,15 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 2.4080653050071930e-02
-best_mse["ql_mean"] = 1.2384009655013500e+02
-best_mse["updraft_area"] = 2.0289574450333936e+02
-best_mse["updraft_w"] = 3.7381317919464681e+00
-best_mse["updraft_qt"] = 7.3627730160904625e-01
-best_mse["updraft_thetal"] = 1.2763401818623445e+01
-best_mse["v_mean"] = 3.9937577145913970e+01
-best_mse["u_mean"] = 3.5689297667797483e+01
-best_mse["tke_mean"] = 2.8069695242105951e+01
+best_mse["qt_mean"] = 3.8001673126194867e-02
+best_mse["ql_mean"] = 8.4578478184878048e+00
+best_mse["updraft_area"] = 2.2324280164372593e+02
+best_mse["updraft_w"] = 3.4444820774461329e+00
+best_mse["updraft_qt"] = 1.3810722649106608e+00
+best_mse["updraft_thetal"] = 1.2761175148454377e+01
+best_mse["v_mean"] = 4.0030908804636987e+01
+best_mse["u_mean"] = 3.5747541514399444e+01
+best_mse["tke_mean"] = 1.4604768548409767e+01
 
 
 @testset "DYCOMS_RF01" begin

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -16,14 +16,14 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.6390882603444535e-01
-best_mse["updraft_area"] = 1.8853365676495407e+03
-best_mse["updraft_w"] = 4.7945623382280445e+02
-best_mse["updraft_qt"] = 2.3388706679021720e+01
-best_mse["updraft_thetal"] = 6.5607702975773350e+01
-best_mse["v_mean"] = 1.0612839837263861e+02
-best_mse["u_mean"] = 1.1376717535211569e+02
-best_mse["tke_mean"] = 9.3298033101721171e+02
+best_mse["qt_mean"] = 4.0432375728696790e-01
+best_mse["updraft_area"] = 1.8875614747005029e+03
+best_mse["updraft_w"] = 4.7945553218441751e+02
+best_mse["updraft_qt"] = 2.3512519674647539e+01
+best_mse["updraft_thetal"] = 6.5601910609184642e+01
+best_mse["v_mean"] = 1.0614382605973881e+02
+best_mse["u_mean"] = 1.1383366513167900e+02
+best_mse["tke_mean"] = 8.9241612675577824e+02
 
 @testset "Rico" begin
     println("Running Rico...")

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -16,13 +16,13 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 2.5281925724570736e-01
-best_mse["updraft_area"] = 8.0505846143469341e+02
-best_mse["updraft_w"] = 2.4989429382521031e+01
-best_mse["updraft_qt"] = 1.0556629689231746e+01
-best_mse["updraft_thetal"] = 2.1622593049473402e+01
-best_mse["u_mean"] = 4.2420351837474118e+03
-best_mse["tke_mean"] = 7.9909840262364895e+01
+best_mse["qt_mean"] = 2.5654529603089010e-01
+best_mse["updraft_area"] = 7.7772077592145229e+02
+best_mse["updraft_w"] = 2.4476512452627702e+01
+best_mse["updraft_qt"] = 1.0639744567172206e+01
+best_mse["updraft_thetal"] = 2.1622331422297314e+01
+best_mse["u_mean"] = 4.2569022743548685e+03
+best_mse["tke_mean"] = 8.1460797862144929e+01
 
 @testset "Soares" begin
     println("Running Soares...")

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -16,14 +16,14 @@ using .ParamList
 include(joinpath("utils", "main.jl"))
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.5887952438571511e+00
-best_mse["updraft_area"] = 2.7567309212676908e+04
-best_mse["updraft_w"] = 8.3284578439530367e+02
-best_mse["updraft_qt"] = 2.6477768979796817e+01
-best_mse["updraft_thetal"] = 1.1133163765141744e+02
-best_mse["v_mean"] = 2.9887530573861000e+02
-best_mse["u_mean"] = 1.6846997921575100e+03
-best_mse["tke_mean"] = 3.2347475342303137e+03
+best_mse["qt_mean"] = 3.0653862333906230e+00
+best_mse["updraft_area"] = 2.7495023710812657e+04
+best_mse["updraft_w"] = 9.7223483893047478e+02
+best_mse["updraft_qt"] = 2.6322481932140143e+01
+best_mse["updraft_thetal"] = 1.1133829792791128e+02
+best_mse["v_mean"] = 2.9873166404994379e+02
+best_mse["u_mean"] = 1.6851451431733847e+03
+best_mse["tke_mean"] = 2.5415289921483309e+03
 
 @testset "TRMM_LBA" begin
     println("Running TRMM_LBA...")

--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -181,7 +181,7 @@ function compute_mse(
                 label = "SCAMPy",
             )
             @info "Saving $(joinpath(foldername, "$tc_var.png"))"
-            savefig(joinpath(foldername, "$tc_var.png"))
+            savefig(joinpath(foldername, "profile_$tc_var.png"))
 
             contourf(
                 time_scm, z_scm, data_scm_arr';

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -382,6 +382,8 @@ function buoyancy(
     )
 
     gw = self.Gr.gw
+    qt = 0.0
+    h = 0.0
 
     UpdVar.Area.bulkvalues .= up_sum(UpdVar.Area.values)
 
@@ -413,8 +415,6 @@ function buoyancy(
                 elseif UpdVar.Area.values[i,k-1] > 0.0 && k>self.Gr.gw
                     # TODO: report bug:
                     # qt and h were not defined here before the function call.
-                    qt = UpdVar.QT.values[i,k]
-                    h = UpdVar.H.values[i,k]
                     sa = eos(self.t_to_prog_fp,
                         self.prog_to_t_fp,
                         self.Ref.p0_half[k],


### PR DESCRIPTION
Turned out this was the last missing piece. What I thought was a bug fix, I overlooked that `ql` and `h` are _decremented_, and simply needed initial values (they're not initialized in SCAMPy). I don't understand exactly how this works, and why we want it that way, but I'll leave those changes / improvements for a later PR.

DYCOMS now appears nearly identical with SCAMPy master (commit `496dad0c2438235684823511cacbf5761d6a237c`) 🎉 