### PR TITLE
Add field data structures

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -35,3 +35,16 @@ function field(grid::Grid, loc::String, nu::Int)
 end
 
 surface_value(f::AbstractVector, grid::Grid) = f[kf_surface(grid)]
+
+Base.length(space::CC.Spaces.FiniteDifferenceSpace) = length(CC.Spaces.coordinates_data(space))
+
+Base.@propagate_inbounds function Base.getindex(field::CC.Fields.FiniteDifferenceField, i::Integer)
+    Base.getindex(CC.Fields.field_values(field), i)
+end
+
+Base.@propagate_inbounds function Base.setindex!(field::CC.Fields.FiniteDifferenceField, v, i::Integer)
+    Base.setindex!(CC.Fields.field_values(field), v, i)
+end
+
+center_fields(state) = state.cent
+face_fields(state) = state.cent

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -1,15 +1,11 @@
-
-Base.@propagate_inbounds function Base.getindex(field::CC.Fields.FiniteDifferenceField, i::Integer)
-    Base.getindex(CC.Fields.field_values(field), i)
-end
-
-
-struct Grid{FT, SC, SF}
+struct Grid{FT, CS, FS, SC, SF}
     zmin::FT
     zmax::FT
     Δz::FT
     Δzi::FT
     nz::Int
+    cs::CS
+    fs::FS
     zc::SC
     zf::SF
     function Grid(namelist)
@@ -32,10 +28,12 @@ struct Grid{FT, SC, SF}
 
         zmin = minimum(parent(zf))
         zmax = maximum(parent(zf))
+        CS = typeof(cs)
+        FS = typeof(fs)
         SC = typeof(zc)
         SF = typeof(zf)
         FT = typeof(zmax)
-        return new{FT, SC, SF}(zmin, zmax, Δz, Δzi, nz, zc, zf)
+        return new{FT, CS, FS, SC, SF}(zmin, zmax, Δz, Δzi, nz, cs, fs, zc, zf)
     end
 end
 
@@ -57,6 +55,9 @@ zf_toa(grid::Grid) = grid.zf[kf_top_of_atmos(grid)]
 
 real_center_indices(grid::Grid) = kc_surface(grid):kc_top_of_atmos(grid)
 real_face_indices(grid::Grid) = kf_surface(grid):kf_top_of_atmos(grid)
+
+face_space(grid::Grid) = grid.fs
+center_space(grid::Grid) = grid.cs
 
 
 Base.eltype(::Grid{FT}) where {FT} = FT

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"


### PR DESCRIPTION
This PR adds ClimaCore fields to the `Simulation1d` struct, which was also made to be immutable. The idea is that we can pass these fields around (in many places in the code), and we will incrementally port over all of the fields from

 - GMV
 - EDMF_PrognosticTKE
 - RadiationBase
 - ForcingBase
 - EnvironmentThermodynamics
 - EnvironmentVariables

etc.

The result is that all of these existing structs will either disappear (🤞🏻) or become much more compact, and potentially immutable.