### PR TITLE
Fix nh pressure index, as this is indexing into OffsetArray

### DIFF
--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -1135,7 +1135,7 @@ function compute_nh_pressure(self)
 
     @inbounds for i in xrange(self.n_updrafts)
         input.updraft_top = self.UpdVar.updraft_top[i]
-        alen = length(argwhere(self.UpdVar.Area.values[i, cinterior]))
+        alen = max(length(argwhere(self.UpdVar.Area.values[i, cinterior])) - 1, 0)
         avals = off_arr(self.UpdVar.Area.values[i, cinterior])
         input.a_med = Statistics.median(avals[0:alen])
         @inbounds for k in xrange(grid(self).gw, grid(self).nzg - grid(self).gw)


### PR DESCRIPTION
#25 exercises the case where `alen` is equal to the length of `avals`. As this is an offset array, the proper translation was to use `xrange`, which effectively means indexing with `0:alen-1`.