### PR TITLE
Add pipeline to wipe the depot

### DIFF
--- a/.buildkite/clear_depot.yml
+++ b/.buildkite/clear_depot.yml
@@ -1,0 +1,8 @@
+env:
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/cpu"
+
+steps:
+  - label: "init :put_litter_in_its_place:"
+    key: "init_cpu_env"
+    command:
+      - "rm -rf $$JULIA_DEPOT_PATH"


### PR DESCRIPTION
This PR adds a pipeline script (and a second TC.jl pipeline was added) to clear the Julia depot. We may need to periodically clear the depot if we want to continue caching precompiled code on central. So now, I think, we can just click the build button on buildkite to clear it and that (hopefully) will fix CI troubles.