### PR TITLE
move max_supersaturation to namelist

### DIFF
--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -188,6 +188,7 @@ function sgs_mean(self::EnvironmentThermodynamics, EnvVar::EnvironmentVariables,
         # autoconversion and accretion
         mph = microphysics_rain_src(
             Rain.rain_model,
+            Rain.max_supersaturation,
             EnvVar.QT.values[k],
             sa.ql,
             Rain.Env_QR.values[k],
@@ -323,6 +324,7 @@ function sgs_quadrature(self::EnvironmentThermodynamics, EnvVar::EnvironmentVari
                     # autoconversion and accretion
                     mph = microphysics_rain_src(
                         Rain.rain_model,
+                        Rain.max_supersaturation,
                         qt_hat,
                         sa.ql,
                         Rain.Env_QR.values[k],
@@ -402,6 +404,7 @@ function sgs_quadrature(self::EnvironmentThermodynamics, EnvVar::EnvironmentVari
             sa = eos(self.t_to_prog_fp, self.prog_to_t_fp, self.Ref.p0_half[k], EnvVar.QT.values[k], EnvVar.H.values[k])
             mph = microphysics_rain_src(
                 Rain.rain_model,
+                Rain.max_supersaturation,
                 EnvVar.QT.values[k],
                 sa.ql,
                 Rain.Env_QR.values[k],

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -477,6 +477,7 @@ function microphysics(self::UpdraftThermodynamics, UpdVar::UpdraftVariables, Rai
             # autoconversion and accretion
             mph = microphysics_rain_src(
                 Rain.rain_model,
+                Rain.max_supersaturation,
                 UpdVar.QT.new[i, k],
                 UpdVar.QL.new[i, k],
                 Rain.Upd_QR.values[k],

--- a/src/microphysics_functions.jl
+++ b/src/microphysics_functions.jl
@@ -24,7 +24,7 @@ end
 # instantly convert all cloud water exceeding a threshold to rain water
 # the threshold is specified as axcess saturation
 # rain water is immediately removed from the domain
-function acnv_instant(ql, qt, T, p0)
+function acnv_instant(max_supersaturation, ql, qt, T, p0)
 
     psat = pv_star(T)
     qsat = qv_star_c(p0, qt, psat)
@@ -101,7 +101,7 @@ return
   new values: qt, ql, qv, thl, th, alpha
   rates: qr_src, thl_rain_src
 """
-function microphysics_rain_src(rain_model, qt, ql, qr, area, T, p0, rho, dt)
+function microphysics_rain_src(rain_model, max_supersaturation, qt, ql, qr, area, T, p0, rho, dt)
 
     # TODO assumes no ice
     _ret = mph_struct(0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -131,7 +131,7 @@ function microphysics_rain_src(rain_model, qt, ql, qr, area, T, p0, rho, dt)
         end
 
         if tmp_cutoff_acnv_flag
-            _ret.qr_src = fmin(ql, acnv_instant(ql, qt, T, p0))
+            _ret.qr_src = fmin(ql, acnv_instant(max_supersaturation, ql, qt, T, p0))
         end
 
         if tmp_no_acnv_flag

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -36,5 +36,3 @@ const K_therm = 2.4e-2
 const D_vapor = 2.26e-5
 const a_vent = 1.5
 const b_vent = 0.53
-# cutoff microphysics parameter
-const max_supersaturation = 0.02

--- a/src/types.jl
+++ b/src/types.jl
@@ -117,6 +117,7 @@ end
 
 Base.@kwdef mutable struct RainVariables
     rain_model::String = "default_rain_model"
+    max_supersaturation::Float64
     mean_rwp::Float64 = 0
     env_rwp::Float64 = 0
     upd_rwp::Float64 = 0
@@ -156,8 +157,15 @@ function RainVariables(namelist, Gr::Grid)
         error("rain model not recognized")
     end
 
+    max_supersaturation = try
+        namelist["microphysics"]["max_supersaturation"]
+    catch
+        0.02
+    end
+
     return RainVariables(;
         rain_model,
+        max_supersaturation,
         mean_rwp,
         env_rwp,
         upd_rwp,


### PR DESCRIPTION
This is one step towards moving the microphysics parameters to the namelist, so that we can use the calibration pipeline for those parameters. I have confirmed the results using the rain_model = 'cutoff' are the same after this change. @trontrytel @charleskawczynski Could you please take a look and let me know whether it makes sense? Thanks!