### PR TITLE
unify timesteps in the model

### DIFF
--- a/integration_tests/GABLS.jl
+++ b/integration_tests/GABLS.jl
@@ -12,14 +12,14 @@ using .NameList
 
 best_mse = OrderedDict()
 
-best_mse["updraft_thetal"] = 5.0248694008424222e+00
-best_mse["v_mean"] = 4.4630163253493214e+00
-best_mse["u_mean"] = 9.6412500983148846e+00
-best_mse["tke_mean"] = 2.4683562232142533e+00
-best_mse["temperature_mean"] = 8.8678308948818863e-06
-best_mse["thetal_mean"] = 8.7900622849842488e-06
-best_mse["Hvar_mean"] = 1.2891667586703637e+01
-best_mse["QTvar_mean"] = 4.4424755799649029e-01
+best_mse["updraft_thetal"] = 5.0248696023347037e+00
+best_mse["v_mean"] = 4.4593534457868529e+00
+best_mse["u_mean"] = 9.6414943665200035e+00
+best_mse["tke_mean"] = 2.4674095133951375e+00
+best_mse["temperature_mean"] = 8.8584843672667532e-06
+best_mse["thetal_mean"] = 8.7856734759460943e-06
+best_mse["Hvar_mean"] = 1.2892749042279126e+01
+best_mse["QTvar_mean"] = 4.4456710317999498e-01
 
 @testset "GABLS" begin
     case_name = "GABLS"

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -14,19 +14,19 @@ using .NameList
 CLIMAParameters.Planet.T_freeze(::EarthParameterSet) = 100.0
 
 best_mse = OrderedDict()
-best_mse["qt_mean"] = 2.1123818327762196e+00
-best_mse["updraft_area"] = 2.2936100671363765e+04
-best_mse["updraft_w"] = 9.7871834647382809e+02
-best_mse["updraft_qt"] = 3.0602076184487512e+01
-best_mse["updraft_thetal"] = 1.1001487658208509e+02
-best_mse["v_mean"] = 2.9250821023986430e+02
-best_mse["u_mean"] = 1.6873198920581733e+03
-best_mse["tke_mean"] = 9.3648065006898219e+02
-best_mse["temperature_mean"] = 8.1826613372337135e-04
-best_mse["ql_mean"] = 7.2432912110535301e+02
-best_mse["thetal_mean"] = 8.2748526945473598e-03
-best_mse["Hvar_mean"] = 3.5701761092936244e+03
-best_mse["QTvar_mean"] = 1.7865858561907439e+03
+best_mse["qt_mean"] = 2.1180570149373197e+00
+best_mse["updraft_area"] = 2.2911123097125790e+04
+best_mse["updraft_w"] = 9.9122631422628353e+02
+best_mse["updraft_qt"] = 3.0750107437154107e+01
+best_mse["updraft_thetal"] = 1.1001770046016014e+02
+best_mse["v_mean"] = 2.9250578870751696e+02
+best_mse["u_mean"] = 1.6873177041648653e+03
+best_mse["tke_mean"] = 9.3810901861977175e+02
+best_mse["temperature_mean"] = 8.1897112533893871e-04
+best_mse["ql_mean"] = 7.3150520783875129e+02
+best_mse["thetal_mean"] = 8.2746696205323478e-03
+best_mse["Hvar_mean"] = 3.5185010182273427e+03
+best_mse["QTvar_mean"] = 1.7745546315637387e+03
 
 @testset "TRMM_LBA" begin
     case_name = "TRMM_LBA"

--- a/src/EDMF_Rain.jl
+++ b/src/EDMF_Rain.jl
@@ -120,51 +120,35 @@ function solve_rain_fall(
         term_vel[k] = terminal_velocity(Rain.C_drag, Rain.MP_n_0, QR.values[k], self.Ref.rho0_half[k])
     end
 
-    # calculate the allowed timestep (CFL_limit >= v dt / dz)
-    # TODO: report bug: dt_rain has no value in else-case
-    if !(maximum(term_vel) ≈ 0)
-        dt_rain = min(dt_model, CFL_limit * grid.dz / maximum(term_vel))
-    else
-        dt_rain = dt_model
-    end
-
     # rain falling through the domain
-    while t_elapsed < dt_model
-        # TODO: verify translation
-        @inbounds for k in reverse(real_center_indicies(grid))
-            CFL_out = dt_rain / dz * term_vel[k]
+    @inbounds for k in reverse(real_center_indicies(grid))
+        CFL_out = dt_model / dz * term_vel[k]
 
-            if is_toa_center(grid, k)
-                CFL_in = 0.0
-            else
-                CFL_in = dt_rain / dz * term_vel[k + 1]
-            end
-
-            rho_frac = self.Ref.rho0_half[k + 1] / self.Ref.rho0_half[k]
-            area_frac = 1.0 # RainArea.values[k] / RainArea.new[k]
-
-            QR.new[k] = (QR.values[k] * (1 - CFL_out) + QR.values[k + 1] * CFL_in * rho_frac) * area_frac
-            if QR.new[k] != 0.0
-                RainArea.new[k] = 1.0
-            end
-
-            term_vel_new[k] = terminal_velocity(Rain.C_drag, Rain.MP_n_0, QR.new[k], self.Ref.rho0_half[k])
-        end
-
-        t_elapsed += dt_rain
-
-        QR.values .= QR.new
-        RainArea.values .= RainArea.new
-
-        term_vel .= term_vel_new
-
-        if maximum(abs.(term_vel)) > eps(Float64)
-            dt_rain = min(dt_model - t_elapsed, CFL_limit * grid.dz / maximum(term_vel))
+        if is_toa_center(grid, k)
+            CFL_in = 0.0
         else
-            dt_rain = dt_model - t_elapsed
+            CFL_in = dt_model / dz * term_vel[k + 1]
         end
+
+        if max(CFL_in, CFL_out) > CFL_limit
+            error("Time step is too large for rain fall velocity!")
+        end
+
+        rho_frac = self.Ref.rho0_half[k + 1] / self.Ref.rho0_half[k]
+        area_frac = 1.0 # RainArea.values[k] / RainArea.new[k]
+
+        QR.new[k] = (QR.values[k] * (1 - CFL_out) + QR.values[k + 1] * CFL_in * rho_frac) * area_frac
+        if QR.new[k] != 0.0
+            RainArea.new[k] = 1.0
+        end
+
+        term_vel_new[k] = terminal_velocity(Rain.C_drag, Rain.MP_n_0, QR.new[k], self.Ref.rho0_half[k])
     end
 
+    QR.values .= QR.new
+    RainArea.values .= RainArea.new
+
+    term_vel .= term_vel_new
     return
 end
 


### PR DESCRIPTION
This PR unifies the time steps in the model across the updrafts and the grid mean the environment and the microphysics. The tilmestep is set to 3 sec which works. Next step would be to add a CFL condition that combines updraft velocity and rainfall velocity to get the optimal tilmestep. 

** behavioral changes !! ** 

take a close look