### PR TITLE
Turn off codecov comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%


### PR DESCRIPTION
Codecov comments in the files changed is really noisy and gets in the way of code review. Let's turn off the codecov comments it.