### PR TITLE
Swap plots so that TC.jl is last

### DIFF
--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -157,8 +157,8 @@ function compute_mse(
         if plot_comparison
             p = Plots.plot()
             Plots.plot!(data_les_cont_mapped, z_tcc ./ 10^3, xlabel = tc_var, ylabel = "z [km]", label = "PyCLES")
-            Plots.plot!(data_tcc_cont_mapped, z_tcc ./ 10^3, xlabel = tc_var, ylabel = "z [km]", label = "TC.jl")
             Plots.plot!(data_scm_cont_mapped, z_tcc ./ 10^3, xlabel = tc_var, ylabel = "z [km]", label = "SCAMPy")
+            Plots.plot!(data_tcc_cont_mapped, z_tcc ./ 10^3, xlabel = tc_var, ylabel = "z [km]", label = "TC.jl")
             @info "     Saving $(joinpath(foldername, "$tc_var.png"))"
             Plots.savefig(joinpath(foldername, "profile_$tc_var.png"))
             clims_min = min(minimum(data_scm_arr), minimum(data_tcc_arr))


### PR DESCRIPTION
It's a bit difficult to see all plots when they're right on top of each other, and therefore difficult to know if the TC.jl solution is very good or NaNs (NaNs solutions do not show up). This PR swaps the order so that TC is last so that it's always clear. I think that not seeing the artifact file solutions (behind the TC.jl solution) is okay since they don't change and are never NaNs.