### PR TITLE
Fix translation bug in ref state bcs

### DIFF
--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -11,14 +11,14 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.9046069426901999e+00
+best_mse["qt_mean"] = 3.9046069426789907e+00
 best_mse["updraft_area"] = 2.8342045114790926e+04
 best_mse["updraft_w"] = 6.5629758352987142e+02
-best_mse["updraft_qt"] = 2.5132229019229900e+01
-best_mse["updraft_thetal"] = 1.1134327794549542e+02
-best_mse["v_mean"] = 2.9403541501868523e+02
-best_mse["u_mean"] = 1.6903138683581105e+03
-best_mse["tke_mean"] = 2.8534421778168139e+03
+best_mse["updraft_qt"] = 2.5132229019169145e+01
+best_mse["updraft_thetal"] = 1.1134328331311413e+02
+best_mse["v_mean"] = 2.9404204554100676e+02
+best_mse["u_mean"] = 1.6903145439466905e+03
+best_mse["tke_mean"] = 2.8715535630659565e+03
 
 @testset "TRMM_LBA" begin
     println("Running TRMM_LBA...")


### PR DESCRIPTION
This is likely not what we want in the end, but for early-on comparisons, and perhaps if there are assumptions elsewhere about how the ref state bcs are applied, this PR fixes a translation bug in the ref state bcs: in SCAMPy, the `p_half` field has two missing elements at the start and end of the array, and _both_ points are _mirrored_ in _log-space_ about the boundary. This enters the computations [here](https://github.com/CliMA/TurbulenceConvection.jl/blob/main/src/Turbulence_PrognosticTKE.jl#L511).