### PR TITLE
Add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | **Docs Build**       | [![docs build][docs-bld-img]][docs-bld-url]   |
 | **Documentation**    | [![dev][docs-dev-img]][docs-dev-url]          |
 | **GHA CI**           | [![gha ci][gha-ci-img]][gha-ci-url]           |
+| **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 | **Bors enabled**     | [![bors][bors-img]][bors-url]                 |
 
 [docs-bld-img]: https://github.com/CliMA/TurbulenceConvection.jl/actions/workflows/docs.yml/badge.svg
@@ -15,6 +16,9 @@
 
 [gha-ci-img]: https://github.com/CliMA/TurbulenceConvection.jl/actions/workflows/ci.yml/badge.svg
 [gha-ci-url]: https://github.com/CliMA/TurbulenceConvection.jl/actions/workflows/ci.yml
+
+[codecov-img]: https://codecov.io/gh/CliMA/TurbulenceConvection.jl/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/TurbulenceConvection.jl
 
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/35146


### PR DESCRIPTION
Codecov will report that we have zero coverage at the moment because all of our (integration) tests are run on buildkite, which doesn't run codecov.