### PR TITLE
Make bors not depend on GHA CI, dont cache GHA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      # - uses: actions/cache@v1
+      #   env:
+      #     cache-name: cache-artifacts
+      #   with:
+      #     path: ~/.julia/artifacts
+      #     key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-test-${{ env.cache-name }}-
+      #       ${{ runner.os }}-test-
+      #       ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,4 @@
 status = [
-  "ci 1.6.0 - ubuntu-latest",
-  "ci 1.6.0 - macOS-latest",
   "buildkite/turbulenceconvection-ci",
   "docbuild",
   "format",


### PR DESCRIPTION
GHA CI is having some issues, I think this is related to caching precompiled code. To simplify things, let's still run the GHA CI, not cache things (which means that it'll take ~30 min), but also not make merging depend on its success. This way we can still track if/when it fails.