### PR TITLE
add correction to run without tests

### DIFF
--- a/integration_tests/utils/generate_namelist.jl
+++ b/integration_tests/utils/generate_namelist.jl
@@ -354,6 +354,11 @@ end
 
 function write_file(namelist)
 
+    @assert haskey(namelist, "meta")
+    @assert haskey(namelist["meta"], "simname")
+
+    namelist["meta"]["uuid"] = basename(tempname())
+
     open("namelist_" * namelist["meta"]["casename"] * ".in", "w") do io
         JSON.print(io, namelist, 4)
     end


### PR DESCRIPTION
without this fix running:
julia --project integration_tests/utils/generate_namelist.jl Soares
julia --project integration_tests/utils/main.jl Soares
breaks with:

"""""

ERROR: LoadError: KeyError: key "uuid" not found
Stacktrace:
 [1] getindex(h::Dict{String, Any}, key::String)
   @ Base ./dict.jl:482
 [2] TurbulenceConvection.NetCDFIO_Stats(namelist::Dict{String, Any}, Gr::TurbulenceConvection.Grid{OffsetArrays.OffsetVector{Float64, Vector{Float64}}, Float64})
   @ TurbulenceConvection ~/Documents/codes/TurbulenceConvection.jl/src/NetCDFIO.jl:29
 [3] Simulation1d(namelist::Dict{String, Any})
   @ Main ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:27
 [4] main1d(namelist::Dict{String, Any}; time_run::Bool)
   @ Main ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:105
 [5] main1d
   @ ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:105 [inlined]
 [6] #main#1
   @ ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:101 [inlined]
 [7] main(namelist::Dict{String, Any})
   @ Main ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:101
 [8] top-level scope
   @ ~/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:138
in expression starting at /Users/yaircohen/Documents/codes/TurbulenceConvection.jl/integration_tests/utils/main.jl:130

"""""

as uuid is only added in the test file.