### PR TITLE
Move τ_cond_evap to clima params method call

### DIFF
--- a/integration_tests/utils/parameter_set.jl
+++ b/integration_tests/utils/parameter_set.jl
@@ -1,3 +1,4 @@
+import TurbulenceConvection
 import CLIMAParameters
 using CLIMAParameters: AbstractEarthParameterSet
 using CLIMAParameters.Planet
@@ -7,10 +8,15 @@ struct EarthParameterSet{NT} <: AbstractEarthParameterSet
 end
 
 CLIMAParameters.Planet.MSLP(ps::EarthParameterSet) = ps.nt.MSLP
+CLIMAParameters.Atmos.Microphysics.τ_cond_evap(ps::EarthParameterSet) = ps.nt.τ_cond_evap
 
+#! format: off
 function create_parameter_set(namelist)
+    TC = TurbulenceConvection
     nt = (;
         MSLP = 100000.0, # or grab from, e.g., namelist[""][...]
+        τ_cond_evap = TC.parse_namelist(namelist, "microphysics", "τ_cond_evap"; default = 10.0),
     )
     return EarthParameterSet(nt)
 end
+#! format: on

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -11,12 +11,20 @@ using OffsetArrays
 using FastGaussQuadrature: gausshermite
 using LinearAlgebra
 
+import CLIMAParameters
+using CLIMAParameters: AbstractEarthParameterSet
+const APS = AbstractEarthParameterSet
+
+const CPMP = CLIMAParameters.Atmos.Microphysics
+const CPEDMF = CLIMAParameters.Atmos.EDMF
+const CPSGS = CLIMAParameters.Atmos.SubgridScale
+
 # For dispatching to inherited class
 struct BaseCase end
 
 up_sum(vals::OffsetArray) = off_arr(reshape(sum(vals; dims = 1), size(vals, 2)))
 
-function parse_param(namelist, keys...; default = nothing)
+function parse_namelist(namelist, keys...; default = nothing)
     @assert default ≠ nothing
     param = namelist
     for k in keys

--- a/src/microphysics_functions.jl
+++ b/src/microphysics_functions.jl
@@ -52,9 +52,9 @@ function terminal_velocity(C_drag, MP_n_0, q_rai, rho)
     return term_vel
 end
 
-function conv_q_vap_to_q_liq(tau_cond_evap, q_sat_liq, q_liq)
+function conv_q_vap_to_q_liq(param_set::APS, q_sat_liq, q_liq)
 
-    return (q_sat_liq - q_liq) / tau_cond_evap
+    return (q_sat_liq - q_liq) / CPMP.τ_cond_evap(param_set)
 end
 
 function conv_q_liq_to_q_rai_acnv(q_liq_threshold, tau_acnv, q_liq)

--- a/src/types.jl
+++ b/src/types.jl
@@ -118,7 +118,6 @@ Base.@kwdef mutable struct RainVariables
     max_supersaturation::Float64
     C_drag::Float64
     MP_n_0::Float64
-    tau_cond_evap::Float64
     q_liq_threshold::Float64
     tau_acnv::Float64
     E_col::Float64
@@ -180,12 +179,6 @@ function RainVariables(namelist, Gr::Grid)
         16 * 1e6
     end
 
-    tau_cond_evap = try
-        namelist["microphysics"]["tau_cond_evap"]
-    catch
-        10.0
-    end
-
     q_liq_threshold = try
         namelist["microphysics"]["q_liq_threshold"]
     catch
@@ -221,7 +214,6 @@ function RainVariables(namelist, Gr::Grid)
         max_supersaturation,
         C_drag,
         MP_n_0,
-        tau_cond_evap,
         q_liq_threshold,
         tau_acnv,
         E_col,


### PR DESCRIPTION
This should behave the same as before (and, in fact, `conv_q_vap_to_q_liq` is not yet used).