### PR TITLE
Add update_aux to prep fusing more ops

### DIFF
--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -86,39 +86,9 @@ function update_cloud_dry(self::EnvironmentThermodynamics, k, EnvVar::Environmen
     return
 end
 
-function saturation_adjustment(self::EnvironmentThermodynamics, EnvVar::EnvironmentVariables)
-    param_set = parameter_set(EnvVar)
-    mph = mph_struct()
-
-    @inbounds for k in real_center_indices(self.grid)
-        ts = TD.PhaseEquil_pθq(param_set, self.ref_state.p0_half[k], EnvVar.H.values[k], EnvVar.QT.values[k])
-
-        EnvVar.T.values[k] = TD.air_temperature(ts)
-        EnvVar.QL.values[k] = TD.liquid_specific_humidity(ts)
-        rho = TD.air_density(ts)
-        EnvVar.B.values[k] = buoyancy_c(param_set, self.ref_state.rho0_half[k], rho)
-
-        update_cloud_dry(
-            self,
-            k,
-            EnvVar,
-            EnvVar.T.values[k],
-            EnvVar.H.values[k],
-            EnvVar.QT.values[k],
-            EnvVar.QL.values[k],
-            EnvVar.QT.values[k] - EnvVar.QL.values[k],
-        )
-        ts = TD.PhaseEquil_pθq(param_set, self.ref_state.p0_half[k], EnvVar.H.values[k], EnvVar.QT.values[k])
-        EnvVar.RH.values[k] = TD.relative_humidity(ts)
-    end
-    return
-end
-
-
 function sgs_mean(self::EnvironmentThermodynamics, EnvVar::EnvironmentVariables, Rain::RainVariables, dt)
 
     param_set = parameter_set(EnvVar)
-    mph = mph_struct()
 
     @inbounds for k in real_center_indices(self.grid)
         # condensation

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -11,9 +11,9 @@ function initialize(
     else
         initialize(self, self.UpdVar, GMV)
     end
-    decompose_environment(self, GMV)
-    saturation_adjustment(self.EnvThermo, self.EnvVar)
-    buoyancy(self.UpdThermo, self.UpdVar, self.EnvVar, GMV, self.extrapolate_buoyancy)
+    param_set = parameter_set(self)
+    grid = get_grid(self)
+    update_aux!(self, GMV, grid, Case, ref_state, param_set, TS)
     update_inversion(self, GMV, Case.inversion_option)
     self.wstar = get_wstar(Case.Sur.bflux, self.zi)
     microphysics(self.EnvThermo, self.EnvVar, self.Rain, TS.dt)
@@ -414,6 +414,138 @@ function compute_diffusive_fluxes(self::EDMF_PrognosticTKE, GMV::GridMeanVariabl
     return
 end
 
+function update_aux!(tptke, gm, grid, Case, ref_state, param_set, TS)
+    #####
+    ##### decompose_environment
+    #####
+    # Find values of environmental variables by subtracting updraft values from grid mean values
+    # whichvals used to check which substep we are on--correspondingly use "GMV.SomeVar.value" (last timestep value)
+    # first make sure the "bulkvalues" of the updraft variables are updated
+    kc_surf = kc_surface(grid)
+    up = tptke.UpdVar
+    en = tptke.EnvVar
+    EnvThermo = tptke.EnvThermo
+
+    up.Area.bulkvalues .= up_sum(up.Area.values)
+
+    @inbounds for k in real_face_indices(grid)
+        up.W.bulkvalues[k] = 0
+        a_bulk_bcs = (; bottom = SetValue(sum(tptke.area_surface_bc)), top = SetZeroGradient())
+        a_bulk_f = interpc2f(up.Area.bulkvalues, grid, k; a_bulk_bcs...)
+        if a_bulk_f > 1.0e-20
+            @inbounds for i in xrange(up.n_updrafts)
+                a_up_bcs = (; bottom = SetValue(tptke.area_surface_bc[i]), top = SetZeroGradient())
+                a_up_f = interpc2f(up.Area.values, grid, k, i; a_up_bcs...)
+                up.W.bulkvalues[k] += a_up_f * up.W.values[i, k] / a_bulk_f
+            end
+        end
+        # Assuming gm.W = 0!
+        en.W.values[k] = -a_bulk_f / (1 - a_bulk_f) * up.W.bulkvalues[k]
+    end
+
+    @inbounds for k in real_center_indices(grid)
+        ρ0_c = ref_state.rho0_half[k]
+        p0_c = ref_state.p0_half[k]
+        a_bulk_c = up.Area.bulkvalues[k]
+        up.QT.bulkvalues[k] = 0
+        up.QL.bulkvalues[k] = 0
+        up.H.bulkvalues[k] = 0
+        up.T.bulkvalues[k] = 0
+        up.B.bulkvalues[k] = 0
+        up.RH.bulkvalues[k] = 0
+        if a_bulk_c > 1.0e-20
+            @inbounds for i in xrange(up.n_updrafts)
+                up.QT.bulkvalues[k] += up.Area.values[i, k] * up.QT.values[i, k] / a_bulk_c
+                up.QL.bulkvalues[k] += up.Area.values[i, k] * up.QL.values[i, k] / a_bulk_c
+                up.H.bulkvalues[k] += up.Area.values[i, k] * up.H.values[i, k] / a_bulk_c
+                up.T.bulkvalues[k] += up.Area.values[i, k] * up.T.values[i, k] / a_bulk_c
+                up.RH.bulkvalues[k] += up.Area.values[i, k] * up.RH.values[i, k] / a_bulk_c
+                up.B.bulkvalues[k] += up.Area.values[i, k] * up.B.values[i, k] / a_bulk_c
+            end
+        else
+            up.QT.bulkvalues[k] = gm.QT.values[k]
+            up.H.bulkvalues[k] = gm.H.values[k]
+            up.RH.bulkvalues[k] = gm.RH.values[k]
+            up.T.bulkvalues[k] = gm.T.values[k]
+        end
+        if up.QL.bulkvalues[k] > 1e-8 && a_bulk_c > 1e-3
+            up.cloud_fraction[k] = 1.0
+        else
+            up.cloud_fraction[k] = 0.0
+        end
+
+        val1 = 1 / (1 - a_bulk_c)
+        val2 = a_bulk_c * val1
+
+        en.Area.values[k] = 1 - a_bulk_c
+        en.QT.values[k] = max(val1 * gm.QT.values[k] - val2 * up.QT.bulkvalues[k], 0) #Yair - this is here to prevent negative QT
+        en.H.values[k] = val1 * gm.H.values[k] - val2 * up.H.bulkvalues[k]
+
+        #####
+        ##### saturation_adjustment
+        #####
+
+        ts_en = TD.PhaseEquil_pθq(param_set, p0_c, en.H.values[k], en.QT.values[k])
+
+        en.T.values[k] = TD.air_temperature(ts_en)
+        en.QL.values[k] = TD.liquid_specific_humidity(ts_en)
+        rho = TD.air_density(ts_en)
+        en.B.values[k] = buoyancy_c(param_set, ρ0_c, rho)
+
+        # TODO: can we pass `ts_en` here instead?
+        update_cloud_dry(
+            EnvThermo,
+            k,
+            en,
+            en.T.values[k],
+            en.H.values[k],
+            en.QT.values[k],
+            en.QL.values[k],
+            en.QT.values[k] - en.QL.values[k],
+        )
+        en.RH.values[k] = TD.relative_humidity(ts_en)
+
+        #####
+        ##### buoyancy
+        #####
+
+        @inbounds for i in xrange(up.n_updrafts)
+            if up.Area.values[i, k] > 0.0
+                ts_up = TD.PhaseEquil_pθq(param_set, p0_c, up.H.values[i, k], up.QT.values[i, k])
+                up.QL.values[i, k] = TD.liquid_specific_humidity(ts_up)
+                up.T.values[i, k] = TD.air_temperature(ts_up)
+                rho = TD.air_density(ts_up)
+                up.B.values[i, k] = buoyancy_c(param_set, ρ0_c, rho)
+                up.RH.values[i, k] = TD.relative_humidity(ts_up)
+            elseif k > kc_surf
+                if up.Area.values[i, k - 1] > 0.0 && tptke.extrapolate_buoyancy
+                    qt = up.QT.values[i, k - 1]
+                    h = up.H.values[i, k - 1]
+                    ts_up = TD.PhaseEquil_pθq(param_set, p0_c, h, qt)
+                    rho = TD.air_density(ts_up)
+                    up.B.values[i, k] = buoyancy_c(param_set, ρ0_c, rho)
+                    up.RH.values[i, k] = TD.relative_humidity(ts_up)
+                else
+                    up.B.values[i, k] = en.B.values[k]
+                    up.RH.values[i, k] = en.RH.values[k]
+                end
+            else
+                up.B.values[i, k] = en.B.values[k]
+                up.RH.values[i, k] = en.RH.values[k]
+            end
+        end
+
+        gm.B.values[k] = (1.0 - up.Area.bulkvalues[k]) * en.B.values[k]
+        @inbounds for i in xrange(up.n_updrafts)
+            gm.B.values[k] += up.Area.values[i, k] * up.B.values[i, k]
+        end
+        @inbounds for i in xrange(up.n_updrafts)
+            up.B.values[i, k] -= gm.B.values[k]
+        end
+        en.B.values[k] -= gm.B.values[k]
+    end
+end
+
 # Perform the update of the scheme
 function update(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, Case::CasesBase, TS::TimeStepping)
 
@@ -427,9 +559,7 @@ function update(self::EDMF_PrognosticTKE, GMV::GridMeanVariables, Case::CasesBas
     set_updraft_surface_bc(self, GMV, Case)
     diagnose_GMV_moments(self, GMV, Case, TS)
 
-    decompose_environment(self, GMV)
-    saturation_adjustment(self.EnvThermo, self.EnvVar)
-    buoyancy(self.UpdThermo, self.UpdVar, self.EnvVar, GMV, self.extrapolate_buoyancy)
+    update_aux!(self, GMV, grid, Case, ref_state, param_set, TS)
     update_surface(Case, GMV, TS)
     update_forcing(Case, GMV, TS)
     update_radiation(Case, GMV, TS)
@@ -733,35 +863,6 @@ function reset_surface_covariance(self::EDMF_PrognosticTKE, GMV::GridMeanVariabl
     en.Hvar.values[kc_surf] = get_surface_variance(flux1 * alpha0LL, flux1 * alpha0LL, ustar, zLL, oblength)
     en.QTvar.values[kc_surf] = get_surface_variance(flux2 * alpha0LL, flux2 * alpha0LL, ustar, zLL, oblength)
     en.HQTcov.values[kc_surf] = get_surface_variance(flux1 * alpha0LL, flux2 * alpha0LL, ustar, zLL, oblength)
-    return
-end
-
-# Find values of environmental variables by subtracting updraft values from grid mean values
-# whichvals used to check which substep we are on--correspondingly use "GMV.SomeVar.value" (last timestep value)
-function decompose_environment(self::EDMF_PrognosticTKE, GMV::GridMeanVariables)
-
-    # first make sure the "bulkvalues" of the updraft variables are updated
-    gm = GMV
-    up = self.UpdVar
-    en = self.EnvVar
-
-    set_means(self, up, gm)
-    grid = get_grid(self)
-    @inbounds for k in real_center_indices(grid)
-        a_bulk_c = up.Area.bulkvalues[k]
-        val1 = 1 / (1 - a_bulk_c)
-        val2 = a_bulk_c * val1
-
-        en.Area.values[k] = 1 - a_bulk_c
-        en.QT.values[k] = max(val1 * gm.QT.values[k] - val2 * up.QT.bulkvalues[k], 0) #Yair - this is here to prevent negative QT
-        en.H.values[k] = val1 * gm.H.values[k] - val2 * up.H.bulkvalues[k]
-    end
-    @inbounds for k in real_face_indices(grid)
-        # Assuming gm.W = 0!
-        a_bulk_bcs = (; bottom = SetValue(sum(self.area_surface_bc)), top = SetValue(0))
-        a_bulk_f = interpc2f(up.Area.bulkvalues, grid, k; a_bulk_bcs...)
-        en.W.values[k] = -a_bulk_f / (1 - a_bulk_f) * up.W.bulkvalues[k]
-    end
     return
 end
 


### PR DESCRIPTION
In efforts to reduce the many function calls and references to copies of data structures in different places (UpdraftVariables has it's own grid and reference state, same with EnvironmentVariables, ThermodynamicVariables etc.), this PR combines several references, and passes several unpacked data structures from a centralized place. This also reduces the number of aliases and packing/unpacking statements. We also remove some unnecessary function calls
 - `PhaseEquil_pθq` was called multiple times in the same loop
 - `set_means` was called immediately after `initialize`/ `initialize_DryBubble`, and then called again at the beginning of `update`

In addition, this PR refactors the buoyancy computations so that we maintain the `extrapolate_buoyancy` flag, but reduce the scope of the required changes. In addition, we were able to fuse several loops in those computations.

I wanted to extend the scope of `update_aux!`, but the next function call is different between `update` and `initialize`, so it's not guaranteed to be a refactoring change. I figure that we can follow up with expanding the scope next, since this PR is already pretty big.