### PR TITLE
Remove  diagnostic variables

### DIFF
--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -223,9 +223,7 @@ function set_new_with_values(self::UpdraftVariables)
         @inbounds for k in center_indicies(self.Gr)
             self.Area.new[i, k] = self.Area.values[i, k]
             self.QT.new[i, k] = self.QT.values[i, k]
-            self.QL.new[i, k] = self.QL.values[i, k]
             self.H.new[i, k] = self.H.values[i, k]
-            self.T.new[i, k] = self.T.values[i, k]
         end
     end
     return
@@ -252,9 +250,7 @@ function set_values_with_new(self::UpdraftVariables)
             self.W.values[i, k] = self.W.new[i, k]
             self.Area.values[i, k] = self.Area.new[i, k]
             self.QT.values[i, k] = self.QT.new[i, k]
-            self.QL.values[i, k] = self.QL.new[i, k]
             self.H.values[i, k] = self.H.new[i, k]
-            self.T.values[i, k] = self.T.new[i, k]
         end
     end
     return
@@ -433,10 +429,10 @@ function microphysics(self::UpdraftThermodynamics, UpdVar::UpdraftVariables, Rai
                 Rain.tau_acnv,
                 Rain.E_col,
                 UpdVar.QT.new[i, k],
-                UpdVar.QL.new[i, k],
+                UpdVar.QL.values[i, k],
                 Rain.Upd_QR.values[k],
                 UpdVar.Area.new[i, k],
-                UpdVar.T.new[i, k],
+                UpdVar.T.values[i, k],
                 self.Ref.p0_half[k],
                 self.Ref.rho0_half[k],
                 dt,
@@ -444,7 +440,7 @@ function microphysics(self::UpdraftThermodynamics, UpdVar::UpdraftVariables, Rai
 
             # update Updraft.new
             UpdVar.QT.new[i, k] = mph.qt
-            UpdVar.QL.new[i, k] = mph.ql
+            UpdVar.QL.values[i, k] = mph.ql
             UpdVar.H.new[i, k] = mph.thl
 
             # update rain sources of state variables

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -1004,8 +1004,8 @@ function solve_updraft(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, TS::Tim
 
                 # saturation adjustment
                 sa = eos(param_set, ref_state.p0_half[k], self.UpdVar.QT.new[i, k], self.UpdVar.H.new[i, k])
-                self.UpdVar.QL.new[i, k] = sa.ql
-                self.UpdVar.T.new[i, k] = sa.T
+                self.UpdVar.QL.values[i, k] = sa.ql
+                self.UpdVar.T.values[i, k] = sa.T
                 continue
             end
 
@@ -1037,8 +1037,8 @@ function solve_updraft(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, TS::Tim
 
             # saturation adjustment
             sa = eos(param_set, ref_state.p0_half[k], self.UpdVar.QT.new[i, k], self.UpdVar.H.new[i, k])
-            self.UpdVar.QL.new[i, k] = sa.ql
-            self.UpdVar.T.new[i, k] = sa.T
+            self.UpdVar.QL.values[i, k] = sa.ql
+            self.UpdVar.T.values[i, k] = sa.T
         end
     end
 


### PR DESCRIPTION
There's no reason for diagnostic quantities to have `new`, `old`, `tendencies` etc.. This PR removes the use of `new` for diagnostic variables `QL` and `T`. I'm hoping that in a later PR we can make all diagnostic variables fields, rather than, e.g., `UpdraftVariable`.