### PR TITLE
Remove 1.5 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
           - '1.6.0'
         os:
           - ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,4 @@
 status = [
-  "ci 1.5 - ubuntu-latest",
-  "ci 1.5 - windows-latest",
-  "ci 1.5 - macOS-latest",
   "ci 1.6.0 - ubuntu-latest",
   "ci 1.6.0 - windows-latest",
   "ci 1.6.0 - macOS-latest",


### PR DESCRIPTION
For some reason, the 1.5 CI, which doesn't even run any tests, is taking even longer than the entire buildkite run. Let's 