### PR TITLE
Use more centered gradients

### DIFF
--- a/src/Forcing.jl
+++ b/src/Forcing.jl
@@ -48,10 +48,10 @@ function update(self::ForcingBase{ForcingStandard}, GMV::GridMeanVariables)
     if self.apply_subsidence
         @inbounds for k in real_center_indicies(grid)
             # Apply large-scale subsidence tendencies
-            H_cut = ccut_onesided(GMV.H.values, grid, k)
-            q_tot_cut = ccut_onesided(GMV.QT.values, grid, k)
-            ∇H = c∇_onesided(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            ∇q_tot = c∇_onesided(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
+            H_cut = ccut(GMV.H.values, grid, k)
+            q_tot_cut = ccut(GMV.QT.values, grid, k)
+            ∇H = c∇(H_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
+            ∇q_tot = c∇(q_tot_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
             GMV.H.tendencies[k] -= ∇H * self.subsidence[k]
             GMV.QT.tendencies[k] -= ∇q_tot * self.subsidence[k]
         end
@@ -77,10 +77,10 @@ end
 function update(self::ForcingBase{ForcingDYCOMS_RF01}, GMV::GridMeanVariables)
     grid = self.Gr
     @inbounds for k in real_center_indicies(grid)
-        H_cut = ccut_onesided(GMV.H.values, grid, k)
-        q_tot_cut = ccut_onesided(GMV.QT.values, grid, k)
-        ∇H = c∇_onesided(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-        ∇q_tot = c∇_onesided(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
+        H_cut = ccut(GMV.H.values, grid, k)
+        q_tot_cut = ccut(GMV.QT.values, grid, k)
+        ∇H = c∇(H_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
+        ∇q_tot = c∇(q_tot_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
 
         GMV.QT.tendencies[k] += self.dqtdt[k]
         # Apply large-scale subsidence tendencies
@@ -138,10 +138,10 @@ function update(self::ForcingBase{ForcingLES}, GMV::GridMeanVariables)
         if self.apply_subsidence
             # Apply large-scale subsidence tendencies
 
-            H_cut = ccut_onesided(GMV.H.values, grid, k)
-            q_tot_cut = ccut_onesided(GMV.QT.values, grid, k)
-            ∇H = c∇_onesided(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            ∇q_tot = c∇_onesided(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
+            H_cut = ccut(GMV.H.values, grid, k)
+            q_tot_cut = ccut(GMV.QT.values, grid, k)
+            ∇H = c∇(H_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
+            ∇q_tot = c∇(q_tot_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
             GMV_H_subsidence_k = -∇H * self.subsidence[k]
             GMV_QT_subsidence_k = -∇q_tot * self.subsidence[k]
         else

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -1836,8 +1836,8 @@ function update_inversion(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, opti
     elseif option == "thetal_maxgrad"
 
         @inbounds for k in real_center_indicies(grid)
-            ∇θ_liq_cut = ccut_onesided(GMV.H.values, grid, k)
-            ∇θ_liq = c∇_onesided(∇θ_liq_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
+            ∇θ_liq_cut = ccut(GMV.H.values, grid, k)
+            ∇θ_liq = c∇(∇θ_liq_cut, grid, k; bottom = Extrapolate(), top = SetGradient(0))
             if ∇θ_liq > ∇θ_liq_max
                 ∇θ_liq_max = ∇θ_liq
                 self.zi = grid.z[k]


### PR DESCRIPTION
`c∇_onesided` is currently a _downwind_ scheme, which means that it can't be used in the upwind advection operators. Rather than adding yet another stencil/operator category, I figured it'd be easier to switch calls from `c∇_onesided` to `c∇`, and then change the implementation of `c∇_onesided` so that it's actually upwind, and then a new stencil/operator is not needed.

I'm not exactly sure if this is consistent with how the time-implicit operators are defined but, AFAIK only the advection terms _really_ need to be upwinded, and these changes are only applied to other sources.