### PR TITLE
Consolidate turbulent entrainment

### DIFF
--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -11,18 +11,18 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 5.8920349209467660e-01
-best_mse["updraft_area"] = 2.9161664375922396e+02
-best_mse["updraft_w"] = 9.2064966152387040e-01
-best_mse["updraft_qt"] = 5.2856934357682029e+01
-best_mse["updraft_thetal"] = 6.9072600122408147e+01
-best_mse["u_mean"] = 8.7994360629094189e+01
-best_mse["tke_mean"] = 2.8644243409080627e+00
-best_mse["temperature_mean"] = 2.7496219242928010e-04
-best_mse["ql_mean"] = 5.0850007235659434e-03
-best_mse["thetal_mean"] = 2.7328104527915207e-04
-best_mse["Hvar_mean"] = 2.2244310672644488e+01
-best_mse["QTvar_mean"] = 2.6090373899600383e+01
+best_mse["qt_mean"] = 6.4559638590248924e-01
+best_mse["updraft_area"] = 2.9732339500518958e+02
+best_mse["updraft_w"] = 1.0894427841756977e+00
+best_mse["updraft_qt"] = 5.2188511467832939e+01
+best_mse["updraft_thetal"] = 6.9082849512451588e+01
+best_mse["u_mean"] = 8.7994360629094146e+01
+best_mse["tke_mean"] = 3.0426947022991828e+00
+best_mse["temperature_mean"] = 2.9081377572297745e-04
+best_mse["ql_mean"] = 0.0000000000000000e+00
+best_mse["thetal_mean"] = 2.8896514406812518e-04
+best_mse["Hvar_mean"] = 8.9154045834618110e+00
+best_mse["QTvar_mean"] = 4.3180594810766799e+01
 
 @testset "ARM_SGP" begin
     println("Running ARM_SGP...")

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -11,19 +11,19 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 8.4924728795344143e-02
-best_mse["updraft_area"] = 7.0195368138769777e+02
-best_mse["updraft_w"] = 8.7703050153771670e+01
-best_mse["updraft_qt"] = 5.9194060591321715e+00
-best_mse["updraft_thetal"] = 2.2932547498112353e+01
-best_mse["v_mean"] = 1.2350993295040250e+02
-best_mse["u_mean"] = 5.3487467706554988e+01
-best_mse["tke_mean"] = 3.2337733855931930e+01
-best_mse["temperature_mean"] = 3.1767291118329973e-05
-best_mse["ql_mean"] = 1.4250971600048450e+01
-best_mse["thetal_mean"] = 3.2420072527836003e-05
-best_mse["Hvar_mean"] = 6.2697869671981366e+01
-best_mse["QTvar_mean"] = 2.2154880539077912e+01
+best_mse["qt_mean"] = 8.9644597356208541e-02
+best_mse["updraft_area"] = 6.9327817412026047e+02
+best_mse["updraft_w"] = 8.9057089858539797e+01
+best_mse["updraft_qt"] = 5.9179688063528078e+00
+best_mse["updraft_thetal"] = 2.2933264810554988e+01
+best_mse["v_mean"] = 1.2348440297549568e+02
+best_mse["u_mean"] = 5.3484778922733959e+01
+best_mse["tke_mean"] = 3.2847767205446033e+01
+best_mse["temperature_mean"] = 3.4874387520736297e-05
+best_mse["ql_mean"] = 2.1344864368686135e+01
+best_mse["thetal_mean"] = 3.5327188090292184e-05
+best_mse["Hvar_mean"] = 1.7623971358198961e+02
+best_mse["QTvar_mean"] = 4.0583986764371645e+01
 
 @testset "Bomex" begin
     println("Running Bomex...")

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -11,19 +11,19 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 6.0388473616576316e-02
-best_mse["ql_mean"] = 1.2115084290811327e+01
-best_mse["updraft_area"] = 2.2617648541231165e+02
-best_mse["updraft_w"] = 3.5276164268861083e+00
-best_mse["updraft_qt"] = 1.4783169383809973e+00
-best_mse["updraft_thetal"] = 1.2734822030084649e+01
-best_mse["v_mean"] = 4.0031347631418541e+01
-best_mse["u_mean"] = 3.5748261847248195e+01
-best_mse["tke_mean"] = 1.3793746033690562e+01
-best_mse["temperature_mean"] = 1.2544336319315940e-05
-best_mse["thetal_mean"] = 1.6300691998904447e-05
-best_mse["Hvar_mean"] = 8.6297462230569654e+04
-best_mse["QTvar_mean"] = 6.5374676585278166e+03
+best_mse["qt_mean"] = 6.3055740870523944e-02
+best_mse["ql_mean"] = 1.0898102515993909e+01
+best_mse["updraft_area"] = 2.1643245563605532e+02
+best_mse["updraft_w"] = 3.7742918972750585e+00
+best_mse["updraft_qt"] = 1.4833369346056364e+00
+best_mse["updraft_thetal"] = 1.2735585448251884e+01
+best_mse["v_mean"] = 4.0028336968928720e+01
+best_mse["u_mean"] = 3.5748548802210514e+01
+best_mse["tke_mean"] = 1.3334607271849251e+01
+best_mse["temperature_mean"] = 1.3282908741777973e-05
+best_mse["thetal_mean"] = 1.7266062255939275e-05
+best_mse["Hvar_mean"] = 8.5678621532669626e+04
+best_mse["QTvar_mean"] = 6.5174106643485084e+03
 
 
 @testset "DYCOMS_RF01" begin

--- a/integration_tests/Nieuwstadt.jl
+++ b/integration_tests/Nieuwstadt.jl
@@ -11,14 +11,14 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["updraft_area"] = 5.0454151695959411e+02
-best_mse["updraft_w"] = 3.6872853179114287e+01
-best_mse["updraft_thetal"] = 2.9768390317748754e+01
-best_mse["u_mean"] = 7.6320346670292111e+02
-best_mse["tke_mean"] = 6.9114000131939633e+01
-best_mse["temperature_mean"] = 1.6216693070306151e-05
-best_mse["thetal_mean"] = 1.6067825070848235e-05
-best_mse["Hvar_mean"] = 2.0364798295577725e+02
+best_mse["updraft_area"] = 6.7123367331397571e+02
+best_mse["updraft_w"] = 4.3115995379486961e+01
+best_mse["updraft_thetal"] = 2.9769609162505365e+01
+best_mse["u_mean"] = 7.6376436377614436e+02
+best_mse["tke_mean"] = 7.2281909958288438e+01
+best_mse["temperature_mean"] = 1.5773181513042552e-05
+best_mse["thetal_mean"] = 1.5665330726140129e-05
+best_mse["Hvar_mean"] = 2.0155355014688541e+02
 
 @testset "Nieuwstadt" begin
     println("Running Nieuwstadt...")

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -11,19 +11,19 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 5.0707745192217146e-01
-best_mse["updraft_area"] = 1.6283285530615315e+03
-best_mse["updraft_w"] = 5.7196482018497807e+02
-best_mse["updraft_qt"] = 2.4565269303654755e+01
-best_mse["updraft_thetal"] = 6.5505090179439435e+01
-best_mse["v_mean"] = 1.0611825566231954e+02
-best_mse["u_mean"] = 1.1390377464452069e+02
-best_mse["tke_mean"] = 8.9525123248795580e+02
-best_mse["temperature_mean"] = 1.4787364980827869e-04
-best_mse["ql_mean"] = 1.7937532436604911e+02
-best_mse["thetal_mean"] = 1.4098220595492702e-04
-best_mse["Hvar_mean"] = 1.6499437998682095e+03
-best_mse["QTvar_mean"] = 7.3181087637066230e+02
+best_mse["qt_mean"] = 4.9523533702786315e-01
+best_mse["updraft_area"] = 1.7419532961183722e+03
+best_mse["updraft_w"] = 5.3893010779565452e+02
+best_mse["updraft_qt"] = 2.4530572533274270e+01
+best_mse["updraft_thetal"] = 6.5509509302767754e+01
+best_mse["v_mean"] = 1.0615326468150907e+02
+best_mse["u_mean"] = 1.1393191702720974e+02
+best_mse["tke_mean"] = 8.4090034387266689e+02
+best_mse["temperature_mean"] = 1.4274314152822176e-04
+best_mse["ql_mean"] = 2.1441653002617767e+02
+best_mse["thetal_mean"] = 1.3609606969128344e-04
+best_mse["Hvar_mean"] = 3.7305257502890240e+03
+best_mse["QTvar_mean"] = 1.2241261056877631e+03
 
 @testset "Rico" begin
     println("Running Rico...")

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -11,16 +11,16 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 2.5795949502235077e-01
-best_mse["updraft_area"] = 9.2319813604790897e+02
-best_mse["updraft_w"] = 2.7143888970271533e+01
-best_mse["updraft_qt"] = 1.0608841949065969e+01
-best_mse["updraft_thetal"] = 2.1532908755155134e+01
-best_mse["u_mean"] = 3.9494974585811301e+03
-best_mse["tke_mean"] = 6.3308887592281366e+01
-best_mse["temperature_mean"] = 1.9251642797449680e-05
-best_mse["thetal_mean"] = 1.9375920993365417e-05
-best_mse["Hvar_mean"] = 2.4476641501276720e+02
+best_mse["qt_mean"] = 3.2147414017234566e-01
+best_mse["updraft_area"] = 7.5523687950242140e+02
+best_mse["updraft_w"] = 3.5564080086151499e+01
+best_mse["updraft_qt"] = 1.0702812362369221e+01
+best_mse["updraft_thetal"] = 2.1534108878970788e+01
+best_mse["u_mean"] = 3.9385484811475408e+03
+best_mse["tke_mean"] = 5.2022934994314660e+01
+best_mse["temperature_mean"] = 1.9333588833166558e-05
+best_mse["thetal_mean"] = 1.9486304719984318e-05
+best_mse["Hvar_mean"] = 2.6039266998435176e+02
 
 
 @testset "Soares" begin

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -11,19 +11,19 @@ include(joinpath("utils", "compute_mse.jl"))
 using .NameList
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.9066401784413203e+00
-best_mse["updraft_area"] = 2.8333333642947131e+04
-best_mse["updraft_w"] = 6.5662893402745362e+02
-best_mse["updraft_qt"] = 2.5017304239563906e+01
-best_mse["updraft_thetal"] = 1.1072812435859557e+02
-best_mse["v_mean"] = 2.9403959926399466e+02
-best_mse["u_mean"] = 1.6903038672404982e+03
-best_mse["tke_mean"] = 2.8972134698112682e+03
-best_mse["temperature_mean"] = 8.3944025946955543e-04
-best_mse["ql_mean"] = 4.3199525166349194e+03
-best_mse["thetal_mean"] = 5.7974301596273598e-04
-best_mse["Hvar_mean"] = 1.3419697125412104e+04
-best_mse["QTvar_mean"] = 1.6238639092892809e+04
+best_mse["qt_mean"] = 3.0609461714234958e+00
+best_mse["updraft_area"] = 3.5992222800156262e+04
+best_mse["updraft_w"] = 1.0100451430716917e+03
+best_mse["updraft_qt"] = 2.7507151910663865e+01
+best_mse["updraft_thetal"] = 1.1074070908480367e+02
+best_mse["v_mean"] = 2.9438922611828133e+02
+best_mse["u_mean"] = 1.6906200771006561e+03
+best_mse["tke_mean"] = 2.5854592261914117e+03
+best_mse["temperature_mean"] = 9.2883217582418853e-04
+best_mse["ql_mean"] = 2.1864394985446243e+03
+best_mse["thetal_mean"] = 6.4455936975381660e-04
+best_mse["Hvar_mean"] = 1.2394474700136290e+04
+best_mse["QTvar_mean"] = 9.2129571715440597e+03
 
 @testset "TRMM_LBA" begin
     println("Running TRMM_LBA...")

--- a/src/types.jl
+++ b/src/types.jl
@@ -794,10 +794,6 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
     sorting_function::A2
     b_mix::A2
     frac_turb_entr::A2
-    frac_turb_entr_full::A2
-    turb_entr_W::A2
-    turb_entr_H::A2
-    turb_entr_QT::A2
     nh_pressure::A2
     nh_pressure_b::A2
     nh_pressure_adv::A2
@@ -806,8 +802,7 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
     b_coeff::A2
     m::A2
     mixing_length::A1
-    horizontal_KM::A2
-    horizontal_KH::A2
+    horiz_K_eddy::A2
     tke_transport::A1
     tke_advection::A1
     area_surface_bc::A1
@@ -992,10 +987,6 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
 
         # turbulent entrainment
         frac_turb_entr = center_field(Gr, n_updrafts)
-        frac_turb_entr_full = face_field(Gr, n_updrafts)
-        turb_entr_W = center_field(Gr, n_updrafts)
-        turb_entr_H = center_field(Gr, n_updrafts)
-        turb_entr_QT = center_field(Gr, n_updrafts)
 
         # Pressure term in updraft vertical momentum equation
         nh_pressure = center_field(Gr, n_updrafts)
@@ -1010,8 +1001,7 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
 
         # mixing length
         mixing_length = center_field(Gr)
-        horizontal_KM = center_field(Gr, n_updrafts)
-        horizontal_KH = center_field(Gr, n_updrafts)
+        horiz_K_eddy = center_field(Gr, n_updrafts)
 
         # diagnosed tke budget terms
         tke_transport = center_field(Gr)
@@ -1055,7 +1045,7 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
         detr_surface_bc = 0
         dt_upd = 0
         A1 = typeof(mixing_length)
-        A2 = typeof(horizontal_KM)
+        A2 = typeof(horiz_K_eddy)
         return new{PS, A1, A2}(
             param_set,
             turbulence_tendency,
@@ -1109,10 +1099,6 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
             sorting_function,
             b_mix,
             frac_turb_entr,
-            frac_turb_entr_full,
-            turb_entr_W,
-            turb_entr_H,
-            turb_entr_QT,
             nh_pressure,
             nh_pressure_b,
             nh_pressure_adv,
@@ -1121,8 +1107,7 @@ mutable struct EDMF_PrognosticTKE{PS, A1, A2}
             b_coeff,
             m,
             mixing_length,
-            horizontal_KM,
-            horizontal_KH,
+            horiz_K_eddy,
             tke_transport,
             tke_advection,
             area_surface_bc,


### PR DESCRIPTION
This PR consolidate turbulent entrainment to a single term that is effectively added to the dynamic entrainment. It is a step on the way to merging the two into a single closure file. 

** this branch has behavioral changes as it computes turbulent entrainment only at half levels and interpolates it to full levels **