### PR TITLE
Make advection operators use bcs, fix index in method call

### DIFF
--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -98,6 +98,43 @@ interpf2c(f::SVector, grid::Grid, ::InteriorTag) = (f[1] + f[2]) / 2
 interpf2c(f::SVector, grid::Grid, ::TopBCTag, bc::SetValue) = (f[1] + bc.value) / 2
 interpf2c(f::SVector, grid::Grid, ::BottomBCTag, bc::SetValue) = (bc.value + f[2]) / 2
 
+
+# To be deprecated
+interp2pt(val1, val2) = 0.5 * (val1 + val2)
+
+#####
+##### advection operators
+#####
+
+function upwind_advection_area(ρ0_half::Vector{Float64}, a_up::Vector{Float64}, w_up::Vector{Float64}, grid, k)
+    whalf_kp = interp2pt(w_up[k - 1], w_up[k])
+    whalf_k = interp2pt(w_up[k - 2], w_up[k - 1])
+
+    m_kp = (ρ0_half[k] * a_up[k] * whalf_kp)
+    m_k = (ρ0_half[k - 1] * a_up[k - 1] * whalf_k)
+    return -grid.dzi * (m_kp - m_k) / ρ0_half[k]
+end
+
+function upwind_advection_velocity(ρ0::Vector{Float64}, a_up::Vector{Float64}, w_up::Vector{Float64}, grid, k)
+    a_k = interp2pt(a_up[k], a_up[k + 1])
+    a_km = interp2pt(a_up[k - 1], a_up[k])
+    adv = (ρ0[k] * a_k * w_up[k] * w_up[k] * grid.dzi - ρ0[k - 1] * a_km * w_up[k - 1] * w_up[k - 1] * grid.dzi)
+    return adv
+end
+
+function upwind_advection_scalar(
+    ρ0_half::Vector{Float64},
+    a_up::Vector{Float64},
+    w_up::Vector{Float64},
+    var::Vector{Float64},
+    grid,
+    k,
+)
+    m_k = (ρ0_half[k] * a_up[k] * interp2pt(w_up[k - 1], w_up[k]))
+    m_km = (ρ0_half[k - 1] * a_up[k - 1] * interp2pt(w_up[k - 2], w_up[k - 1]))
+    return (m_k * var[k] - m_km * var[k - 1]) * grid.dzi
+end
+
 #####
 ##### ∇(center data)
 #####

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -833,7 +833,7 @@ function solve_updraft(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, TS::Tim
                 self.UpdVar.Area.values[i, :],
                 self.UpdVar.W.values[i, :],
                 grid,
-                k + 1,
+                k,
             )
 
             entr_term = self.UpdVar.Area.values[i, k + 1] * whalf_kp * (self.entr_sc[i, k + 1])

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -12,11 +12,6 @@ function percentile_bounds_mean_norm(low_percentile::FT, high_percentile::FT, n_
     return pbmn
 end
 
-
-function interp2pt(val1, val2)
-    return 0.5 * (val1 + val2)
-end
-
 function logistic(x, slope, mid)
     return 1.0 / (1.0 + exp(-slope * (x - mid)))
 end
@@ -33,35 +28,6 @@ function lamb_smooth_minimum(l, lower_bound, upper_bound)
     end)
     smin = num / den
     return smin
-end
-
-function upwind_advection_area(ρ0_half::Vector{Float64}, a_up::Vector{Float64}, w_up::Vector{Float64}, grid, k)
-    whalf_kp = interp2pt(w_up[k - 1], w_up[k])
-    whalf_k = interp2pt(w_up[k - 2], w_up[k - 1])
-
-    m_kp = (ρ0_half[k] * a_up[k] * whalf_kp)
-    m_k = (ρ0_half[k - 1] * a_up[k - 1] * whalf_k)
-    return -grid.dzi * (m_kp - m_k) / ρ0_half[k]
-end
-
-function upwind_advection_velocity(ρ0::Vector{Float64}, a_up::Vector{Float64}, w_up::Vector{Float64}, grid, k)
-    a_k = interp2pt(a_up[k], a_up[k + 1])
-    a_km = interp2pt(a_up[k - 1], a_up[k])
-    adv = (ρ0[k] * a_k * w_up[k] * w_up[k] * grid.dzi - ρ0[k - 1] * a_km * w_up[k - 1] * w_up[k - 1] * grid.dzi)
-    return adv
-end
-
-function upwind_advection_scalar(
-    ρ0_half::Vector{Float64},
-    a_up::Vector{Float64},
-    w_up::Vector{Float64},
-    var::Vector{Float64},
-    grid,
-    k,
-)
-    m_k = (ρ0_half[k] * a_up[k] * interp2pt(w_up[k - 1], w_up[k]))
-    m_km = (ρ0_half[k - 1] * a_up[k - 1] * interp2pt(w_up[k - 2], w_up[k - 1]))
-    return (m_k * var[k] - m_km * var[k - 1]) * grid.dzi
 end
 
 get_nc_data(data, group, var, imin, imax) = mean(data.group[group][var][:][:, imin:imax], dims = 2)[:]


### PR DESCRIPTION
This PR:
 - Makes one of the advection operators use bcs
 - Changes the index from `k+1` to `k` in the call to `upwind_advection_area`. Doing so requires changing the indices inside the method, and I noticed something odd: we are (and have been for a while) dividing `∇m` by `ρ0_half[k + 1]`.