### PR TITLE
remove old

### DIFF
--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -215,16 +215,6 @@ function set_new_with_values(self::UpdraftVariables)
     return
 end
 
-# quick utility to set "new" arrays with values in the "values" arrays
-function set_old_with_values(self::UpdraftVariables)
-    @inbounds for i in xrange(self.n_updrafts)
-        @inbounds for k in real_center_indices(self.grid)
-            self.Area.old[i, k] = self.Area.values[i, k]
-        end
-    end
-    return
-end
-
 # quick utility to set "tmp" arrays with values in the "new" arrays
 function set_values_with_new(self::UpdraftVariables)
     @inbounds for i in xrange(self.n_updrafts)

--- a/src/types.jl
+++ b/src/types.jl
@@ -298,7 +298,6 @@ end
 
 struct UpdraftVariable{A1, A2}
     values::A2
-    old::A2
     new::A2
     tendencies::A2
     flux::A2
@@ -309,7 +308,6 @@ struct UpdraftVariable{A1, A2}
     units::String
     function UpdraftVariable(grid, nu, loc, kind, name, units)
         values = field(grid, loc, nu)
-        old = field(grid, loc, nu)  # needed for prognostic updrafts
         new = field(grid, loc, nu) # needed for prognostic updrafts
         tendencies = field(grid, loc, nu)
         flux = field(grid, loc, nu)
@@ -319,7 +317,7 @@ struct UpdraftVariable{A1, A2}
         end
         A1 = typeof(bulkvalues)
         A2 = typeof(values)
-        return new{A1, A2}(values, old, new, tendencies, flux, bulkvalues, loc, kind, name, units)
+        return new{A1, A2}(values, new, tendencies, flux, bulkvalues, loc, kind, name, units)
     end
 end
 


### PR DESCRIPTION
ever since we unified the time steps in the model old was effectively equal to values. 
It can be removed, along with 'set_old_with_values' function and relevant type definitions. 