### PR TITLE
Ignore artifact file to avoid git conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+integration_tests/utils/Artifacts.toml

--- a/integration_tests/utils/Artifacts.toml
+++ b/integration_tests/utils/Artifacts.toml
@@ -1,5 +1,0 @@
-[PyCLES_output]
-git-tree-sha1 = "4a54eb3dfa48035d7a4318005963408a4e94c6d5"
-
-[SCAMPy_output]
-git-tree-sha1 = "fb9af006a3ca35cb713caa00ef06db4047bede07"


### PR DESCRIPTION
This artifact file has proven to be problematic for people's workflow. I think everything should work fine if we git-ignore it.