### PR TITLE
Avoid OOB for when the grid changes

### DIFF
--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -955,11 +955,15 @@ function solve_updraft(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, TS::Tim
 
                 w_up_new[i, k] = max(w_up_new[i, k], 0)
                 if w_up_new[i, k] <= 0.0
-                    is_toa_face(grid, k) || (a_up_new[i, k + 1] = 0)
+                    if !(k + 1 > size(a_up_new, 2))
+                        a_up_new[i, k + 1] = 0
+                    end
                 end
             else
                 w_up_new[i, k] = 0
-                is_toa_face(grid, k) || (a_up_new[i, k + 1] = 0)
+                if !(k + 1 > size(a_up_new, 2))
+                    a_up_new[i, k + 1] = 0
+                end
             end
         end
     end


### PR DESCRIPTION
Another peel off from #218. This PR ensures that we avoid Out-Of-Bounds (OOB) error for when the grid structure changes.