### PR TITLE
Invert updraft hierarchy to prog.up[i][k]

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -64,19 +64,23 @@ face_diagnostic_vars(FT, n_up) = (; face_diagnostic_vars_gm(FT)..., face_diagnos
 ##### Prognostic fields
 #####
 
+up_var(FT, n_up) = (; up = ntuple(i -> FT(0), n_up))
+
 # Center only
 cent_prognostic_vars(FT, n_up) = (; cent_prognostic_vars_gm(FT)..., cent_prognostic_vars_edmf(FT, n_up)...)
 cent_prognostic_vars_gm(FT) = (; U = FT(0), V = FT(0), H = FT(0), QT = FT(0))
-cent_prognostic_vars_up(FT) = (; area = FT(0), H = FT(0), QT = FT(0))
-cent_prognostic_vars_en(FT) = (; TKE = FT(0), Hvar = FT(0), QTvar = FT(0), HQTcov = FT(0))
-cent_prognostic_vars_edmf(FT, n_up) =
-    (; turbconv = (; en = cent_prognostic_vars_en(FT), up = ntuple(i -> cent_prognostic_vars_up(FT), n_up)))
+cent_prognostic_vars_edmf(FT, n_up) = (;
+    turbconv = (;
+        area = up_var(FT, n_up), θ_liq_ice = up_var(FT, n_up), q_tot = up_var(FT, n_up), tke = (; en = FT(0)),
+    ),
+)
 # cent_prognostic_vars_edmf(FT, n_up) = (;) # could also use this for empty model
 
 # Face only
 face_prognostic_vars(FT, n_up) = (; face_prognostic_vars_edmf(FT, n_up)...)
 face_prognostic_vars_up(FT) = (; W = FT(0))
-face_prognostic_vars_edmf(FT, n_up) = (; turbconv = (; up = ntuple(i -> face_prognostic_vars_up(FT), n_up)))
+face_prognostic_vars_edmf(FT, n_up) = (; turbconv = (; w = up_var(FT, n_up)))
+
 # face_prognostic_vars_edmf(FT, n_up) = (;) # could also use this for empty model
 
 function Simulation1d(namelist)

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -1,7 +1,7 @@
 function initialize(edmf, grid, state, up::UpdraftVariables, gm::GridMeanVariables)
     kc_surf = kc_surface(grid)
 
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     up.W.values .= 0
     up.B.values .= 0
     @inbounds for i in 1:(up.n_updrafts)
@@ -9,9 +9,9 @@ function initialize(edmf, grid, state, up::UpdraftVariables, gm::GridMeanVariabl
             # Simple treatment for now, revise when multiple updraft closures
             # become more well defined
             if up.prognostic
-                prog_up[i].area[k] = 0.0 #up.updraft_fraction/up.n_updrafts
+                prog_tc.area.up[i][k] = 0.0 #up.updraft_fraction/up.n_updrafts
             else
-                prog_up[i].area[k] = up.updraft_fraction / up.n_updrafts
+                prog_tc.area.up[i][k] = up.updraft_fraction / up.n_updrafts
             end
             up.QT.values[i, k] = gm.QT.values[k]
             up.QL.values[i, k] = gm.QL.values[k]
@@ -19,7 +19,7 @@ function initialize(edmf, grid, state, up::UpdraftVariables, gm::GridMeanVariabl
             up.T.values[i, k] = gm.T.values[k]
         end
 
-        prog_up[i].area[kc_surf] = up.updraft_fraction / up.n_updrafts
+        prog_tc.area.up[i][kc_surf] = up.updraft_fraction / up.n_updrafts
     end
     return
 end
@@ -94,7 +94,7 @@ function initialize_DryBubble(edmf, grid, state, up::UpdraftVariables, gm::GridM
         264.1574, 263.6518, 263.1461, 262.6451, 262.1476, 261.6524]
     #! format: on
 
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     Area_in = pyinterp(grid.zc, z_in, Area_in)
     θ_liq_in = pyinterp(grid.zc, z_in, θ_liq_in)
     T_in = pyinterp(grid.zc, z_in, T_in)
@@ -107,7 +107,7 @@ function initialize_DryBubble(edmf, grid, state, up::UpdraftVariables, gm::GridM
 
         @inbounds for k in real_center_indices(grid)
             if minimum(z_in) <= grid.zc[k] <= maximum(z_in)
-                prog_up[i].area[k] = Area_in[k] #up.updraft_fraction/up.n_updrafts
+                prog_tc.area.up[i][k] = Area_in[k] #up.updraft_fraction/up.n_updrafts
                 up.H.values[i, k] = θ_liq_in[k]
                 up.QT.values[i, k] = 0.0
                 up.QL.values[i, k] = 0.0
@@ -115,7 +115,7 @@ function initialize_DryBubble(edmf, grid, state, up::UpdraftVariables, gm::GridM
                 # for now temperature is provided as diagnostics from LES
                 up.T.values[i, k] = T_in[k]
             else
-                prog_up[i].area[k] = 0.0 #up.updraft_fraction/up.n_updrafts
+                prog_tc.area.up[i][k] = 0.0 #up.updraft_fraction/up.n_updrafts
                 up.H.values[i, k] = gm.H.values[k]
                 up.T.values[i, k] = gm.T.values[k]
             end
@@ -143,14 +143,14 @@ end
 
 # quick utility to set "new" arrays with values in the "values" arrays
 function set_new_with_values(up::UpdraftVariables, grid, state)
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     @inbounds for i in 1:(up.n_updrafts)
         @inbounds for k in real_face_indices(grid)
             up.W.new[i, k] = up.W.values[i, k]
         end
 
         @inbounds for k in real_center_indices(grid)
-            up.Area.new[i, k] = prog_up[i].area[k]
+            up.Area.new[i, k] = prog_tc.area.up[i][k]
             up.QT.new[i, k] = up.QT.values[i, k]
             up.H.new[i, k] = up.H.values[i, k]
         end
@@ -160,7 +160,7 @@ end
 
 # quick utility to set "tmp" arrays with values in the "new" arrays
 function set_values_with_new(up::UpdraftVariables, grid, state)
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     @inbounds for i in 1:(up.n_updrafts)
         @inbounds for k in real_face_indices(grid)
             up.W.values[i, k] = up.W.new[i, k]
@@ -168,7 +168,7 @@ function set_values_with_new(up::UpdraftVariables, grid, state)
 
         @inbounds for k in real_center_indices(grid)
             up.W.values[i, k] = up.W.new[i, k]
-            prog_up[i].area[k] = up.Area.new[i, k]
+            prog_tc.area.up[i][k] = up.Area.new[i, k]
             up.QT.values[i, k] = up.QT.new[i, k]
             up.H.values[i, k] = up.H.new[i, k]
         end
@@ -201,7 +201,7 @@ end
 function upd_cloud_diagnostics(up::UpdraftVariables, grid, state)
     up.lwp = 0.0
 
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     ρ0_c = center_ref_state(state).ρ0
     @inbounds for i in 1:(up.n_updrafts)
         up.cloud_base[i] = zc_toa(grid)
@@ -210,14 +210,14 @@ function upd_cloud_diagnostics(up::UpdraftVariables, grid, state)
         up.cloud_cover[i] = 0.0
 
         @inbounds for k in real_center_indices(grid)
-            if prog_up[i].area[k] > 1e-3
+            if prog_tc.area.up[i][k] > 1e-3
                 up.updraft_top[i] = max(up.updraft_top[i], grid.zc[k])
-                up.lwp += ρ0_c[k] * up.QL.values[i, k] * prog_up[i].area[k] * grid.Δz
+                up.lwp += ρ0_c[k] * up.QL.values[i, k] * prog_tc.area.up[i][k] * grid.Δz
 
                 if up.QL.values[i, k] > 1e-8
                     up.cloud_base[i] = min(up.cloud_base[i], grid.zc[k])
                     up.cloud_top[i] = max(up.cloud_top[i], grid.zc[k])
-                    up.cloud_cover[i] = max(up.cloud_cover[i], prog_up[i].area[k])
+                    up.cloud_cover[i] = max(up.cloud_cover[i], prog_tc.area.up[i][k])
                 end
             end
         end
@@ -239,7 +239,7 @@ function compute_rain_formation_tendencies(
 )
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
 
     @inbounds for i in 1:(up.n_updrafts)
         @inbounds for k in real_center_indices(grid)
@@ -252,13 +252,13 @@ function compute_rain_formation_tendencies(
                 param_set,
                 rain.rain_model,
                 rain.QR.values[k],
-                prog_up[i].area[k],
+                prog_tc.area.up[i][k],
                 ρ0_c[k],
                 dt,
                 ts_up,
             )
-            up_thermo.qt_tendency_rain_formation[i, k] = mph.qt_tendency * prog_up[i].area[k]
-            up_thermo.θ_liq_ice_tendency_rain_formation[i, k] = mph.θ_liq_ice_tendency * prog_up[i].area[k]
+            up_thermo.qt_tendency_rain_formation[i, k] = mph.qt_tendency * prog_tc.area.up[i][k]
+            up_thermo.θ_liq_ice_tendency_rain_formation[i, k] = mph.θ_liq_ice_tendency * prog_tc.area.up[i][k]
         end
     end
     # TODO - to be deleted once we sum all tendencies elsewhere

--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -613,7 +613,6 @@ function construct_tridiag_diffusion_en(
     TS,
     KM,
     KH,
-    prog_up,
     w_up,
     w_en,
     tke_en,
@@ -637,6 +636,7 @@ function construct_tridiag_diffusion_en(
     ρ0_c = center_ref_state(state).ρ0
     ρ0_f = face_ref_state(state).ρ0
     aux_tc = center_aux_tc(state)
+    prog_tc = center_prog_tc(state)
 
     ae = vec(1 .- aux_tc.bulk.area)
     rho_ae_K_m = face_field(grid)
@@ -658,11 +658,11 @@ function construct_tridiag_diffusion_en(
         D_env = 0.0
 
         @inbounds for i in 1:n_updrafts
-            if prog_up[i].area[k] > minimum_area
+            if prog_tc.area.up[i][k] > minimum_area
                 turb_entr = frac_turb_entr[i, k]
                 R_up = pressure_plume_spacing[i]
                 w_up_c = interpf2c(w_up, grid, k, i)
-                D_env += ρ0_c[k] * prog_up[i].area[k] * w_up_c * (entr_sc[i, k] + turb_entr)
+                D_env += ρ0_c[k] * prog_tc.area.up[i][k] * w_up_c * (entr_sc[i, k] + turb_entr)
             else
                 D_env = 0.0
             end

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -103,7 +103,7 @@ function io(edmf::EDMF_PrognosticTKE, grid, state, Stats::NetCDFIO_Stats, TS::Ti
     io(edmf.EnvVar, grid, state, Stats)
     io(edmf.Rain, grid, state, Stats, edmf.UpdThermo, edmf.EnvThermo, TS)
 
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     aux_tc = center_aux_tc(state)
     a_up_bulk = aux_tc.bulk.area
 
@@ -115,13 +115,13 @@ function io(edmf::EDMF_PrognosticTKE, grid, state, Stats::NetCDFIO_Stats, TS::Ti
         if a_up_bulk[k] > 0.0
             @inbounds for i in 1:(edmf.n_updrafts)
                 massflux[k] += interpf2c(edmf.m, grid, k, i)
-                mean_entr_sc[k] += prog_up[i].area[k] * edmf.entr_sc[i, k] / a_up_bulk[k]
-                mean_detr_sc[k] += prog_up[i].area[k] * edmf.detr_sc[i, k] / a_up_bulk[k]
-                mean_asp_ratio[k] += prog_up[i].area[k] * edmf.asp_ratio[i, k] / a_up_bulk[k]
-                mean_frac_turb_entr[k] += prog_up[i].area[k] * edmf.frac_turb_entr[i, k] / a_up_bulk[k]
-                mean_horiz_K_eddy[k] += prog_up[i].area[k] * edmf.horiz_K_eddy[i, k] / a_up_bulk[k]
-                mean_sorting_function[k] += prog_up[i].area[k] * edmf.sorting_function[i, k] / a_up_bulk[k]
-                mean_b_mix[k] += prog_up[i].area[k] * edmf.b_mix[i, k] / a_up_bulk[k]
+                mean_entr_sc[k] += prog_tc.area.up[i][k] * edmf.entr_sc[i, k] / a_up_bulk[k]
+                mean_detr_sc[k] += prog_tc.area.up[i][k] * edmf.detr_sc[i, k] / a_up_bulk[k]
+                mean_asp_ratio[k] += prog_tc.area.up[i][k] * edmf.asp_ratio[i, k] / a_up_bulk[k]
+                mean_frac_turb_entr[k] += prog_tc.area.up[i][k] * edmf.frac_turb_entr[i, k] / a_up_bulk[k]
+                mean_horiz_K_eddy[k] += prog_tc.area.up[i][k] * edmf.horiz_K_eddy[i, k] / a_up_bulk[k]
+                mean_sorting_function[k] += prog_tc.area.up[i][k] * edmf.sorting_function[i, k] / a_up_bulk[k]
+                mean_b_mix[k] += prog_tc.area.up[i][k] * edmf.b_mix[i, k] / a_up_bulk[k]
             end
         end
     end
@@ -132,7 +132,7 @@ function io(edmf::EDMF_PrognosticTKE, grid, state, Stats::NetCDFIO_Stats, TS::Ti
         if a_up_bulk_f > 0.0
             @inbounds for i in 1:(edmf.n_updrafts)
                 a_up_f = interpc2f(
-                    prog_up[i].area,
+                    prog_tc.area.up[i],
                     grid,
                     k;
                     bottom = SetValue(edmf.area_surface_bc[i]),
@@ -221,7 +221,7 @@ function update_radiation end
 
 function update_cloud_frac(edmf::EDMF_PrognosticTKE, grid, state, GMV::GridMeanVariables)
     # update grid-mean cloud fraction and cloud cover
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     aux_tc = center_aux_tc(state)
     a_up_bulk = aux_tc.bulk.area
     @inbounds for k in real_center_indices(grid) # update grid-mean cloud fraction and cloud cover
@@ -315,7 +315,7 @@ function compute_gm_tendencies!(edmf::EDMF_PrognosticTKE, grid, state, Case, gm,
             edmf.RainPhys.θ_liq_ice_tendency_rain_evap[k]
     end
 
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     edmf.massflux_h .= 0.0
     edmf.massflux_qt .= 0.0
     # Compute the mass flux and associated scalar fluxes
@@ -323,7 +323,7 @@ function compute_gm_tendencies!(edmf::EDMF_PrognosticTKE, grid, state, Case, gm,
         edmf.m[i, kf_surf] = 0.0
         a_up_bcs = (; bottom = SetValue(edmf.area_surface_bc[i]), top = SetZeroGradient())
         @inbounds for k in real_face_indices(grid)
-            a_up = interpc2f(prog_up[i].area, grid, k; a_up_bcs...)
+            a_up = interpc2f(prog_tc.area.up[i], grid, k; a_up_bcs...)
             a_en = interpc2f(ae, grid, k; a_up_bcs...)
             edmf.m[i, k] = ρ0_f[k] * a_up * a_en * (up.W.values[i, k] - en.W.values[k])
         end
@@ -469,7 +469,7 @@ function update(edmf::EDMF_PrognosticTKE, grid, state, GMV::GridMeanVariables, C
     # ----------- TODO: move to compute_tendencies
     implicit_eqs = edmf.implicit_eqs
     # Matrix is the same for all variables that use the same eddy diffusivity, we can construct once and reuse
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
 
     KM = diffusivity_m(edmf).values
     KH = diffusivity_h(edmf).values
@@ -480,7 +480,6 @@ function update(edmf::EDMF_PrognosticTKE, grid, state, GMV::GridMeanVariables, C
         TS,
         KM,
         KH,
-        prog_up,
         up.W.values,
         en.W.values,
         en.TKE.values,
@@ -614,7 +613,7 @@ function get_GMV_CoVar(
     ae = 1 .- aux_tc.bulk.area
     is_tke = covar_e.name == "tke"
     tke_factor = is_tke ? 0.5 : 1
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
 
     if is_tke
         @inbounds for k in real_center_indices(grid)
@@ -637,7 +636,7 @@ function get_GMV_CoVar(
                 Δψ_dual = ψ_up_dual .- ψ_gm_dual
                 Δϕ = interpf2c(Δϕ_dual, grid, k)
                 Δψ = interpf2c(Δψ_dual, grid, k)
-                gmv_covar[k] += tke_factor * prog_up[i].area[k] * Δϕ * Δψ
+                gmv_covar[k] += tke_factor * prog_tc.area.up[i][k] * Δϕ * Δψ
             end
         end
     else
@@ -650,7 +649,7 @@ function get_GMV_CoVar(
             @inbounds for i in 1:(edmf.n_updrafts)
                 Δϕ = ϕ_up.values[i, k] - ϕ_gm[k]
                 Δψ = ψ_up.values[i, k] - ψ_gm[k]
-                gmv_covar[k] += tke_factor * prog_up[i].area[k] * Δϕ * Δψ
+                gmv_covar[k] += tke_factor * prog_tc.area.up[i][k] * Δϕ * Δψ
             end
         end
     end
@@ -677,7 +676,7 @@ function compute_updraft_tendencies(edmf::EDMF_PrognosticTKE, grid, state, gm::G
     up = edmf.UpdVar
     up_thermo = edmf.UpdThermo
     en = edmf.EnvVar
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     w_up = up.W.values
     ρ_0_c = center_ref_state(state).ρ0
     ρ_0_f = face_ref_state(state).ρ0
@@ -698,9 +697,9 @@ function compute_updraft_tendencies(edmf::EDMF_PrognosticTKE, grid, state, gm::G
         @inbounds for i in 1:(up.n_updrafts)
             is_surface_center(grid, k) && continue
             w_up_c = interpf2c(w_up, grid, k, i)
-            adv = upwind_advection_area(ρ_0_c, prog_up[i].area, w_up[i, :], grid, k)
+            adv = upwind_advection_area(ρ_0_c, prog_tc.area.up[i], w_up[i, :], grid, k)
 
-            a_up_c = prog_up[i].area[k]
+            a_up_c = prog_tc.area.up[i][k]
             entr_term = a_up_c * w_up_c * (edmf.entr_sc[i, k])
             detr_term = a_up_c * w_up_c * (-edmf.detr_sc[i, k])
             up.Area.tendencies[i, k] = adv + entr_term + detr_term
@@ -720,15 +719,15 @@ function compute_updraft_tendencies(edmf::EDMF_PrognosticTKE, grid, state, gm::G
     @inbounds for k in real_center_indices(grid)
         @inbounds for i in 1:(up.n_updrafts)
             w_up_c = interpf2c(w_up, grid, k, i)
-            m_k = (ρ_0_c[k] * prog_up[i].area[k] * w_up_c)
+            m_k = (ρ_0_c[k] * prog_tc.area.up[i][k] * w_up_c)
 
-            adv = upwind_advection_scalar(ρ_0_c, prog_up[i].area, w_up[i, :], up.H.values[i, :], grid, k)
+            adv = upwind_advection_scalar(ρ_0_c, prog_tc.area.up[i], w_up[i, :], up.H.values[i, :], grid, k)
             entr = entr_w_c[i, k] * en.H.values[k]
             detr = detr_w_c[i, k] * up.H.values[i, k]
             rain = ρ_0_c[k] * up_thermo.θ_liq_ice_tendency_rain_formation[i, k]
             up.H.tendencies[i, k] = -adv + m_k * (entr - detr) + rain
 
-            adv = upwind_advection_scalar(ρ_0_c, prog_up[i].area, w_up[i, :], up.QT.values[i, :], grid, k)
+            adv = upwind_advection_scalar(ρ_0_c, prog_tc.area.up[i], w_up[i, :], up.QT.values[i, :], grid, k)
             entr = entr_w_c[i, k] * en.QT.values[k]
             detr = detr_w_c[i, k] * up.QT.values[i, k]
             rain = ρ_0_c[k] * up_thermo.qt_tendency_rain_formation[i, k]
@@ -741,14 +740,14 @@ function compute_updraft_tendencies(edmf::EDMF_PrognosticTKE, grid, state, gm::G
         is_surface_face(grid, k) && continue
         @inbounds for i in 1:(up.n_updrafts)
             a_up_bcs = (; bottom = SetValue(edmf.area_surface_bc[i]), top = SetZeroGradient())
-            a_k = interpc2f(prog_up[i].area, grid, k; a_up_bcs...)
+            a_k = interpc2f(prog_tc.area.up[i], grid, k; a_up_bcs...)
             # We know that, since W = 0 at z = 0, these BCs should
             # not matter in the end:
             entr_w = interpc2f(entr_w_c, grid, k, i; bottom = SetValue(0), top = SetValue(0))
             detr_w = interpc2f(detr_w_c, grid, k, i; bottom = SetValue(0), top = SetValue(0))
             B_k = interpc2f(up.B.values, grid, k, i; bottom = SetValue(0), top = SetValue(0))
 
-            adv = upwind_advection_velocity(ρ_0_f, prog_up[i].area, w_up[i, :], grid, k; a_up_bcs)
+            adv = upwind_advection_velocity(ρ_0_f, prog_tc.area.up[i], w_up[i, :], grid, k; a_up_bcs)
             exch = (ρ_0_f[k] * a_k * w_up[i, k] * (entr_w * en.W.values[k] - detr_w * w_up[i, k]))
             buoy = ρ_0_f[k] * a_k * B_k
             up.W.tendencies[i, k] = -adv + exch + buoy + edmf.nh_pressure[i, k]
@@ -768,7 +767,7 @@ function update_updraft(edmf::EDMF_PrognosticTKE, grid, state, gm::GridMeanVaria
     up = edmf.UpdVar
     up_thermo = edmf.UpdThermo
     en = edmf.EnvVar
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     a_up_new = up.Area.new
     w_up = up.W.values
     w_up_new = up.W.new
@@ -783,7 +782,7 @@ function update_updraft(edmf::EDMF_PrognosticTKE, grid, state, gm::GridMeanVaria
     @inbounds for k in real_center_indices(grid)
         @inbounds for i in 1:(up.n_updrafts)
             is_surface_center(grid, k) && continue
-            a_up_c = prog_up[i].area[k]
+            a_up_c = prog_tc.area.up[i][k]
             a_up_candidate = max(a_up_c + Δt * up.Area.tendencies[i, k], 0)
             a_up_new[i, k] = a_up_candidate
         end
@@ -795,7 +794,7 @@ function update_updraft(edmf::EDMF_PrognosticTKE, grid, state, gm::GridMeanVaria
             a_up_bcs = (; bottom = SetValue(edmf.area_surface_bc[i]), top = SetZeroGradient())
             anew_k = interpc2f(a_up_new, grid, k, i; a_up_bcs...)
             if anew_k >= edmf.minimum_area
-                a_k = interpc2f(prog_up[i].area, grid, k; a_up_bcs...)
+                a_k = interpc2f(prog_tc.area.up[i], grid, k; a_up_bcs...)
                 w_up_new[i, k] = (ρ_0_f[k] * a_k * w_up[i, k] + Δt * up.W.tendencies[i, k]) / (ρ_0_f[k] * anew_k)
 
                 w_up_new[i, k] = max(w_up_new[i, k], 0)
@@ -832,11 +831,11 @@ function update_updraft(edmf::EDMF_PrognosticTKE, grid, state, gm::GridMeanVaria
             # c1 * phi_new[k] = c2 * phi[k] + c3 * phi[k-1] + c4 * ϕ_enntr
             if a_up_new[i, k] >= edmf.minimum_area
                 up.H.new[i, k] =
-                    (ρ_0_c[k] * prog_up[i].area[k] * up.H.values[i, k] + Δt * up.H.tendencies[i, k]) /
+                    (ρ_0_c[k] * prog_tc.area.up[i][k] * up.H.values[i, k] + Δt * up.H.tendencies[i, k]) /
                     (ρ_0_c[k] * a_up_new[i, k])
 
                 up.QT.new[i, k] = max(
-                    (ρ_0_c[k] * prog_up[i].area[k] * up.QT.values[i, k] + Δt * up.QT.tendencies[i, k]) /
+                    (ρ_0_c[k] * prog_tc.area.up[i][k] * up.QT.values[i, k] + Δt * up.QT.tendencies[i, k]) /
                     (ρ_0_c[k] * a_up_new[i, k]),
                     0.0,
                 )
@@ -932,7 +931,7 @@ function compute_covariance_interdomain_src(
 
     is_tke = Covar.name == "tke"
     tke_factor = is_tke ? 0.5 : 1
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     if is_tke
         @inbounds for k in real_center_indices(grid)
             Covar.interdomain[k] = 0.0
@@ -940,7 +939,7 @@ function compute_covariance_interdomain_src(
                 Δϕ = interpf2c(ϕ_up.values, grid, k, i) - interpf2c(ϕ_en.values, grid, k)
                 Δψ = interpf2c(ψ_up.values, grid, k, i) - interpf2c(ψ_en.values, grid, k)
 
-                Covar.interdomain[k] += tke_factor * prog_up[i].area[k] * (1.0 - prog_up[i].area[k]) * Δϕ * Δψ
+                Covar.interdomain[k] += tke_factor * prog_tc.area.up[i][k] * (1.0 - prog_tc.area.up[i][k]) * Δϕ * Δψ
             end
         end
     else
@@ -949,7 +948,7 @@ function compute_covariance_interdomain_src(
             @inbounds for i in 1:(edmf.n_updrafts)
                 Δϕ = ϕ_up.values[i, k] - ϕ_en.values[k]
                 Δψ = ψ_up.values[i, k] - ψ_en.values[k]
-                Covar.interdomain[k] += tke_factor * prog_up[i].area[k] * (1.0 - prog_up[i].area[k]) * Δϕ * Δψ
+                Covar.interdomain[k] += tke_factor * prog_tc.area.up[i][k] * (1.0 - prog_tc.area.up[i][k]) * Δϕ * Δψ
             end
         end
     end
@@ -973,13 +972,13 @@ function compute_covariance_entr(
 
     is_tke = Covar.name == "tke"
     tke_factor = is_tke ? 0.5 : 1
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
 
     @inbounds for k in real_center_indices(grid)
         Covar.entr_gain[k] = 0.0
         Covar.detr_loss[k] = 0.0
         @inbounds for i in 1:(edmf.n_updrafts)
-            a_up = prog_up[i].area[k]
+            a_up = prog_tc.area.up[i][k]
             if a_up > edmf.minimum_area
                 R_up = edmf.pressure_plume_spacing[i]
                 updvar1 = is_tke ? interpf2c(UpdVar1.values, grid, k, i) : UpdVar1.values[i, k]
@@ -1020,12 +1019,12 @@ end
 function compute_covariance_detr(edmf::EDMF_PrognosticTKE, grid, state, Covar::EnvironmentVariable_2m)
     up = edmf.UpdVar
     ρ0_c = center_ref_state(state).ρ0
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     @inbounds for k in real_center_indices(grid)
         Covar.detr_loss[k] = 0.0
         @inbounds for i in 1:(up.n_updrafts)
             w_up_c = interpf2c(up.W.values, grid, k, i)
-            Covar.detr_loss[k] += prog_up[i].area[k] * abs(w_up_c) * edmf.entr_sc[i, k]
+            Covar.detr_loss[k] += prog_tc.area.up[i][k] * abs(w_up_c) * edmf.entr_sc[i, k]
         end
         Covar.detr_loss[k] *= ρ0_c[k] * Covar.values[k]
     end
@@ -1051,12 +1050,12 @@ function en_diffusion_tendencies(grid::Grid, state, TS, covar, n_updrafts)
     dti = TS.dti
     b = center_field(grid)
     ρ0_c = center_ref_state(state).ρ0
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
 
     ae = center_field(grid)
 
     @inbounds for k in real_center_indices(grid)
-        ae[k] = 1 .- sum(ntuple(i -> prog_up[i].area[k], n_updrafts))
+        ae[k] = 1 .- sum(ntuple(i -> prog_tc.area.up[i][k], n_updrafts))
     end
 
     kc_surf = kc_surface(grid)
@@ -1094,7 +1093,7 @@ function GMV_third_m(
     en = edmf.EnvVar
     aux_tc = center_aux_tc(state)
     ae = 1 .- aux_tc.bulk.area
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     is_tke = env_covar.name == "tke"
 
     @inbounds for k in real_center_indices(grid)
@@ -1102,7 +1101,7 @@ function GMV_third_m(
         GMVv_ = ae[k] * mean_en
         @inbounds for i in 1:(up.n_updrafts)
             mean_up = is_tke ? interpf2c(upd_mean.values, grid, k, i) : upd_mean.values[i, k]
-            GMVv_ += prog_up[i].area[k] * mean_up
+            GMVv_ += prog_tc.area.up[i][k] * mean_up
         end
 
         # TODO: report bug: i used outside of scope.
@@ -1122,8 +1121,8 @@ function GMV_third_m(
         GMVcov_ = ae[k] * (Envcov_ + (mean_en - GMVv_)^2)
         @inbounds for i in 1:(up.n_updrafts)
             mean_up = is_tke ? interpf2c(upd_mean.values, grid, k, i) : upd_mean.values[i, k]
-            GMVcov_ += prog_up[i].area[k] * (mean_up - GMVv_)^2
-            Upd_cubed += prog_up[i].area[k] * mean_up^3
+            GMVcov_ += prog_tc.area.up[i][k] * (mean_up - GMVv_)^2
+            Upd_cubed += prog_tc.area.up[i][k] * mean_up^3
         end
 
         if is_surface_center(grid, k)

--- a/src/dycore_api.jl
+++ b/src/dycore_api.jl
@@ -36,15 +36,10 @@ center_ref_state(state) = ref_state(state, CentField())
 
 #= Prognostic fields for TurbulenceConvection =#
 prognostic_tc(state, fl) = prognostic(state, fl).turbconv
-center_prog_updrafts(state) = prognostic_tc(state, CentField()).up
-face_prog_updrafts(state) = prognostic_tc(state, FaceField()).up
-center_prog_environment(state) = prognostic_tc(state, CentField()).en
-face_prog_environment(state) = prognostic_tc(state, FaceField()).en
+center_prog_tc(state) = prognostic_tc(state, CentField())
+face_prog_tc(state) = prognostic_tc(state, FaceField())
 
 #= Auxiliary fields for TurbulenceConvection =#
 aux_turbconv(state, fl) = aux(state, fl).turbconv
 center_aux_tc(state) = aux_turbconv(state, CentField())
-center_aux_updrafts(state) = aux_turbconv(state, CentField()).up
-face_aux_updrafts(state) = aux_turbconv(state, FaceField()).up
-center_aux_environment(state) = aux_turbconv(state, CentField()).en
-face_aux_environment(state) = aux_turbconv(state, FaceField()).en
+face_aux_tc(state) = aux_turbconv(state, FaceField())

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -18,11 +18,11 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     surface = Case.Sur
     obukhov_length = surface.obukhov_length
     FT = eltype(grid)
-    prog_up = center_prog_updrafts(state)
+    prog_tc = center_prog_tc(state)
     aux_tc = center_aux_tc(state)
 
     for k in real_center_indices(grid)
-        aux_tc.bulk.area[k] = sum(ntuple(i -> prog_up[i].area[k], up.n_updrafts))
+        aux_tc.bulk.area[k] = sum(ntuple(i -> prog_tc.area.up[i][k], up.n_updrafts))
     end
 
     #####
@@ -50,7 +50,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
         if a_bulk_f > 1.0e-20
             @inbounds for i in 1:(up.n_updrafts)
                 a_up_bcs = (; bottom = SetValue(edmf.area_surface_bc[i]), top = SetZeroGradient())
-                a_up_f = interpc2f(prog_up[i].area, grid, k; a_up_bcs...)
+                a_up_f = interpc2f(prog_tc.area.up[i], grid, k; a_up_bcs...)
                 up.W.bulkvalues[k] += a_up_f * up.W.values[i, k] / a_bulk_f
             end
         end
@@ -68,12 +68,12 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
         up.RH.bulkvalues[k] = 0
         if a_bulk_c > 1.0e-20
             @inbounds for i in 1:(up.n_updrafts)
-                up.QT.bulkvalues[k] += prog_up[i].area[k] * up.QT.values[i, k] / a_bulk_c
-                up.QL.bulkvalues[k] += prog_up[i].area[k] * up.QL.values[i, k] / a_bulk_c
-                up.H.bulkvalues[k] += prog_up[i].area[k] * up.H.values[i, k] / a_bulk_c
-                up.T.bulkvalues[k] += prog_up[i].area[k] * up.T.values[i, k] / a_bulk_c
-                up.RH.bulkvalues[k] += prog_up[i].area[k] * up.RH.values[i, k] / a_bulk_c
-                up.B.bulkvalues[k] += prog_up[i].area[k] * up.B.values[i, k] / a_bulk_c
+                up.QT.bulkvalues[k] += prog_tc.area.up[i][k] * up.QT.values[i, k] / a_bulk_c
+                up.QL.bulkvalues[k] += prog_tc.area.up[i][k] * up.QL.values[i, k] / a_bulk_c
+                up.H.bulkvalues[k] += prog_tc.area.up[i][k] * up.H.values[i, k] / a_bulk_c
+                up.T.bulkvalues[k] += prog_tc.area.up[i][k] * up.T.values[i, k] / a_bulk_c
+                up.RH.bulkvalues[k] += prog_tc.area.up[i][k] * up.RH.values[i, k] / a_bulk_c
+                up.B.bulkvalues[k] += prog_tc.area.up[i][k] * up.B.values[i, k] / a_bulk_c
             end
         else
             up.QT.bulkvalues[k] = gm.QT.values[k]
@@ -113,7 +113,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
         #####
 
         @inbounds for i in 1:(up.n_updrafts)
-            if prog_up[i].area[k] > 0.0
+            if prog_tc.area.up[i][k] > 0.0
                 ts_up = TD.PhaseEquil_pθq(param_set, p0_c[k], up.H.values[i, k], up.QT.values[i, k])
                 up.QL.values[i, k] = TD.liquid_specific_humidity(ts_up)
                 up.T.values[i, k] = TD.air_temperature(ts_up)
@@ -121,7 +121,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
                 up.B.values[i, k] = buoyancy_c(param_set, ρ0_c[k], ρ)
                 up.RH.values[i, k] = TD.relative_humidity(ts_up)
             elseif k > kc_surf
-                if prog_up[i].area[k - 1] > 0.0 && edmf.extrapolate_buoyancy
+                if prog_tc.area.up[i][k - 1] > 0.0 && edmf.extrapolate_buoyancy
                     qt = up.QT.values[i, k - 1]
                     h = up.H.values[i, k - 1]
                     ts_up = TD.PhaseEquil_pθq(param_set, p0_c[k], h, qt)
@@ -140,7 +140,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
 
         gm.B.values[k] = (1.0 - aux_tc.bulk.area[k]) * en.B.values[k]
         @inbounds for i in 1:(up.n_updrafts)
-            gm.B.values[k] += prog_up[i].area[k] * up.B.values[i, k]
+            gm.B.values[k] += prog_tc.area.up[i][k] * up.B.values[i, k]
         end
         @inbounds for i in 1:(up.n_updrafts)
             up.B.values[i, k] -= gm.B.values[k]
@@ -178,13 +178,13 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     @inbounds for k in real_center_indices(grid)
         @inbounds for i in 1:(up.n_updrafts)
             # entrainment
-            if prog_up[i].area[k] > 0.0
+            if prog_tc.area.up[i][k] > 0.0
                 # compute ∇m at cell centers
-                a_up_c = prog_up[i].area[k]
+                a_up_c = prog_tc.area.up[i][k]
                 w_up_c = interpf2c(up.W.values, grid, k, i)
                 w_gm_c = interpf2c(gm.W.values, grid, k)
                 m = a_up_c * (w_up_c - w_gm_c)
-                a_up_cut = ccut_upwind(prog_up[i].area, grid, k)
+                a_up_cut = ccut_upwind(prog_tc.area.up[i], grid, k)
                 w_up_cut = daul_f2c_upwind(up.W.values, grid, k, i)
                 w_gm_cut = daul_f2c_upwind(gm.W.values, grid, k)
                 m_cut = a_up_cut .* (w_up_cut .- w_gm_cut)
@@ -202,7 +202,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
                     tke = en.TKE.values[k],
                     dMdz = ∇m,
                     M = m,
-                    a_up = prog_up[i].area[k],
+                    a_up = prog_tc.area.up[i][k],
                     a_en = en.Area.values[k],
                     R_up = edmf.pressure_plume_spacing[i],
                     RH_up = up.RH.values[i, k],
@@ -235,7 +235,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
 
             # pressure
             a_bcs = (; bottom = SetValue(edmf.area_surface_bc[i]), top = SetValue(0))
-            a_kfull = interpc2f(prog_up[i].area, grid, k; a_bcs...)
+            a_kfull = interpc2f(prog_tc.area.up[i], grid, k; a_bcs...)
             if a_kfull > 0.0
                 B = up.B.values
                 b_bcs = (; bottom = SetValue(B[i, kc_surf]), top = SetValue(B[i, kc_toa]))
@@ -337,7 +337,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
             a_en = (1 - aux_tc.bulk.area[k]),
             wc_en = wc_en,
             wc_up = Tuple(wc_up),
-            a_up = ntuple(i -> prog_up[i].area[k], up.n_updrafts),
+            a_up = ntuple(i -> prog_tc.area.up[i][k], up.n_updrafts),
             ε_turb = ntuple(i -> edmf.frac_turb_entr[i, k], up.n_updrafts),
             δ_dyn = ntuple(i -> edmf.detr_sc[i, k], up.n_updrafts),
             en_cld_frac = en.cloud_fraction.values[k],


### PR DESCRIPTION
I realized that certain functions (e.g., `get_GMV_CoVar`, `compute_covariance_shear`, `compute_covariance_interdomain_src` etc.) would be a real pain to inject updraft fields because of the `up[i].var[k]` hierarchy. This PR inverts the hierarchy so that updrafts have the form `var.up[i][k]`. This will allow us to transition to fields much easier for the above mentioned functions.

We technically could have written an interface where we pass Symbols and use `getproperty`, but the problem with that is that we'd then need to replace more than one variable in one sweep (`get_GMV_CoVar` is called with velocity, potential temperature, and total specific humidity, so all would need to change for an updated interface to be compatible with all calls).

One downside of this inversion is that we can no longer pass, for example, all updraft variables into a function. Each variable needs to be accessed before specifying that it's an updraft. I think this isn't too problematic since we're passing `state` around nearly everywhere, so we should still be able to shrink the list of function args for several methods. We'll just need to pay with more packing/unpacking. Maybe this won't be too bad once we fuse more methods.

Perhaps we'll re-invert this hierarchy down the road if it seems beneficial.