### PR TITLE
Qualify NameList methods, improve plotting warnings

### DIFF
--- a/docs/src/PlotReferenceStates.jl
+++ b/docs/src/PlotReferenceStates.jl
@@ -8,11 +8,11 @@ tc_dir = dirname(dirname(pathof(TurbulenceConvection)))
 include(joinpath(tc_dir, "integration_tests", "utils", "generate_namelist.jl"))
 include(joinpath(tc_dir, "integration_tests", "utils", "Cases.jl"))
 include(joinpath(tc_dir, "integration_tests", "utils", "parameter_set.jl"))
-using .NameList
+import .NameList
 import .Cases
 function export_ref_profile(case_name::String)
     TC = TurbulenceConvection
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     param_set = create_parameter_set(namelist)
     namelist["meta"]["uuid"] = "01"
 

--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["ARM_SGP"]
 
 @testset "ARM_SGP" begin
     case_name = "ARM_SGP"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["Bomex"]
 
 @testset "Bomex" begin
     case_name = "Bomex"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["DYCOMS_RF01"]
 
 @testset "DYCOMS_RF01" begin
     case_name = "DYCOMS_RF01"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/DryBubble.jl
+++ b/integration_tests/DryBubble.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["DryBubble"]
 
 @testset "DryBubble" begin
     case_name = "DryBubble"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/GABLS.jl
+++ b/integration_tests/GABLS.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["GABLS"]
 
 @testset "GABLS" begin
     case_name = "GABLS"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/GATE_III.jl
+++ b/integration_tests/GATE_III.jl
@@ -8,7 +8,7 @@ using Test
 include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
-using .NameList
+import .NameList
 
 # Note: temperatures in this case become extremely low.
 CLIMAParameters.Planet.T_freeze(::EarthParameterSet) = 100.0

--- a/integration_tests/LES_driven_SCM.jl
+++ b/integration_tests/LES_driven_SCM.jl
@@ -9,7 +9,7 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["LES_driven_SCM"]
 

--- a/integration_tests/Nieuwstadt.jl
+++ b/integration_tests/Nieuwstadt.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["Nieuwstadt"]
 
 @testset "Nieuwstadt" begin
     case_name = "Nieuwstadt"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["Rico"]
 
 @testset "Rico" begin
     case_name = "Rico"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/SP.jl
+++ b/integration_tests/SP.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["SP"]
 
 @testset "SP" begin
     case_name = "SP"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["Soares"]
 
 @testset "Soares" begin
     case_name = "Soares"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -9,7 +9,7 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 # Note: temperatures in this case become extremely low.
 CLIMAParameters.Planet.T_freeze(::EarthParameterSet) = 100.0
@@ -19,7 +19,7 @@ best_mse = all_best_mse["TRMM_LBA"]
 @testset "TRMM_LBA" begin
     case_name = "TRMM_LBA"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/life_cycle_Tan2018.jl
+++ b/integration_tests/life_cycle_Tan2018.jl
@@ -9,14 +9,14 @@ include(joinpath("utils", "main.jl"))
 include(joinpath("utils", "generate_namelist.jl"))
 include(joinpath("utils", "compute_mse.jl"))
 include(joinpath("utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 
 best_mse = all_best_mse["life_cycle_Tan2018"]
 
 @testset "life_cycle_Tan2018" begin
     case_name = "life_cycle_Tan2018"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 

--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -244,28 +244,28 @@ function compute_mse(case_name, best_mse, plot_dir; ds_dict, plot_comparison = t
         end
 
         if missing_les_var
-            @warn "Missing data for variable $tc_var, filling with zeros"
+            @warn "les missing data for variable $tc_var, filling with zeros"
             data_les_arr = zeros(length(z_les), length(time_les))
             warn_msg_les = " Warning: missing data"
         else
             warn_msg_les = ""
         end
         if missing_tcm_var
-            @warn "Missing data for variable $tc_var, filling with zeros"
+            @warn "tcm missing data for variable $tc_var, filling with zeros"
             data_tcm_arr = zeros(length(z_tcm), length(time_tcm))
             warn_msg_tcm = " Warning: missing data"
         else
             warn_msg_tcm = ""
         end
         if missing_tcc_var
-            @warn "Missing data for variable $tc_var, filling with zeros"
+            @warn "tcc missing data for variable $tc_var, filling with zeros"
             data_tcc_arr = zeros(length(z_tcc), length(time_tcc))
             warn_msg_tcc = " Warning: missing data"
         else
             warn_msg_tcc = ""
         end
         if missing_scm_var
-            @warn "Missing data for variable $tc_var, filling with zeros"
+            @warn "scm missing data for variable $tc_var, filling with zeros"
             data_scm_arr = zeros(length(z_scm), length(time_scm))
             warn_msg_scm = " Warning: missing data"
         else

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -7,7 +7,7 @@ using Profile
 include(joinpath("integration_tests", "utils", "Cases.jl"))
 include(joinpath("integration_tests", "utils", "generate_namelist.jl"))
 using .Cases
-using .NameList
+import .NameList
 
 include(joinpath("integration_tests", "utils", "main.jl"))
 

--- a/test/profile.jl
+++ b/test/profile.jl
@@ -7,7 +7,7 @@ using Profile
 include(joinpath("integration_tests", "utils", "Cases.jl"))
 include(joinpath("integration_tests", "utils", "generate_namelist.jl"))
 using .Cases
-using .NameList
+import .NameList
 
 include(joinpath("integration_tests", "utils", "main.jl"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ include(joinpath(tc_dir, "integration_tests", "utils", "main.jl"))
 include(joinpath(tc_dir, "integration_tests", "utils", "generate_namelist.jl"))
 include(joinpath(tc_dir, "integration_tests", "utils", "compute_mse.jl"))
 include(joinpath(tc_dir, "integration_tests", "utils", "mse_tables.jl"))
-using .NameList
+import .NameList
 best_mse = all_best_mse["Bomex"]
 
 @testset "Unit tests" begin
@@ -21,7 +21,7 @@ end
 
     case_name = "Bomex"
     println("Running $case_name...")
-    namelist = default_namelist(case_name)
+    namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
     ds_tc_filename = @time main(namelist)
 


### PR DESCRIPTION
Qualifying NameList allows us to modify the namelist in interactive sessions. Which dataset has missing data per variable is now included in the error message.