### PR TITLE
Fuse grid mean tendencies into single loop

### DIFF
--- a/src/Forcing.jl
+++ b/src/Forcing.jl
@@ -1,4 +1,3 @@
-
 function initialize(self::ForcingBase, GMV::GridMeanVariables, ::ForcingBaseType)
     self.subsidence = center_field(self.Gr)
     self.dTdt = center_field(self.Gr)
@@ -9,103 +8,15 @@ function initialize(self::ForcingBase, GMV::GridMeanVariables, ::ForcingBaseType
 end
 
 update(self::ForcingBase, GMV::GridMeanVariables) = nothing
-
-function coriolis_force(self::ForcingBase, U::VariablePrognostic, V::VariablePrognostic, ::ForcingBaseType)
-    @inbounds for k in real_center_indicies(self.Gr)
-        U.tendencies[k] -= self.coriolis_param * (self.vg[k] - V.values[k])
-        V.tendencies[k] += self.coriolis_param * (self.ug[k] - U.values[k])
-    end
-    return
-end
-
 initialize_io(self::ForcingBase, Stats) = nothing
 io(self::ForcingBase, Stats) = nothing
-
-
-function initialize(self::ForcingBase{ForcingNone}, GMV::GridMeanVariables)
-    initialize(self, GMV, ForcingBaseType())
-end
-
-update(self::ForcingBase{ForcingNone}, GMV::GridMeanVariables) = nothing
-coriolis_force(self::ForcingBase{ForcingNone}, U, V) = nothing
-initialize_io(self::ForcingBase{ForcingNone}, Stats) = nothing
-io(self::ForcingBase{ForcingNone}, Stats) = nothing
-
-
-function initialize(self::ForcingBase{ForcingStandard}, GMV::GridMeanVariables)
-    initialize(self, GMV, ForcingBaseType())
-end
-
+initialize(self::ForcingBase{ForcingNone}, GMV::GridMeanVariables) = initialize(self, GMV, ForcingBaseType())
+initialize(self::ForcingBase{ForcingStandard}, GMV::GridMeanVariables) = initialize(self, GMV, ForcingBaseType())
 initialize(self::ForcingBase{ForcingStandard}, GMV) = initialize(self, GMV, ForcingBaseType())
-
-function update(self::ForcingBase{ForcingStandard}, GMV::GridMeanVariables)
-    grid = self.Gr
-    @inbounds for k in real_center_indicies(grid)
-        # Apply large-scale horizontal advection tendencies
-        GMV.H.tendencies[k] += self.dTdt[k] / exner_c(self.Ref.p0_half[k])
-        GMV.QT.tendencies[k] += self.dqtdt[k]
-    end
-    if self.apply_subsidence
-        @inbounds for k in real_center_indicies(grid)
-            # Apply large-scale subsidence tendencies
-            H_cut = ccut_downwind(GMV.H.values, grid, k)
-            q_tot_cut = ccut_downwind(GMV.QT.values, grid, k)
-            ∇H = c∇_downwind(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            ∇q_tot = c∇_downwind(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            GMV.H.tendencies[k] -= ∇H * self.subsidence[k]
-            GMV.QT.tendencies[k] -= ∇q_tot * self.subsidence[k]
-        end
-    end
-    if self.apply_coriolis
-        coriolis_force(self, GMV.U, GMV.V, ForcingBaseType())
-    end
-    return
-end
-initialize_io(self::ForcingBase{ForcingStandard}, Stats) = nothing
-io(self::ForcingBase{ForcingStandard}, Stats) = nothing
-
-function initialize(self::ForcingBase{ForcingDYCOMS_RF01}, GMV::GridMeanVariables)
-    initialize(self, GMV, ForcingBaseType())
-    return
-end
-
-function coriolis_force(self::ForcingBase{ForcingDYCOMS_RF01}, U::VariablePrognostic, V::VariablePrognostic)
-    coriolis_force(self, U, V, ForcingBaseType())
-    return
-end
-
-function update(self::ForcingBase{ForcingDYCOMS_RF01}, GMV::GridMeanVariables)
-    grid = self.Gr
-    @inbounds for k in real_center_indicies(grid)
-        H_cut = ccut_downwind(GMV.H.values, grid, k)
-        q_tot_cut = ccut_downwind(GMV.QT.values, grid, k)
-        ∇H = c∇_downwind(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-        ∇q_tot = c∇_downwind(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-
-        GMV.QT.tendencies[k] += self.dqtdt[k]
-        # Apply large-scale subsidence tendencies
-        GMV.H.tendencies[k] -= ∇H * self.subsidence[k]
-        GMV.QT.tendencies[k] -= ∇q_tot * self.subsidence[k]
-    end
-
-    if self.apply_coriolis
-        coriolis_force(self, GMV.U, GMV.V)
-    end
-
-    return
-end
-
-function initialize_io(self::ForcingBase{ForcingDYCOMS_RF01}, Stats::NetCDFIO_Stats)
-    return
-end
-
-function io(self::ForcingBase{ForcingDYCOMS_RF01}, Stats::NetCDFIO_Stats)
-    return
-end
+initialize(self::ForcingBase{ForcingDYCOMS_RF01}, GMV::GridMeanVariables) = initialize(self, GMV, ForcingBaseType())
 
 function initialize(self::ForcingBase{ForcingLES}, GMV::GridMeanVariables, Gr::Grid, LESDat::LESData)
     initialize(self, GMV, ForcingBaseType())
-
     Dataset(LESDat.les_filename, "r") do data
         imin = LESDat.imin
         imax = LESDat.imax
@@ -122,44 +33,4 @@ function initialize(self::ForcingBase{ForcingLES}, GMV::GridMeanVariables, Gr::G
         self.u_nudge = pyinterp(Gr.z_half, z_les_half, get_nc_data(data, "profiles", "u_mean", imin, imax))
         self.v_nudge = pyinterp(Gr.z_half, z_les_half, get_nc_data(data, "profiles", "v_mean", imin, imax))
     end
-
 end
-
-function update(self::ForcingBase{ForcingLES}, GMV::GridMeanVariables)
-
-    grid = self.Gr
-    @inbounds for k in real_center_indicies(grid)
-        H_horz_adv = self.dtdt_hadv[k] / exner_c(self.Ref.p0_half[k])
-        H_nudge = self.dtdt_nudge[k] / exner_c(self.Ref.p0_half[k])
-        H_fluc = self.dtdt_fluc[k] / exner_c(self.Ref.p0_half[k])
-
-        GMV_U_nudge_k = (self.u_nudge[k] - GMV.U.values[k]) / self.nudge_tau
-        GMV_V_nudge_k = (self.v_nudge[k] - GMV.V.values[k]) / self.nudge_tau
-        if self.apply_subsidence
-            # Apply large-scale subsidence tendencies
-
-            H_cut = ccut_downwind(GMV.H.values, grid, k)
-            q_tot_cut = ccut_downwind(GMV.QT.values, grid, k)
-            ∇H = c∇_downwind(H_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            ∇q_tot = c∇_downwind(q_tot_cut, grid, k; bottom = FreeBoundary(), top = SetGradient(0))
-            GMV_H_subsidence_k = -∇H * self.subsidence[k]
-            GMV_QT_subsidence_k = -∇q_tot * self.subsidence[k]
-        else
-            GMV_H_subsidence_k = 0.0
-            GMV_QT_subsidence_k = 0.0
-        end
-
-        GMV.H.tendencies[k] += H_horz_adv + H_nudge + H_fluc + GMV_H_subsidence_k
-        GMV.QT.tendencies[k] += self.dqtdt_hadv[k] + self.dqtdt_nudge[k] + GMV_QT_subsidence_k + self.dqtdt_fluc[k]
-
-        GMV.U.tendencies[k] += GMV_U_nudge_k
-        GMV.V.tendencies[k] += GMV_V_nudge_k
-    end
-
-    if self.apply_coriolis
-        coriolis_force(self, GMV.U, GMV.V, ForcingBaseType())
-    end
-    return
-end
-initialize_io(self::ForcingBase{ForcingLES}, Stats) = nothing
-io(self::ForcingBase{ForcingLES}, Stats) = nothing

--- a/src/Radiation.jl
+++ b/src/Radiation.jl
@@ -90,12 +90,6 @@ end
 function update(self::RadiationBase{RadiationDYCOMS_RF01}, GMV::GridMeanVariables)
 
     calculate_radiation(self, GMV)
-
-    @inbounds for k in real_center_indicies(self.Gr)
-        # Apply large-scale horizontal advection tendencies
-        GMV.H.tendencies[k] += self.dTdt[k] / exner_c(self.Ref.p0_half[k])
-    end
-
     return
 end
 
@@ -127,15 +121,7 @@ function initialize(self::RadiationBase{RadiationLES}, GMV::GridMeanVariables, L
     return
 end
 
-function update(self::RadiationBase{RadiationLES}, GMV::GridMeanVariables)
-
-    @inbounds for k in real_center_indicies(self.Gr)
-        # Apply large-scale horizontal advection tendencies
-        GMV.H.tendencies[k] += self.dTdt[k] / exner_c(self.Ref.p0_half[k])
-    end
-
-    return
-end
+update(self::RadiationBase{RadiationLES}, GMV::GridMeanVariables) = nothing
 
 function initialize_io(self::RadiationBase{RadiationLES}, Stats::NetCDFIO_Stats)
     add_profile(Stats, "rad_dTdt")

--- a/src/Variables.jl
+++ b/src/Variables.jl
@@ -1,18 +1,3 @@
-function zero_tendencies(self::VariablePrognostic, Gr::Grid)
-    @inbounds for k in center_indicies(Gr)
-        self.tendencies[k] = 0.0
-    end
-    return
-end
-
-function zero_tendencies(self::GridMeanVariables)
-    zero_tendencies(self.U, self.Gr)
-    zero_tendencies(self.V, self.Gr)
-    zero_tendencies(self.QT, self.Gr)
-    zero_tendencies(self.H, self.Gr)
-    return
-end
-
 function update(self::GridMeanVariables, TS::TimeStepping)
     grid = self.Gr
     @inbounds for k in center_indicies(grid)
@@ -31,8 +16,6 @@ function update(self::GridMeanVariables, TS::TimeStepping)
     set_bcs(self.QTvar, grid)
     set_bcs(self.Hvar, grid)
     set_bcs(self.HQTcov, grid)
-
-    zero_tendencies(self)
     return
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -799,6 +799,8 @@ Base.@kwdef mutable struct ForcingBase{T}
     Ref::ReferenceState
 end
 
+force_type(::ForcingBase{T}) where {T} = T
+
 Base.@kwdef mutable struct RadiationBase{T}
     dTdt::AbstractArray{Float64, 1} = zeros(1) # horizontal advection temperature tendency
     dqtdt::AbstractArray{Float64, 1} = zeros(1) # horizontal advection moisture tendency
@@ -811,6 +813,8 @@ Base.@kwdef mutable struct RadiationBase{T}
     F1::Float64 = 0
     f_rad::AbstractArray{Float64, 1} = zeros(1)
 end
+
+rad_type(::RadiationBase{T}) where {T} = T
 
 Base.@kwdef mutable struct CasesBase{T}
     casename::String = "default_casename"


### PR DESCRIPTION
Looking through the code, I realized that _all_ grid mean quantities seem to be updated in a standardized way, and I think we can fuse all the tendencies into a single loop.

This is still not a great final version, but we can start thinking about how we want to dispatch to add sources for a given model.