### PR TITLE
Match scampy by using linear interpolation

### DIFF
--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -11,13 +11,13 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 6.7066415019414212e+00
-best_mse["updraft_area"] = 2.6634274082490697e+02
-best_mse["updraft_w"] = 2.6471400756560365e-01
-best_mse["updraft_qt"] = 6.0143099892375709e+01
-best_mse["updraft_thetal"] = 6.9062807673298735e+01
-best_mse["u_mean"] = 8.7994360629094302e+01
-best_mse["tke_mean"] = 4.1628443606689931e+00
+best_mse["qt_mean"] = 5.5166749573532592e-01
+best_mse["updraft_area"] = 2.8505841871593282e+02
+best_mse["updraft_w"] = 7.7404844506417481e-01
+best_mse["updraft_qt"] = 5.2600486259435868e+01
+best_mse["updraft_thetal"] = 6.9238569266089868e+01
+best_mse["u_mean"] = 8.7994360629094174e+01
+best_mse["tke_mean"] = 2.9609371778386242e+00
 
 @testset "ARM_SGP" begin
     println("Running ARM_SGP...")

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -11,14 +11,14 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.0653870799814622e+00
-best_mse["updraft_area"] = 2.7495027092511747e+04
-best_mse["updraft_w"] = 9.7223505744470913e+02
-best_mse["updraft_qt"] = 2.6322483788147938e+01
-best_mse["updraft_thetal"] = 1.1133829792870439e+02
-best_mse["v_mean"] = 2.9873166545343321e+02
-best_mse["u_mean"] = 1.6851451412164733e+03
-best_mse["tke_mean"] = 2.5415255485687139e+03
+best_mse["qt_mean"] = 3.9046069426901999e+00
+best_mse["updraft_area"] = 2.8342045114790926e+04
+best_mse["updraft_w"] = 6.5629758352987142e+02
+best_mse["updraft_qt"] = 2.5132229019229900e+01
+best_mse["updraft_thetal"] = 1.1134327794549542e+02
+best_mse["v_mean"] = 2.9403541501868523e+02
+best_mse["u_mean"] = 1.6903138683581105e+03
+best_mse["tke_mean"] = 2.8534421778168139e+03
 
 @testset "TRMM_LBA" begin
     println("Running TRMM_LBA...")

--- a/src/python_primitives.jl
+++ b/src/python_primitives.jl
@@ -34,6 +34,6 @@ power(a::AbstractVector, b::AbstractVector) = a .^ b
 linspace(a, b; num = 50) = range(a, b; length = num)
 
 function pyinterp(x::T, xp::T, fp::T) where {T}
-    spl = Dierckx.Spline1D([xp...], [fp...])
+    spl = Dierckx.Spline1D([xp...], [fp...]; k = 1)
     return off_arr(spl([x...]))
 end


### PR DESCRIPTION
This PR changes `pyinterp` to use linear interpolation, which is what `numpy.interp` does by default.

I believe TRMM should match with SCAMPy far better with these changes. This should hopefully give us a clearer view of how #43 changes the results.