### PR TITLE
Replace more operators

### DIFF
--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -58,6 +58,9 @@ c∇_downwind(f::SVector, grid::Grid, ::BottomBCTag, bc::FreeBoundary) = (f[2] -
 # top of the domain.
 c∇_downwind(f::SVector, grid::Grid, ::BottomBCTag, bc::SetGradient) = bc.value
 
+c∇_upwind(f, grid::Grid, k::Int; bottom = NoBCGivenError(), top = NoBCGivenError()) =
+    c∇_upwind(ccut_upwind(f, grid, k), grid, k; bottom, top)
+
 function c∇_upwind(f_dual::SVector, grid::Grid, k::Int; bottom = NoBCGivenError(), top = NoBCGivenError())
     if is_surface_center(grid, k)
         return c∇_upwind(f_dual, grid, BottomBCTag(), bottom)

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -17,16 +17,11 @@ function get_inversion(param_set, θ_ρ, u, v, grid::Grid, Ri_bulk_crit)
     k_last = last(real_center_indicies(grid))
     # test if we need to look at the free convective limit
     if (u[kmin] * u[kmin] + v[kmin] * v[kmin]) <= 0.01
-        @inbounds for k in real_center_indicies(grid)
-            if θ_ρ[k] > θ_ρ_b
-                k_last = k
-                break
-            end
-        end
-        k = k_last
-        h =
-            (z_half[k] - z_half[k - 1]) / (θ_ρ[k] - θ_ρ[k - 1]) * (θ_ρ_b - θ_ρ[k - 1]) +
-            z_half[k - 1]
+
+        kmask = map(k -> (k, θ_ρ[k] > θ_ρ_b), real_center_indicies(grid))
+        k = first(kmask[findlast(km -> km[2], kmask)])
+        ∇θ_ρ = c∇_upwind(θ_ρ, grid, k; bottom = SetGradient(0), top = FreeBoundary())
+        h = (θ_ρ_b - θ_ρ[k - 1]) / ∇θ_ρ + z_half[k - 1]
     else
         @inbounds for k in real_center_indicies(grid)
             Ri_bulk_low = Ri_bulk

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -4,11 +4,11 @@ function get_wstar(bflux, zi)
 end
 
 # BL height
-function get_inversion(param_set, theta_rho, u, v, grid::Grid, Ri_bulk_crit)
+function get_inversion(param_set, θ_ρ, u, v, grid::Grid, Ri_bulk_crit)
     g = CPP.grav(param_set)
     kc_surf = kc_surface(grid)
     kmin = kc_surf
-    theta_rho_b = theta_rho[kmin]
+    θ_ρ_b = θ_ρ[kmin]
     k = kmin
     Ri_bulk = 0.0
     Ri_bulk_low = 0.0
@@ -18,19 +18,19 @@ function get_inversion(param_set, theta_rho, u, v, grid::Grid, Ri_bulk_crit)
     # test if we need to look at the free convective limit
     if (u[kmin] * u[kmin] + v[kmin] * v[kmin]) <= 0.01
         @inbounds for k in real_center_indicies(grid)
-            if theta_rho[k] > theta_rho_b
+            if θ_ρ[k] > θ_ρ_b
                 k_last = k
                 break
             end
         end
         k = k_last
         h =
-            (z_half[k] - z_half[k - 1]) / (theta_rho[k] - theta_rho[k - 1]) * (theta_rho_b - theta_rho[k - 1]) +
+            (z_half[k] - z_half[k - 1]) / (θ_ρ[k] - θ_ρ[k - 1]) * (θ_ρ_b - θ_ρ[k - 1]) +
             z_half[k - 1]
     else
         @inbounds for k in real_center_indicies(grid)
             Ri_bulk_low = Ri_bulk
-            Ri_bulk = g * (theta_rho[k] - theta_rho_b) * z_half[k] / theta_rho_b / (u[k] * u[k] + v[k] * v[k])
+            Ri_bulk = g * (θ_ρ[k] - θ_ρ_b) * z_half[k] / θ_ρ_b / (u[k] * u[k] + v[k] * v[k])
             if Ri_bulk > Ri_bulk_crit
                 k_last = k
                 break
@@ -68,12 +68,12 @@ function get_surface_variance(flux1, flux2, ustar, zLL, oblength)
     end
 end
 
-function construct_tridiag_diffusion(grid, dt, rho_ae_K_m, rho, ae, a, b, c)
+function construct_tridiag_diffusion(grid, dt, ρ_ae_K_m, ρ_0, ae, a, b, c)
     dzi = grid.dzi
     @inbounds for k in real_center_indicies(grid)
-        X = rho[k] * ae[k] / dt
-        Y = rho_ae_K_m[k] * dzi * dzi
-        Z = rho_ae_K_m[k - 1] * dzi * dzi
+        X = ρ_0[k] * ae[k] / dt
+        Y = ρ_ae_K_m[k] * dzi * dzi
+        Z = ρ_ae_K_m[k - 1] * dzi * dzi
         if is_surface_center(grid, k)
             Z = 0.0
         elseif is_toa_center(grid, k)


### PR DESCRIPTION
This PR
 - uses unicode
 - Replaces a gradient operator
 - uses `findlast`

The remaining `k - 1` calls do not necessarily access ghost points, but could and we'll see what happens.