### PR TITLE
Add diagnostics dict for io

### DIFF
--- a/src/Variables.jl
+++ b/src/Variables.jl
@@ -57,27 +57,9 @@ function io(self::GridMeanVariables, Stats::NetCDFIO_Stats)
     write_profile(Stats, "cloud_fraction_mean", self.cloud_fraction.values)
     write_ts(Stats, "cloud_cover_mean", self.cloud_cover)
 
-    mean_cloud_diagnostics(self)
     write_ts(Stats, "lwp_mean", self.lwp)
     write_ts(Stats, "cloud_base_mean", self.cloud_base)
     write_ts(Stats, "cloud_top_mean", self.cloud_top)
-    return
-end
-
-function mean_cloud_diagnostics(self)
-    self.lwp = 0.0
-    kc_toa = kc_top_of_atmos(self.grid)
-    self.cloud_base = self.grid.zc[kc_toa]
-    self.cloud_top = 0.0
-
-    @inbounds for k in real_center_indices(self.grid)
-        self.lwp += self.ref_state.rho0_half[k] * self.QL.values[k] * self.grid.Δz
-
-        if self.QL.values[k] > 1e-8
-            self.cloud_base = min(self.cloud_base, self.grid.zc[k])
-            self.cloud_top = max(self.cloud_top, self.grid.zc[k])
-        end
-    end
     return
 end
 
@@ -93,7 +75,6 @@ function satadjust(self::GridMeanVariables)
         self.T.values[k] = TD.air_temperature(ts)
         ρ = TD.air_density(ts)
         self.B.values[k] = buoyancy_c(param_set, ρ0, ρ)
-        ts = TD.PhaseEquil_pθq(param_set, p0, h, qt)
         self.RH.values[k] = TD.relative_humidity(ts)
     end
     return

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -5,6 +5,7 @@
 #=
     io_dictionary_ref_state()
     io_dictionary_aux()
+    io_dictionary_diagnostics()
     io_dictionary_state()
     io_dictionary_tendencies()
 
@@ -29,6 +30,7 @@ function io_dictionary_ref_state(aux)
     return io_dict
 end
 io_dictionary_aux(aux) = Dict()
+io_dictionary_diagnostics(diagnostics) = Dict()
 io_dictionary_state(state) = Dict()
 io_dictionary_tendencies(tendencies) = Dict()
 
@@ -42,4 +44,29 @@ function io(io_dict::Dict, Stats::NetCDFIO_Stats)
     for var in keys(io_dict)
         write_field(Stats, var, io_dict[var].field; group = io_dict[var].group)
     end
+end
+
+#=
+    compute_diagnostics!
+
+Computes diagnostic quantities. The state _should not_ depend
+on any quantities here. I.e., we should be able to shut down
+diagnostics and still run, at which point we'll be able to export
+the state, auxiliary fields (which the state does depend on), and
+tendencies.
+=#
+function compute_diagnostics!(edmf, gm, grid, Case, ref_state, TS)
+    gm.lwp = 0.0
+    kc_toa = kc_top_of_atmos(grid)
+    gm.cloud_base = grid.zc[kc_toa]
+    gm.cloud_top = 0.0
+
+    @inbounds for k in real_center_indices(grid)
+        gm.lwp += ref_state.rho0_half[k] * gm.QL.values[k] * grid.Δz
+        if gm.QL.values[k] > 1e-8
+            gm.cloud_base = min(gm.cloud_base, grid.zc[k])
+            gm.cloud_top = max(gm.cloud_top, grid.zc[k])
+        end
+    end
+    return
 end


### PR DESCRIPTION
I realized that, in addition to exporting auxiliary fields, we should have separate diagnostic fields that are computed only when needed. This PR adds a diagnostics dict so that we can separate these.

This PR also removes a duplicate call to `PhaseEquil_pθq`.