### PR TITLE
Use fields for reference state, add field io, compute_mse bugfixes

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -9,6 +9,7 @@ include("Cases.jl")
 import .Cases
 
 struct Simulation1d
+    io_nt::NamedTuple
     grid
     state
     tendencies
@@ -58,11 +59,6 @@ face_prognostic_vars_up(FT) = (; W = FT(0))
 face_prognostic_vars_edmf(FT, n_up) = (; turbconv = (; up = ntuple(i -> face_prognostic_vars_up(FT), n_up)))
 # face_prognostic_vars_edmf(FT, n_up) = (;) # could also use this for empty model
 
-function FieldFromNamedTuple(space, nt::NamedTuple)
-    cmv(z) = nt
-    return cmv.(CC.Fields.coordinate_field(space))
-end
-
 function Simulation1d(namelist)
     TC = TurbulenceConvection
     param_set = create_parameter_set(namelist)
@@ -85,21 +81,34 @@ function Simulation1d(namelist)
     FT = Float64
     n_updrafts = Turb.n_updrafts
 
-    cent_state_fields = FieldFromNamedTuple(TC.center_space(grid), cent_prognostic_vars(FT, n_updrafts))
-    face_state_fields = FieldFromNamedTuple(TC.face_space(grid), face_prognostic_vars(FT, n_updrafts))
-    aux_cent_fields = FieldFromNamedTuple(TC.center_space(grid), cent_aux_vars(FT, n_updrafts))
-    aux_face_fields = FieldFromNamedTuple(TC.face_space(grid), face_aux_vars(FT, n_updrafts))
+    cent_state_fields = TC.FieldFromNamedTuple(TC.center_space(grid), cent_prognostic_vars(FT, n_updrafts))
+    face_state_fields = TC.FieldFromNamedTuple(TC.face_space(grid), face_prognostic_vars(FT, n_updrafts))
+    aux_cent_fields = TC.FieldFromNamedTuple(TC.center_space(grid), cent_aux_vars(FT, n_updrafts))
+    aux_face_fields = TC.FieldFromNamedTuple(TC.face_space(grid), face_aux_vars(FT, n_updrafts))
+
+    parent(aux_face_fields.ref_state.p0) .= ref_state.p0
+    parent(aux_face_fields.ref_state.ρ0) .= ref_state.rho0
+    parent(aux_face_fields.ref_state.α0) .= ref_state.alpha0
+    parent(aux_cent_fields.ref_state.p0) .= ref_state.p0_half
+    parent(aux_cent_fields.ref_state.ρ0) .= ref_state.rho0_half
+    parent(aux_cent_fields.ref_state.α0) .= ref_state.alpha0_half
 
     state = CC.Fields.FieldVector(cent = cent_state_fields, face = face_state_fields)
     tendencies = CC.Fields.FieldVector(cent = cent_state_fields, face = face_state_fields)
     aux = CC.Fields.FieldVector(cent = aux_cent_fields, face = aux_face_fields)
+    io_nt = (;
+        ref_state = TC.io_dictionary_ref_state(aux),
+        aux = TC.io_dictionary_aux(aux),
+        state = TC.io_dictionary_state(state),
+        tendencies = TC.io_dictionary_tendencies(tendencies),
+    )
 
-    return Simulation1d(grid, state, tendencies, aux, ref_state, GMV, Case, Turb, TS, Stats)
+    return Simulation1d(io_nt, grid, state, tendencies, aux, ref_state, GMV, Case, Turb, TS, Stats)
 end
 
 function TurbulenceConvection.initialize(self::Simulation1d, namelist)
     TC = TurbulenceConvection
-    Cases.initialize_profiles(self.Case, self.grid, self.GMV, self.ref_state)
+    Cases.initialize_profiles(self.Case, self.grid, self.GMV, TC.center_ref_state(self.aux))
     TC.satadjust(self.GMV)
 
     Cases.initialize_surface(self.Case, self.grid, self.ref_state)
@@ -107,9 +116,9 @@ function TurbulenceConvection.initialize(self::Simulation1d, namelist)
     Cases.initialize_radiation(self.Case, self.grid, self.ref_state, self.GMV)
 
     TC.initialize(self.Turb, self.Case, self.GMV, self.ref_state, self.TS)
+
     TC.initialize_io(self)
     TC.io(self)
-
     return
 end
 
@@ -131,6 +140,11 @@ function run(self::Simulation1d)
             # opening/closing files every step should be okay. #removeVarsHack
             # TurbulenceConvection.io(self) # #removeVarsHack
             TC.write_simulation_time(self.Stats, self.TS.t) # #removeVarsHack
+
+            TC.io(self.io_nt.aux, self.Stats)
+            TC.io(self.io_nt.state, self.Stats)
+            TC.io(self.io_nt.tendencies, self.Stats)
+
             TC.io(self.GMV, self.Stats) # #removeVarsHack
             TC.io(self.Case, self.Stats) # #removeVarsHack
             TC.io(self.Turb, self.Stats, self.TS) # #removeVarsHack
@@ -143,6 +157,14 @@ end
 
 function TurbulenceConvection.initialize_io(self::Simulation1d)
     TC = TurbulenceConvection
+    TC.initialize_io(self.io_nt.ref_state, self.Stats)
+    TC.io(self.io_nt.ref_state, self.Stats) # since the reference state is static
+
+    TC.initialize_io(self.io_nt.aux, self.Stats)
+    TC.initialize_io(self.io_nt.state, self.Stats)
+    TC.initialize_io(self.io_nt.tendencies, self.Stats)
+
+    # TODO: depricate
     TC.initialize_io(self.GMV, self.Stats)
     TC.initialize_io(self.Case, self.Stats)
     TC.initialize_io(self.Turb, self.Stats)
@@ -153,6 +175,12 @@ function TurbulenceConvection.io(self::Simulation1d)
     TC = TurbulenceConvection
     TC.open_files(self.Stats)
     TC.write_simulation_time(self.Stats, self.TS.t)
+
+    TC.io(self.io_nt.aux, self.Stats)
+    TC.io(self.io_nt.state, self.Stats)
+    TC.io(self.io_nt.tendencies, self.Stats)
+
+    # TODO: depricate
     TC.io(self.GMV, self.Stats)
     TC.io(self.Case, self.Stats)
     TC.io(self.Turb, self.Stats, self.TS)

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -46,5 +46,7 @@ Base.@propagate_inbounds function Base.setindex!(field::CC.Fields.FiniteDifferen
     Base.setindex!(CC.Fields.field_values(field), v, i)
 end
 
-center_fields(state) = state.cent
-face_fields(state) = state.cent
+function FieldFromNamedTuple(space, nt::NamedTuple)
+    cmv(z) = nt
+    return cmv.(CC.Fields.coordinate_field(space))
+end

--- a/src/ReferenceState.jl
+++ b/src/ReferenceState.jl
@@ -84,21 +84,6 @@ function ReferenceState(grid::Grid, param_set::PS, Stats::NetCDFIO_Stats; Pg::FT
     rho0 = 1 ./ alpha0
     rho0_half = 1 ./ alpha0_half
 
-    add_reference_profile(Stats, "alpha0")
-    write_reference_profile(Stats, "alpha0", alpha0)
-    add_reference_profile(Stats, "alpha0_half")
-    write_reference_profile(Stats, "alpha0_half", alpha0_half)
-
-    add_reference_profile(Stats, "p0")
-    write_reference_profile(Stats, "p0", p0)
-    add_reference_profile(Stats, "p0_half")
-    write_reference_profile(Stats, "p0_half", p0_half)
-
-    add_reference_profile(Stats, "rho0")
-    write_reference_profile(Stats, "rho0", rho0)
-    add_reference_profile(Stats, "rho0_half")
-    write_reference_profile(Stats, "rho0_half", rho0_half)
-
     args = (param_set, p0, p0_half, alpha0, alpha0_half, rho0, rho0_half, Pg, Tg, qtg)
     return ReferenceState{PS, typeof(p0)}(args...)
 end

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -79,8 +79,10 @@ import .TCThermodynamics
 const TCTD = TCThermodynamics
 
 include("Grid.jl")
-include("Fields.jl")
+include("dycore_api.jl")
 include("NetCDFIO.jl")
+include("diagnostics.jl")
+include("Fields.jl")
 include("ReferenceState.jl")
 include("types.jl")
 include("name_aliases.jl")

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,0 +1,45 @@
+#####
+##### Diagnostics
+#####
+
+#=
+    io_dictionary_ref_state()
+    io_dictionary_aux()
+    io_dictionary_state()
+    io_dictionary_tendencies()
+
+All of these functions return a dictionary whose
+ - `keys` are the nc variable names
+ - `values` are NamedTuples corresponding
+    - `dims` (`("z")`  or `("z", "t")`) and
+    - `group` (`"reference"` or `"profiles"`)
+=#
+
+function io_dictionary_ref_state(aux)
+    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String}, String, Any}}
+    cent_ref_state = center_ref_state # so that things nicely align :)
+    io_dict = Dict{String, DT}(
+        "ρ0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(aux).ρ0),
+        "ρ0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(aux).ρ0),
+        "p0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(aux).p0),
+        "p0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(aux).p0),
+        "α0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(aux).α0),
+        "α0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(aux).α0),
+    )
+    return io_dict
+end
+io_dictionary_aux(aux) = Dict()
+io_dictionary_state(state) = Dict()
+io_dictionary_tendencies(tendencies) = Dict()
+
+function initialize_io(io_dict::Dict, Stats::NetCDFIO_Stats)
+    for var_name in keys(io_dict)
+        add_field(Stats, var_name; dims = io_dict[var_name].dims, group = io_dict[var_name].group)
+    end
+end
+
+function io(io_dict::Dict, Stats::NetCDFIO_Stats)
+    for var in keys(io_dict)
+        write_field(Stats, var, io_dict[var].field; group = io_dict[var].group)
+    end
+end

--- a/src/dycore_api.jl
+++ b/src/dycore_api.jl
@@ -1,0 +1,21 @@
+#####
+##### Dycore API
+#####
+
+#=
+This file provides a list of methods that TurbulenceConvection.jl
+expects that the host dycore supports. This is experimental, as
+we're not sure how the data structures / flow control will shake out.
+=#
+
+""" The cell center fields of any state vector """
+center_fields(state) = state.cent
+
+""" The cell face fields of any state vector """
+face_fields(state) = state.face
+
+""" The cell center reference state fields """
+center_ref_state(aux) = center_fields(aux).ref_state
+
+""" The cell face reference state fields """
+face_ref_state(aux) = face_fields(aux).ref_state

--- a/src/name_aliases.jl
+++ b/src/name_aliases.jl
@@ -11,6 +11,8 @@ function name_aliases()
         "zf" => ("z",),
         "α0_c" => ("alpha0_half",),
         "α0_f" => ("alpha0",),
+        "p0_c" => ("p0_half",),
+        "p0_f" => ("p0",),
         "ρ0_c" => ("rho0_half",),
         "ρ0_f" => ("rho0",),
         "updraft_area" => ("updraft_fraction",),


### PR DESCRIPTION
This PR
 - Adds io for fields
 - Debugs compute mse for plotting steady state data
 - Makes `initialize_profiles` accept the cell center reference state

Note that, with these changes, we're no longer relying on

```julia
    add_reference_profile(Stats, "alpha0")
    write_reference_profile(Stats, "alpha0", alpha0)
    add_reference_profile(Stats, "alpha0_half")
    write_reference_profile(Stats, "alpha0_half", alpha0_half)

    add_reference_profile(Stats, "p0")
    write_reference_profile(Stats, "p0", p0)
    add_reference_profile(Stats, "p0_half")
    write_reference_profile(Stats, "p0_half", p0_half)

    add_reference_profile(Stats, "rho0")
    write_reference_profile(Stats, "rho0", rho0)
    add_reference_profile(Stats, "rho0_half")
    write_reference_profile(Stats, "rho0_half", rho0_half)
```
For exporting reference state profiles to the NC file. It's now managed in the newly added `diagnostics.jl` file.