### PR TITLE
Put eos into a submodule

### DIFF
--- a/integration_tests/utils/Cases.jl
+++ b/integration_tests/utils/Cases.jl
@@ -16,17 +16,16 @@ const TD = Thermodynamics
 
 import ..TurbulenceConvection
 const TC = TurbulenceConvection
+const TCTD = TC.TCThermodynamics
 
 using ..TurbulenceConvection: CasesBase
 using ..TurbulenceConvection: off_arr
 using ..TurbulenceConvection: omega
 using ..TurbulenceConvection: pyinterp
 using ..TurbulenceConvection: eps_vi
-using ..TurbulenceConvection: eos
 using ..TurbulenceConvection: eps_v
 using ..TurbulenceConvection: cpd
 using ..TurbulenceConvection: buoyancy_c
-using ..TurbulenceConvection: rho_c
 using ..TurbulenceConvection: add_ts
 using ..TurbulenceConvection: update
 using ..TurbulenceConvection: write_ts
@@ -1273,15 +1272,15 @@ function initialize_profiles(
             GMV.QT.values[k] = 1.5 / 1000.0
         end
 
-        sa = eos(param_set, ref_state.p0_half[k], GMV.QT.values[k], thetal[k])
-        GMV.QL.values[k] = sa.ql
-        GMV.T.values[k] = sa.T
+        ts = TCTD.eos(param_set, ref_state.p0_half[k], thetal[k], GMV.QT.values[k])
+        GMV.QL.values[k] = TCTD.liquid_specific_humidity(ts)
+        GMV.T.values[k] = TCTD.air_temperature(ts)
         ts = TD.PhaseEquil_pTq(param_set, ref_state.p0_half[k], GMV.T.values[k], GMV.QT.values[k])
         GMV.H.values[k] = TD.liquid_ice_pottemp(ts)
 
         # buoyancy profile
         qv = GMV.QT.values[k] - qi - GMV.QL.values[k]
-        rho = rho_c(ref_state.p0_half[k], GMV.T.values[k], GMV.QT.values[k], qv)
+        rho = TCTD.rho_c(ref_state.p0_half[k], GMV.T.values[k], GMV.QT.values[k], qv)
         GMV.B.values[k] = buoyancy_c(param_set, ref_state.rho0_half[k], rho)
 
         # velocity profile (geostrophic)

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -64,6 +64,11 @@ const ICP = ClimaParams # internal clima parameters
 
 include("python_primitives.jl")
 include("parameters.jl")
+
+include("thermodynamic_functions.jl")
+import .TCThermodynamics
+const TCTD = TCThermodynamics
+
 include("Grid.jl")
 include("Fields.jl")
 include("NetCDFIO.jl")
@@ -72,7 +77,6 @@ include("types.jl")
 include("name_aliases.jl")
 include("Operators.jl")
 
-include("thermodynamic_functions.jl")
 include("microphysics_functions.jl")
 include("turbulence_functions.jl")
 include("utility_functions.jl")

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -409,9 +409,9 @@ function update(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, Case::CasesBas
     @inbounds for k in real_center_indices(grid)
         @inbounds for i in xrange(self.n_updrafts)
             # saturation adjustment
-            sa = eos(param_set, ref_state.p0_half[k], self.UpdVar.QT.new[i, k], self.UpdVar.H.new[i, k])
-            self.UpdVar.QL.values[i, k] = sa.ql
-            self.UpdVar.T.values[i, k] = sa.T
+            ts = TCTD.eos(param_set, ref_state.p0_half[k], self.UpdVar.H.new[i, k], self.UpdVar.QT.new[i, k])
+            self.UpdVar.QL.values[i, k] = TCTD.liquid_specific_humidity(ts)
+            self.UpdVar.T.values[i, k] = TCTD.air_temperature(ts)
         end
     end
     if self.Rain.rain_model == "clima_1m"
@@ -922,7 +922,6 @@ function solve_updraft(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, TS::Tim
     kf_surf = kf_surface(grid)
     dti_ = 1.0 / TS.dt
     Δt = TS.dt
-    sa = eos_struct()
 
     a_up = self.UpdVar.Area.values
     a_up_new = self.UpdVar.Area.new

--- a/src/Variables.jl
+++ b/src/Variables.jl
@@ -82,19 +82,18 @@ function mean_cloud_diagnostics(self)
 end
 
 function satadjust(self::GridMeanVariables)
-    sa = eos_struct()
     param_set = parameter_set(self)
     @inbounds for k in real_center_indices(self.grid)
         h = self.H.values[k]
         qt = self.QT.values[k]
         p0 = self.ref_state.p0_half[k]
-        sa = eos(param_set, p0, qt, h)
-        self.QL.values[k] = sa.ql
-        self.T.values[k] = sa.T
-        qv = qt - sa.ql
-        rho = rho_c(p0, sa.T, qt, qv)
-        self.B.values[k] = buoyancy_c(param_set, self.ref_state.rho0_half[k], rho)
-        ts = TD.PhaseEquil_pθq(param_set, self.ref_state.p0_half[k], h, qt)
+        ρ0 = self.ref_state.rho0_half[k]
+        ts = TCTD.eos(param_set, p0, h, qt)
+        self.QL.values[k] = TCTD.liquid_specific_humidity(ts)
+        self.T.values[k] = TCTD.air_temperature(ts)
+        ρ = TCTD.air_density(ts)
+        self.B.values[k] = buoyancy_c(param_set, ρ0, ρ)
+        ts = TD.PhaseEquil_pθq(param_set, p0, h, qt)
         self.RH.values[k] = TD.relative_humidity(ts)
     end
     return

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -3,6 +3,11 @@ function get_wstar(bflux, zi)
     return cbrt(max(bflux * zi, 0.0))
 end
 
+function buoyancy_c(param_set, ρ0, ρ)
+    g = CPP.grav(param_set)
+    return g * (ρ0 - ρ) / ρ0
+end
+
 # BL height
 function get_inversion(param_set, θ_ρ, u, v, grid::Grid, Ri_bulk_crit)
     g = CPP.grav(param_set)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,8 +1,3 @@
-Base.@kwdef mutable struct eos_struct
-    T::Float64 = 0
-    ql::Float64 = 0
-end
-
 Base.@kwdef mutable struct rain_struct
     qr::Float64 = 0
     ar::Float64 = 0


### PR DESCRIPTION
This PR does several things to smooth the transition to new thermo functions:
 - puts all of `thermodynamic_functions.jl` into a submodule, `TCThermodynamics`
 - Moves `buoyancy_c` out into `turbulence_functions`, since this function will remain after new thermo functions land
 - Adds some methods defined in `thermodynamic_functions.jl` that match Thermodynamic interfaces
 - Changes the argument order of `eos` to match the thermodynamics interface