### PR TITLE
Remove GMV new

### DIFF
--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -505,10 +505,10 @@ function update(edmf::EDMF_PrognosticTKE, GMV::GridMeanVariables, Case::CasesBas
         implicit_eqs.b_q_tot_gm[k] = GMV.QT.values[k] + TS.dt * GMV.QT.tendencies[k]
         implicit_eqs.b_θ_liq_ice_gm[k] = GMV.H.values[k] + TS.dt * GMV.H.tendencies[k]
         if is_surface_center(grid, k)
-            implicit_eqs.b_u_gm[k] += TS.dt * Case.Sur.rho_uflux * Δzi * ref_state.alpha0_half[k] / edmf.ae[k]
-            implicit_eqs.b_v_gm[k] += TS.dt * Case.Sur.rho_vflux * Δzi * ref_state.alpha0_half[k] / edmf.ae[k]
-            implicit_eqs.b_q_tot_gm[k] += TS.dt * Case.Sur.rho_qtflux * Δzi * ref_state.alpha0_half[k] / edmf.ae[k]
-            implicit_eqs.b_θ_liq_ice_gm[k] += TS.dt * Case.Sur.rho_hflux * Δzi * ref_state.alpha0_half[k] / edmf.ae[k]
+            implicit_eqs.b_u_gm[k] += TS.dt * Case.Sur.rho_uflux * Δzi * ref_state.alpha0_half[k]
+            implicit_eqs.b_v_gm[k] += TS.dt * Case.Sur.rho_vflux * Δzi * ref_state.alpha0_half[k]
+            implicit_eqs.b_q_tot_gm[k] += TS.dt * Case.Sur.rho_qtflux * Δzi * ref_state.alpha0_half[k]
+            implicit_eqs.b_θ_liq_ice_gm[k] += TS.dt * Case.Sur.rho_hflux * Δzi * ref_state.alpha0_half[k]
         end
     end
 

--- a/src/Variables.jl
+++ b/src/Variables.jl
@@ -1,14 +1,3 @@
-function update(self::GridMeanVariables, TS::TimeStepping)
-    grid = self.grid
-    @inbounds for k in real_center_indices(grid)
-        self.U.values[k] += self.U.tendencies[k] * TS.dt
-        self.V.values[k] += self.V.tendencies[k] * TS.dt
-        self.H.values[k] += self.H.tendencies[k] * TS.dt
-        self.QT.values[k] += self.QT.tendencies[k] * TS.dt
-    end
-    return
-end
-
 function initialize_io(self::GridMeanVariables, Stats::NetCDFIO_Stats)
     add_profile(Stats, "u_mean")
     add_profile(Stats, "v_mean")

--- a/src/types.jl
+++ b/src/types.jl
@@ -227,7 +227,6 @@ end
 
 struct VariablePrognostic{T}
     values::T
-    new::T
     tendencies::T
     loc::String
     bc::String
@@ -238,12 +237,11 @@ struct VariablePrognostic{T}
         # Value at the current timestep
         values = field(grid, loc)
         # Value at the next timestep, used for calculating turbulence tendencies
-        new = field(grid, loc)
         tendencies = field(grid, loc)
         if kind != "scalar" && kind != "velocity"
             print("Invalid kind setting for variable! Must be scalar or velocity")
         end
-        return new{typeof(values)}(values, new, tendencies, loc, bc, kind, name, units)
+        return new{typeof(values)}(values, tendencies, loc, bc, kind, name, units)
     end
 end
 


### PR DESCRIPTION
This PR moves the explicit part of the grid mean equations to the explicit part of the implicit solve--allowing us to remove the grid mean `new` property. This PR also inlines some functions to prepare for more loop fusing.