### PR TITLE
Rename some variable names

### DIFF
--- a/src/EDMF_Rain.jl
+++ b/src/EDMF_Rain.jl
@@ -1,5 +1,5 @@
 
-function initialize_io(self::RainVariables, Stats::NetCDFIO_Stats)
+function initialize_io(rain::RainVariables, Stats::NetCDFIO_Stats)
     add_profile(Stats, "qr_mean")
     add_ts(Stats, "rwp_mean")
     add_ts(Stats, "cutoff_rain_rate")
@@ -7,41 +7,41 @@ function initialize_io(self::RainVariables, Stats::NetCDFIO_Stats)
 end
 
 function io(
-    self::RainVariables,
+    rain::RainVariables,
     Stats::NetCDFIO_Stats,
     ref_state::ReferenceState,
-    UpdThermo::UpdraftThermodynamics,
-    EnvThermo::EnvironmentThermodynamics,
+    up_thermo::UpdraftThermodynamics,
+    en_thermo::EnvironmentThermodynamics,
     TS::TimeStepping,
 )
-    write_profile(Stats, "qr_mean", self.QR.values)
+    write_profile(Stats, "qr_mean", rain.QR.values)
 
-    rain_diagnostics(self, ref_state, UpdThermo, EnvThermo)
-    write_ts(Stats, "rwp_mean", self.mean_rwp)
+    rain_diagnostics(rain, ref_state, up_thermo, en_thermo)
+    write_ts(Stats, "rwp_mean", rain.mean_rwp)
 
     #TODO - change to rain rate that depends on rain model choice
-    write_ts(Stats, "cutoff_rain_rate", self.cutoff_rain_rate)
+    write_ts(Stats, "cutoff_rain_rate", rain.cutoff_rain_rate)
     return
 end
 
 function rain_diagnostics(
-    self::RainVariables,
+    rain::RainVariables,
     ref_state::ReferenceState,
-    UpdThermo::UpdraftThermodynamics,
-    EnvThermo::EnvironmentThermodynamics,
+    up_thermo::UpdraftThermodynamics,
+    en_thermo::EnvironmentThermodynamics,
 )
-    self.mean_rwp = 0.0
-    self.cutoff_rain_rate = 0.0
-    grid = self.grid
+    rain.mean_rwp = 0.0
+    rain.cutoff_rain_rate = 0.0
+    grid = rain.grid
 
     @inbounds for k in real_center_indices(grid)
-        self.mean_rwp += ref_state.rho0_half[k] * self.QR.values[k] * grid.Δz
+        rain.mean_rwp += ref_state.rho0_half[k] * rain.QR.values[k] * grid.Δz
 
         # rain rate from cutoff microphysics scheme defined as a total amount of removed water
         # per timestep per EDMF surface area [mm/h]
-        if (self.rain_model == "cutoff")
-            self.cutoff_rain_rate -=
-                (EnvThermo.prec_source_qt[k] + UpdThermo.prec_source_qt_tot[k]) * ref_state.rho0_half[k] * grid.Δz /
+        if (rain.rain_model == "cutoff")
+            rain.cutoff_rain_rate -=
+                (en_thermo.prec_source_qt[k] + up_thermo.prec_source_qt_tot[k]) * ref_state.rho0_half[k] * grid.Δz /
                 rho_cloud_liq *
                 3.6 *
                 1e6
@@ -51,33 +51,33 @@ function rain_diagnostics(
 end
 
 function sum_subdomains_rain(
-    self::RainVariables,
-    UpdThermo::UpdraftThermodynamics,
-    EnvThermo::EnvironmentThermodynamics,
+    rain::RainVariables,
+    up_thermo::UpdraftThermodynamics,
+    en_thermo::EnvironmentThermodynamics,
     TS::TimeStepping,
 )
-    @inbounds for k in real_center_indices(self.grid)
-        self.QR.values[k] -= (EnvThermo.prec_source_qt[k] + UpdThermo.prec_source_qt_tot[k]) * TS.dt
+    @inbounds for k in real_center_indices(rain.grid)
+        rain.QR.values[k] -= (en_thermo.prec_source_qt[k] + up_thermo.prec_source_qt_tot[k]) * TS.dt
     end
     return
 end
 
-function solve_rain_fall(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStepping, QR::RainVariable)
-    param_set = parameter_set(GMV)
-    grid = get_grid(GMV)
+function solve_rain_fall(rain::RainPhysics, gm::GridMeanVariables, TS::TimeStepping, QR::RainVariable)
+    param_set = parameter_set(gm)
+    grid = get_grid(gm)
     Δz = grid.Δz
     Δt = TS.dt
     CFL_limit = 0.5
 
     term_vel = center_field(grid)
     term_vel_new = center_field(grid)
-    ρ_0_c_field = self.ref_state.rho0_half
+    ρ_0_c_field = rain.ref_state.rho0_half
 
     # helper to calculate the rain velocity
-    # TODO: assuming GMV.W = 0
+    # TODO: assuming gm.W = 0
     # TODO: verify translation
     @inbounds for k in real_center_indices(grid)
-        term_vel[k] = CM1.terminal_velocity(param_set, rain_type, self.ref_state.rho0_half[k], QR.values[k])
+        term_vel[k] = CM1.terminal_velocity(param_set, rain_type, rain.ref_state.rho0_half[k], QR.values[k])
     end
 
     # rain falling through the domain
@@ -93,7 +93,7 @@ function solve_rain_fall(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStep
         if max(CFL_in, CFL_out) > CFL_limit
             error("Time step is too large for rain fall velocity!")
         end
-        ρ_0_c = self.ref_state.rho0_half[k]
+        ρ_0_c = rain.ref_state.rho0_half[k]
 
         ρ_0_cut = ccut_downwind(ρ_0_c_field, grid, k)
         QR_cut = ccut_downwind(QR.values, grid, k)
@@ -114,15 +114,15 @@ function solve_rain_fall(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStep
     return
 end
 
-function solve_rain_evap(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStepping, QR::RainVariable)
-    param_set = parameter_set(GMV)
+function solve_rain_evap(rain::RainPhysics, gm::GridMeanVariables, TS::TimeStepping, QR::RainVariable)
+    param_set = parameter_set(gm)
     Δt = TS.dt
     flag_evaporate_all = false
 
-    @inbounds for k in real_center_indices(self.grid)
+    @inbounds for k in real_center_indices(rain.grid)
         flag_evaporate_all = false
 
-        q = TD.PhasePartition(GMV.QT.values[k], GMV.QL.values[k], 0.0)
+        q = TD.PhasePartition(gm.QT.values[k], gm.QL.values[k], 0.0)
 
         tmp_evap_rate =
             -CM1.evaporation_sublimation(
@@ -130,8 +130,8 @@ function solve_rain_evap(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStep
                 rain_type,
                 q,
                 QR.values[k],
-                self.ref_state.rho0_half[k],
-                GMV.T.values[k],
+                rain.ref_state.rho0_half[k],
+                gm.T.values[k],
             )
 
         if tmp_evap_rate * Δt > QR.values[k]
@@ -139,15 +139,15 @@ function solve_rain_evap(self::RainPhysics, GMV::GridMeanVariables, TS::TimeStep
             tmp_evap_rate = QR.values[k] / Δt
         end
 
-        self.rain_evap_source_qt[k] = tmp_evap_rate
+        rain.rain_evap_source_qt[k] = tmp_evap_rate
 
         # TODO add ice
         rain_source_to_thetal(
             param_set,
-            self.ref_state.p0_half[k],
-            GMV.T.values[k],
-            GMV.QT.values[k],
-            GMV.QL.values[k],
+            rain.ref_state.p0_half[k],
+            gm.T.values[k],
+            gm.QT.values[k],
+            gm.QL.values[k],
             0.0,
             -tmp_evap_rate,
         )


### PR DESCRIPTION
I'm starting to wonder if #73 is the way to go. There's really so many names that need to be re-thought. In addition, it no longer really makes sense to use `self` as a name--since we're using multiple dispatch. This PR makes a few name changes, including

 - GMV -> gm
 - EnvVar -> en
 - EnvThermo -> en_thermo
 - UpdThermo -> up_thermo
 - UpdVar -> up
 - tptke -> edmf
 - self -> appropriate names listed above
 - Rain -> rain

This doesn't actually change any struct field names, which would be a bit more strict, but I'm wondering what people think about migrating names a bit more incrementally.

cc @trontrytel, @yairchn, @ilopezgp, @haakon-e, @costachris 