### PR TITLE
Merge mse tables->1 file, print mse table post run

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -154,6 +154,18 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":robot_face: Print new mse tables"
+    key: "cpu_print_new_mse"
+    command:
+      - "julia --color=yes --project utils/print_new_mse.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - wait
 
   - label: ":robot_face: Move main results"

--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -8,21 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.7029179410890994e-01
-best_mse["updraft_area"] = 2.0066768291734027e+03
-best_mse["updraft_w"] = 3.3021026158842852e+02
-best_mse["updraft_qt"] = 1.3362770693863471e+01
-best_mse["updraft_thetal"] = 2.7682689602916721e+01
-best_mse["u_mean"] = 8.7998547277817892e+01
-best_mse["tke_mean"] = 6.5902888656341383e+02
-best_mse["temperature_mean"] = 1.4835874987504939e-04
-best_mse["ql_mean"] = 2.5289195067821601e+02
-best_mse["thetal_mean"] = 1.5194012840291993e-04
-best_mse["Hvar_mean"] = 3.6200709711739819e+03
-best_mse["QTvar_mean"] = 2.5763919693088642e+03
+best_mse = all_best_mse["ARM_SGP"]
 
 @testset "ARM_SGP" begin
     case_name = "ARM_SGP"
@@ -39,6 +28,10 @@ best_mse["QTvar_mean"] = 2.5763919693088642e+03
         t_start = 8 * 3600,
         t_stop = 11 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -8,22 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 9.7923185944396543e-02
-best_mse["updraft_area"] = 6.9825342418932712e+02
-best_mse["updraft_w"] = 3.2817058320329416e+01
-best_mse["updraft_qt"] = 4.2756945036338720e+00
-best_mse["updraft_thetal"] = 2.1546731002204076e+01
-best_mse["v_mean"] = 6.8320914112603603e+01
-best_mse["u_mean"] = 5.3308019185027945e+01
-best_mse["tke_mean"] = 4.2619460317296351e+01
-best_mse["temperature_mean"] = 4.2264960813453363e-05
-best_mse["ql_mean"] = 6.1078690857394591e+00
-best_mse["thetal_mean"] = 4.3075669150884208e-05
-best_mse["Hvar_mean"] = 1.4320193838595969e+03
-best_mse["QTvar_mean"] = 7.4620132655591669e+02
+best_mse = all_best_mse["Bomex"]
 
 @testset "Bomex" begin
     case_name = "Bomex"
@@ -40,6 +28,10 @@ best_mse["QTvar_mean"] = 7.4620132655591669e+02
         t_start = 4 * 3600,
         t_stop = 6 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -8,22 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 1.6511493474924487e-02
-best_mse["ql_mean"] = 5.2388152463600228e+00
-best_mse["updraft_area"] = 2.3937655332711191e+02
-best_mse["updraft_w"] = 4.2950818025166271e+00
-best_mse["updraft_qt"] = 1.1670622064912242e+00
-best_mse["updraft_thetal"] = 1.2740701334370282e+01
-best_mse["v_mean"] = 3.9746921720562241e+01
-best_mse["u_mean"] = 3.7046560343565211e+01
-best_mse["tke_mean"] = 1.4700070268008988e+01
-best_mse["temperature_mean"] = 2.1532443073348772e-05
-best_mse["thetal_mean"] = 2.2397858591617206e-05
-best_mse["Hvar_mean"] = 8.2677316059854074e+03
-best_mse["QTvar_mean"] = 6.0266525107346490e+02
+best_mse = all_best_mse["DYCOMS_RF01"]
 
 key = "Hvar_mean"
 @testset "DYCOMS_RF01" begin
@@ -41,6 +29,10 @@ key = "Hvar_mean"
         t_start = 2 * 3600,
         t_stop = 4 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/DryBubble.jl
+++ b/integration_tests/DryBubble.jl
@@ -8,17 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["updraft_area"] = 6.8552893703976156e+02
-best_mse["updraft_w"] = 1.6342412689086376e+02
-best_mse["updraft_thetal"] = 3.9780037295736014e-05
-best_mse["u_mean"] = 1.9502448099351233e-27
-best_mse["tke_mean"] = 1.9987696066076023e+05
-best_mse["temperature_mean"] = 3.2539779149902821e-05
-best_mse["thetal_mean"] = 2.5848228458179228e-05
-best_mse["Hvar_mean"] = 7.3771757968047757e+02
+best_mse = all_best_mse["DryBubble"]
 
 @testset "DryBubble" begin
     case_name = "DryBubble"
@@ -29,6 +22,10 @@ best_mse["Hvar_mean"] = 7.3771757968047757e+02
 
     computed_mse =
         compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 900, t_stop = 1000)
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/GABLS.jl
+++ b/integration_tests/GABLS.jl
@@ -8,18 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-
-best_mse["updraft_thetal"] = 5.0248696023347037e+00
-best_mse["v_mean"] = 4.4593534457868529e+00
-best_mse["u_mean"] = 9.6414943665200035e+00
-best_mse["tke_mean"] = 2.4674095133951375e+00
-best_mse["temperature_mean"] = 8.8584843672667532e-06
-best_mse["thetal_mean"] = 8.7856734759460943e-06
-best_mse["Hvar_mean"] = 1.2892749042279126e+01
-best_mse["QTvar_mean"] = 4.4456710317999498e-01
+best_mse = all_best_mse["GABLS"]
 
 @testset "GABLS" begin
     case_name = "GABLS"
@@ -36,6 +28,10 @@ best_mse["QTvar_mean"] = 4.4456710317999498e-01
         t_start = 7 * 3600,
         t_stop = 9 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/Nieuwstadt.jl
+++ b/integration_tests/Nieuwstadt.jl
@@ -8,17 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["updraft_area"] = 5.9567286602931904e+02
-best_mse["updraft_w"] = 2.6450205443296568e+01
-best_mse["updraft_thetal"] = 3.0475209174359087e+01
-best_mse["u_mean"] = 1.5244498152508007e+02
-best_mse["tke_mean"] = 7.3585026092564277e+01
-best_mse["temperature_mean"] = 1.1872218655217143e-05
-best_mse["thetal_mean"] = 1.2035241147904184e-05
-best_mse["Hvar_mean"] = 1.8640506843913366e+02
+best_mse = all_best_mse["Nieuwstadt"]
 
 @testset "Nieuwstadt" begin
     case_name = "Nieuwstadt"
@@ -35,6 +28,10 @@ best_mse["Hvar_mean"] = 1.8640506843913366e+02
         t_start = 6 * 3600,
         t_stop = 8 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -8,22 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.6183738581707564e-01
-best_mse["updraft_area"] = 1.9158389580482219e+03
-best_mse["updraft_w"] = 1.7058718197542106e+02
-best_mse["updraft_qt"] = 1.5449827839901584e+01
-best_mse["updraft_thetal"] = 6.3602297256853468e+01
-best_mse["v_mean"] = 1.0630514621668171e+02
-best_mse["u_mean"] = 1.1443613156137732e+02
-best_mse["tke_mean"] = 3.1910880264617197e+02
-best_mse["temperature_mean"] = 1.8245777363727451e-04
-best_mse["ql_mean"] = 2.2808514972615623e+02
-best_mse["thetal_mean"] = 1.5458919462734390e-04
-best_mse["Hvar_mean"] = 1.0744099006973258e+04
-best_mse["QTvar_mean"] = 4.7454844707739849e+03
+best_mse = all_best_mse["Rico"]
 
 @testset "Rico" begin
     case_name = "Rico"
@@ -40,6 +28,10 @@ best_mse["QTvar_mean"] = 4.7454844707739849e+03
         t_start = 22 * 3600,
         t_stop = 24 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/SP.jl
+++ b/integration_tests/SP.jl
@@ -8,21 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 3.5073036121827599e+00
-best_mse["updraft_area"] = 3.9071034998892715e+00
-best_mse["updraft_w"] = 9.3648209541424188e-01
-best_mse["updraft_qt"] = 1.3868858637940826e+00
-best_mse["updraft_thetal"] = 1.0515272505644156e-01
-best_mse["v_mean"] = 4.6000262200176228e-01
-best_mse["u_mean"] = 7.3724093159961937e-05
-best_mse["tke_mean"] = 4.7833665685836724e-01
-best_mse["temperature_mean"] = 6.8550010657332516e-07
-best_mse["thetal_mean"] = 5.1299556226337377e-07
-best_mse["Hvar_mean"] = 3.1719859098824500e+01
-best_mse["QTvar_mean"] = 3.9762684439302052e+00
+best_mse = all_best_mse["SP"]
 
 @testset "SP" begin
     case_name = "SP"
@@ -33,6 +22,10 @@ best_mse["QTvar_mean"] = 3.9762684439302052e+00
 
     computed_mse =
         compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 0, t_stop = 2 * 3600)
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -8,19 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 1.4966760733610701e-01
-best_mse["updraft_area"] = 4.4752734228297282e+02
-best_mse["updraft_w"] = 2.1338748581172648e+01
-best_mse["updraft_qt"] = 1.1050242532811241e+01
-best_mse["updraft_thetal"] = 2.2394553996747693e+01
-best_mse["u_mean"] = 7.3068371493591656e+02
-best_mse["tke_mean"] = 5.9234734475094214e+01
-best_mse["temperature_mean"] = 1.1583915526092593e-05
-best_mse["thetal_mean"] = 1.2172922371309679e-05
-best_mse["Hvar_mean"] = 2.2601616515636465e+02
+best_mse = all_best_mse["Soares"]
 
 @testset "Soares" begin
     case_name = "Soares"
@@ -37,6 +28,10 @@ best_mse["Hvar_mean"] = 2.2601616515636465e+02
         t_start = 6 * 3600,
         t_stop = 8 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -8,25 +8,13 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
 # Note: temperatures in this case become extremely low.
 CLIMAParameters.Planet.T_freeze(::EarthParameterSet) = 100.0
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 2.1180570149373197e+00
-best_mse["updraft_area"] = 2.2911123097125790e+04
-best_mse["updraft_w"] = 9.9122631422628353e+02
-best_mse["updraft_qt"] = 3.0750107437154107e+01
-best_mse["updraft_thetal"] = 1.1001770046016014e+02
-best_mse["v_mean"] = 2.9250578870751696e+02
-best_mse["u_mean"] = 1.6873177041648653e+03
-best_mse["tke_mean"] = 9.3810901861977175e+02
-best_mse["temperature_mean"] = 8.1897112533893871e-04
-best_mse["ql_mean"] = 7.3150520783875129e+02
-best_mse["thetal_mean"] = 8.2746696205323478e-03
-best_mse["Hvar_mean"] = 3.5185010182273427e+03
-best_mse["QTvar_mean"] = 1.7745546315637387e+03
+best_mse = all_best_mse["TRMM_LBA"]
 
 @testset "TRMM_LBA" begin
     case_name = "TRMM_LBA"
@@ -43,6 +31,10 @@ best_mse["QTvar_mean"] = 1.7745546315637387e+03
         t_start = 4 * 3600,
         t_stop = 6 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/life_cycle_Tan2018.jl
+++ b/integration_tests/life_cycle_Tan2018.jl
@@ -8,22 +8,10 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
+include(joinpath("utils", "mse_tables.jl"))
 using .NameList
 
-best_mse = OrderedDict()
-best_mse["qt_mean"] = 5.2649429859732335e-03
-best_mse["ql_mean"] = 8.3701130817214975e-01
-best_mse["updraft_area"] = 7.0432677991444692e-01
-best_mse["updraft_w"] = 5.8558890484998805e-01
-best_mse["updraft_qt"] = 1.1615774284759468e-01
-best_mse["updraft_thetal"] = 6.2885863821116435e-05
-best_mse["v_mean"] = 2.4748668316753225e-01
-best_mse["u_mean"] = 7.1361729071471190e-04
-best_mse["tke_mean"] = 2.0664613818639557e-01
-best_mse["temperature_mean"] = 2.5719773912461363e-06
-best_mse["thetal_mean"] = 2.4566431564965449e-06
-best_mse["Hvar_mean"] = 2.1515252048343000e+03
-best_mse["QTvar_mean"] = 1.1458013034475746e+03
+best_mse = all_best_mse["life_cycle_Tan2018"]
 
 @testset "life_cycle_Tan2018" begin
     case_name = "life_cycle_Tan2018"
@@ -40,6 +28,10 @@ best_mse["QTvar_mean"] = 1.1458013034475746e+03
         t_start = 4 * 3600,
         t_stop = 6 * 3600,
     )
+
+    open("computed_mse_$case_name.json", "w") do io
+        JSON.print(io, computed_mse)
+    end
 
     for k in keys(best_mse)
         test_mse(computed_mse, best_mse, k)

--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -2,6 +2,7 @@ import Plots
 using OrderedCollections
 using Test
 import Dates
+import JSON
 using NCDatasets
 import StatsBase
 using Dierckx
@@ -148,7 +149,7 @@ function compute_mse(case_name, best_mse, plot_dir; ds_dict, plot_comparison = t
     if !have_tc_main
         ds_tc_main = ds_tc
     end
-    mse = Dict()
+    mse = OrderedDict()
     time_tcc = get_time(ds_tc, "t")
     time_les = get_time(ds_pycles, "t")
     time_tcm = get_time(ds_tc_main, "t")

--- a/integration_tests/utils/mse_tables.jl
+++ b/integration_tests/utils/mse_tables.jl
@@ -1,0 +1,154 @@
+#################################
+################################# MSE tables
+#################################
+
+all_best_mse = OrderedDict()
+
+all_best_mse["ARM_SGP"] = OrderedDict()
+all_best_mse["ARM_SGP"]["qt_mean"] = 0.37029179410890994
+all_best_mse["ARM_SGP"]["updraft_area"] = 2006.6768291734027
+all_best_mse["ARM_SGP"]["updraft_w"] = 330.2102615884285
+all_best_mse["ARM_SGP"]["updraft_qt"] = 13.362770693863471
+all_best_mse["ARM_SGP"]["updraft_thetal"] = 27.68268960291672
+all_best_mse["ARM_SGP"]["u_mean"] = 87.99854727781789
+all_best_mse["ARM_SGP"]["tke_mean"] = 659.0288865634138
+all_best_mse["ARM_SGP"]["temperature_mean"] = 0.0001483587498750494
+all_best_mse["ARM_SGP"]["ql_mean"] = 252.891950678216
+all_best_mse["ARM_SGP"]["thetal_mean"] = 0.00015194012840291993
+all_best_mse["ARM_SGP"]["Hvar_mean"] = 3620.070971173982
+all_best_mse["ARM_SGP"]["QTvar_mean"] = 2576.391969308864
+
+all_best_mse["Bomex"] = OrderedDict()
+all_best_mse["Bomex"]["qt_mean"] = 0.09792318594439654
+all_best_mse["Bomex"]["updraft_area"] = 698.2534241893271
+all_best_mse["Bomex"]["updraft_w"] = 32.817058320329416
+all_best_mse["Bomex"]["updraft_qt"] = 4.275694503633872
+all_best_mse["Bomex"]["updraft_thetal"] = 21.546731002204076
+all_best_mse["Bomex"]["v_mean"] = 68.3209141126036
+all_best_mse["Bomex"]["u_mean"] = 53.308019185027945
+all_best_mse["Bomex"]["tke_mean"] = 42.61946031729635
+all_best_mse["Bomex"]["temperature_mean"] = 4.226496081345336e-5
+all_best_mse["Bomex"]["ql_mean"] = 6.107869085739459
+all_best_mse["Bomex"]["thetal_mean"] = 4.307566915088421e-5
+all_best_mse["Bomex"]["Hvar_mean"] = 1432.019383859597
+all_best_mse["Bomex"]["QTvar_mean"] = 746.2013265559167
+
+all_best_mse["DryBubble"] = OrderedDict()
+all_best_mse["DryBubble"]["updraft_area"] = 685.5289370393416
+all_best_mse["DryBubble"]["updraft_w"] = 163.42412689071813
+all_best_mse["DryBubble"]["updraft_thetal"] = 3.978003729572793e-5
+all_best_mse["DryBubble"]["u_mean"] = 2.0014926020490524e-27
+all_best_mse["DryBubble"]["tke_mean"] = 199876.96066069463
+all_best_mse["DryBubble"]["temperature_mean"] = 3.2539779149875255e-5
+all_best_mse["DryBubble"]["thetal_mean"] = 2.5848228458152736e-5
+all_best_mse["DryBubble"]["Hvar_mean"] = 737.7175796791064
+
+all_best_mse["DYCOMS_RF01"] = OrderedDict()
+all_best_mse["DYCOMS_RF01"]["qt_mean"] = 0.016511493474924487
+all_best_mse["DYCOMS_RF01"]["ql_mean"] = 5.238815246360023
+all_best_mse["DYCOMS_RF01"]["updraft_area"] = 239.3765533271119
+all_best_mse["DYCOMS_RF01"]["updraft_w"] = 4.295081802516627
+all_best_mse["DYCOMS_RF01"]["updraft_qt"] = 1.1670622064912242
+all_best_mse["DYCOMS_RF01"]["updraft_thetal"] = 12.740701334370282
+all_best_mse["DYCOMS_RF01"]["v_mean"] = 39.74692172056224
+all_best_mse["DYCOMS_RF01"]["u_mean"] = 37.04656034356521
+all_best_mse["DYCOMS_RF01"]["tke_mean"] = 14.700070268008988
+all_best_mse["DYCOMS_RF01"]["temperature_mean"] = 2.1532443073348772e-5
+all_best_mse["DYCOMS_RF01"]["thetal_mean"] = 2.2397858591617206e-5
+all_best_mse["DYCOMS_RF01"]["Hvar_mean"] = 8267.731605985407
+all_best_mse["DYCOMS_RF01"]["QTvar_mean"] = 602.6652510734649
+
+all_best_mse["GABLS"] = OrderedDict()
+all_best_mse["GABLS"]["updraft_thetal"] = 4.658934473257884e-12
+all_best_mse["GABLS"]["v_mean"] = 1.104476424258302e-6
+all_best_mse["GABLS"]["u_mean"] = 1.4520606470173556e-8
+all_best_mse["GABLS"]["tke_mean"] = 7.921385441931473e-7
+all_best_mse["GABLS"]["temperature_mean"] = 2.4270857956397693e-10
+all_best_mse["GABLS"]["thetal_mean"] = 2.3645009185696995e-12
+all_best_mse["GABLS"]["Hvar_mean"] = 5.76870006248545e-7
+all_best_mse["GABLS"]["QTvar_mean"] = 2.5431241306612773e-7
+
+all_best_mse["life_cycle_Tan2018"] = OrderedDict()
+all_best_mse["life_cycle_Tan2018"]["qt_mean"] = 0.0052649429859732335
+all_best_mse["life_cycle_Tan2018"]["ql_mean"] = 0.8370113081721497
+all_best_mse["life_cycle_Tan2018"]["updraft_area"] = 0.7043267799144469
+all_best_mse["life_cycle_Tan2018"]["updraft_w"] = 0.585588904849988
+all_best_mse["life_cycle_Tan2018"]["updraft_qt"] = 0.11615774284759468
+all_best_mse["life_cycle_Tan2018"]["updraft_thetal"] = 6.288586382111644e-5
+all_best_mse["life_cycle_Tan2018"]["v_mean"] = 0.24748668316753225
+all_best_mse["life_cycle_Tan2018"]["u_mean"] = 0.0007136172907147119
+all_best_mse["life_cycle_Tan2018"]["tke_mean"] = 0.20664613818639557
+all_best_mse["life_cycle_Tan2018"]["temperature_mean"] = 2.5719773912461363e-6
+all_best_mse["life_cycle_Tan2018"]["thetal_mean"] = 2.456643156496545e-6
+all_best_mse["life_cycle_Tan2018"]["Hvar_mean"] = 2151.5252048343
+all_best_mse["life_cycle_Tan2018"]["QTvar_mean"] = 1145.8013034475746
+
+all_best_mse["Nieuwstadt"] = OrderedDict()
+all_best_mse["Nieuwstadt"]["updraft_area"] = 595.672866029319
+all_best_mse["Nieuwstadt"]["updraft_w"] = 26.450205443296568
+all_best_mse["Nieuwstadt"]["updraft_thetal"] = 30.475209174359087
+all_best_mse["Nieuwstadt"]["u_mean"] = 152.44498152508007
+all_best_mse["Nieuwstadt"]["tke_mean"] = 73.58502609256428
+all_best_mse["Nieuwstadt"]["temperature_mean"] = 1.1872218655217143e-5
+all_best_mse["Nieuwstadt"]["thetal_mean"] = 1.2035241147904184e-5
+all_best_mse["Nieuwstadt"]["Hvar_mean"] = 186.40506843913366
+
+all_best_mse["Rico"] = OrderedDict()
+all_best_mse["Rico"]["qt_mean"] = 0.36183738581707564
+all_best_mse["Rico"]["updraft_area"] = 1915.838958048222
+all_best_mse["Rico"]["updraft_w"] = 170.58718197542106
+all_best_mse["Rico"]["updraft_qt"] = 15.449827839901584
+all_best_mse["Rico"]["updraft_thetal"] = 63.60229725685347
+all_best_mse["Rico"]["v_mean"] = 106.3051462166817
+all_best_mse["Rico"]["u_mean"] = 114.43613156137732
+all_best_mse["Rico"]["tke_mean"] = 319.10880264617197
+all_best_mse["Rico"]["temperature_mean"] = 0.00018245777363727451
+all_best_mse["Rico"]["ql_mean"] = 228.08514972615623
+all_best_mse["Rico"]["thetal_mean"] = 0.0001545891946273439
+all_best_mse["Rico"]["Hvar_mean"] = 10744.099006973258
+all_best_mse["Rico"]["QTvar_mean"] = 4745.484470773985
+
+all_best_mse["Soares"] = OrderedDict()
+all_best_mse["Soares"]["qt_mean"] = 0.1496676073332159
+all_best_mse["Soares"]["updraft_area"] = 447.52734228539
+all_best_mse["Soares"]["updraft_w"] = 21.33874858102771
+all_best_mse["Soares"]["updraft_qt"] = 11.050242532807314
+all_best_mse["Soares"]["updraft_thetal"] = 22.394553996747703
+all_best_mse["Soares"]["u_mean"] = 730.6837149360526
+all_best_mse["Soares"]["tke_mean"] = 59.234734474825885
+all_best_mse["Soares"]["temperature_mean"] = 1.158391552593335e-5
+all_best_mse["Soares"]["thetal_mean"] = 1.2172922371148021e-5
+all_best_mse["Soares"]["Hvar_mean"] = 226.01616516403885
+
+all_best_mse["SP"] = OrderedDict()
+all_best_mse["SP"]["qt_mean"] = 3.50730361218276
+all_best_mse["SP"]["updraft_area"] = 3.9071034998892715
+all_best_mse["SP"]["updraft_w"] = 0.9364820954142419
+all_best_mse["SP"]["updraft_qt"] = 1.3868858637940826
+all_best_mse["SP"]["updraft_thetal"] = 0.10515272505644156
+all_best_mse["SP"]["v_mean"] = 0.4600026220017623
+all_best_mse["SP"]["u_mean"] = 7.372409315996194e-5
+all_best_mse["SP"]["tke_mean"] = 0.47833665685836724
+all_best_mse["SP"]["temperature_mean"] = 6.855001065733252e-7
+all_best_mse["SP"]["thetal_mean"] = 5.129955622633738e-7
+all_best_mse["SP"]["Hvar_mean"] = 31.7198590988245
+all_best_mse["SP"]["QTvar_mean"] = 3.976268443930205
+
+all_best_mse["TRMM_LBA"] = OrderedDict()
+all_best_mse["TRMM_LBA"]["qt_mean"] = 2.1180570149373197
+all_best_mse["TRMM_LBA"]["updraft_area"] = 22911.12309712579
+all_best_mse["TRMM_LBA"]["updraft_w"] = 991.2263142262835
+all_best_mse["TRMM_LBA"]["updraft_qt"] = 30.750107437154107
+all_best_mse["TRMM_LBA"]["updraft_thetal"] = 110.01770046016014
+all_best_mse["TRMM_LBA"]["v_mean"] = 292.50578870751696
+all_best_mse["TRMM_LBA"]["u_mean"] = 1687.3177041648653
+all_best_mse["TRMM_LBA"]["tke_mean"] = 938.1090186197717
+all_best_mse["TRMM_LBA"]["temperature_mean"] = 0.0008189711253389387
+all_best_mse["TRMM_LBA"]["ql_mean"] = 731.5052078387513
+all_best_mse["TRMM_LBA"]["thetal_mean"] = 0.008274669620532348
+all_best_mse["TRMM_LBA"]["Hvar_mean"] = 3518.5010182273427
+all_best_mse["TRMM_LBA"]["QTvar_mean"] = 1774.5546315637387
+
+#################################
+#################################
+#################################

--- a/utils/print_new_mse.jl
+++ b/utils/print_new_mse.jl
@@ -1,0 +1,47 @@
+using OrderedCollections
+import JSON
+
+all_cases = [
+    "ARM_SGP",
+    "Bomex",
+    "DryBubble",
+    "DYCOMS_RF01",
+    "GABLS",
+    "GATE_III",
+    "life_cycle_Tan2018",
+    "Nieuwstadt",
+    "Rico",
+    "Soares",
+    "SP",
+    "TRMM_LBA",
+]
+
+filter!(x -> x ≠ "GATE_III", all_cases) # no mse tables for GATE_III
+
+dict = OrderedDict()
+for case in all_cases
+    dict[case] = JSON.parsefile("computed_mse_$case.json"; dicttype = OrderedCollections.OrderedDict)
+end
+
+println("#################################")
+println("################################# MSE tables")
+println("#################################")
+println()
+
+println("all_best_mse = OrderedDict()\n")
+for case in keys(dict)
+    println("all_best_mse[\"$case\"] = OrderedDict()")
+    for var in keys(dict[case])
+        println("all_best_mse[\"$case\"][\"$var\"] = $(dict[case][var])")
+    end
+    println()
+end
+
+println("#################################")
+println("#################################")
+println("#################################")
+
+# Cleanup
+for case in all_cases
+    rm("computed_mse_$case.json"; force = true)
+end


### PR DESCRIPTION
This PR should be a nice quality of life improvement for updating the MSE tables.

Previously, we had to click into each tab (for each case) and copy the table to the corresponding file

With this PR: a new job prints the entire mse table file contents after all cases are complete--so we only need to copy these file contents into the single mse tables file.