### PR TITLE
Remove `revxrange`

### DIFF
--- a/src/python_primitives.jl
+++ b/src/python_primitives.jl
@@ -10,9 +10,6 @@ argwhere(a) = findall(a .> 0)
 xrange(start, stop, step = 1) = range(start, stop - 1; step = step)
 xrange(stop) = xrange(0, stop)
 
-revxrange(start, stop, step = 1) = range(start, stop; step = step)
-revxrange(stop) = revxrange(0, stop)
-
 pyzeros(n::Int) = OffsetArray(zeros(n), 0:(n - 1))
 pyzeros(m::Int, n::Int) = OffsetArray(zeros(m, n), 0:(m - 1), 0:(n - 1))
 


### PR DESCRIPTION
I think that this is done correctly, note that we're not traversing the `term_vel[k] = terminal_velocity(Rain.C_drag, Rain.MP_n_0, QR.values[k], self.Ref.rho0_half[k])` in reverse order, since I don't think that should have any impact on the result.