### PR TITLE
Do not call Array on `get_nc_data` result

### DIFF
--- a/integration_tests/utils/Cases.jl
+++ b/integration_tests/utils/Cases.jl
@@ -1635,7 +1635,7 @@ function initialize_profiles(self::CasesBase{LES_driven_SCM}, grid::Grid, gm, st
         imin = time_interval_bool[1]
         imax = time_interval_bool[end]
 
-        zc_les = TC.get_nc_data(data, "zc")
+        zc_les = Array(TC.get_nc_data(data, "zc"))
         parent(prog_gm.θ_liq_ice) .=
             pyinterp(grid.zc, zc_les, TC.mean_nc_data(data, "profiles", "thetali_mean", imin, imax))
         parent(prog_gm.q_tot) .= pyinterp(grid.zc, zc_les, TC.mean_nc_data(data, "profiles", "qt_mean", imin, imax))

--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -168,12 +168,12 @@ function compute_mse(case_name, best_mse, plot_dir; ds_dict, plot_comparison = t
 
     mkpath(plot_dir)
     # Ensure domain matches:
-    z_les = TC.get_nc_data(ds_pycles, "zc")
-    z_tcc_c = TC.get_nc_data(ds_tc, "zc")
-    z_tcc_f = TC.get_nc_data(ds_tc, "zf")
-    z_tcm_c = TC.get_nc_data(ds_tc_main, "zc")
-    z_tcm_f = TC.get_nc_data(ds_tc_main, "zf")
-    z_scm = TC.get_nc_data(ds_scampy, "zc")
+    z_les = Array(TC.get_nc_data(ds_pycles, "zc"))
+    z_tcc_c = Array(TC.get_nc_data(ds_tc, "zc"))
+    z_tcc_f = Array(TC.get_nc_data(ds_tc, "zf"))
+    z_tcm_c = Array(TC.get_nc_data(ds_tc_main, "zc"))
+    z_tcm_f = Array(TC.get_nc_data(ds_tc_main, "zf"))
+    z_scm = Array(TC.get_nc_data(ds_scampy, "zc"))
     n_grid_points = length(z_tcc_c)
     @info "z extrema (les,scm,tcm,tcc): $(extrema(z_les)), $(extrema(z_scm)), $(extrema(z_tcm_c)), $(extrema(z_tcc_c))"
     @info "n-grid points (les,scm,tcm,tcc): $(length(z_les)), $(length(z_scm)), $(length(z_tcm_c)), $(length(z_tcc_c))"
@@ -272,10 +272,10 @@ function compute_mse(case_name, best_mse, plot_dir; ds_dict, plot_comparison = t
             warn_msg_scm = ""
         end
 
-        data_les_arr = data_les_arr'
-        data_tcm_arr = data_tcm_arr'
-        data_tcc_arr = data_tcc_arr'
-        data_scm_arr = data_scm_arr'
+        data_les_arr = Array(data_les_arr)'
+        data_tcm_arr = Array(data_tcm_arr)'
+        data_tcc_arr = Array(data_tcc_arr)'
+        data_scm_arr = Array(data_scm_arr)'
         push!(tcc_variables, tc_var)
 
         @info "Assembling plots for $tc_var"

--- a/src/Forcing.jl
+++ b/src/Forcing.jl
@@ -18,7 +18,7 @@ function initialize(self::ForcingBase{ForcingLES}, grid, LESDat::LESData)
         imin = LESDat.imin
         imax = LESDat.imax
 
-        zc_les = get_nc_data(data, "zc")
+        zc_les = Array(get_nc_data(data, "zc"))
 
         self.dtdt_hadv = pyinterp(grid.zc, zc_les, mean_nc_data(data, "profiles", "dtdt_hadv", imin, imax))
         self.dtdt_nudge = pyinterp(grid.zc, zc_les, mean_nc_data(data, "profiles", "dtdt_nudge", imin, imax))

--- a/src/Radiation.jl
+++ b/src/Radiation.jl
@@ -113,7 +113,7 @@ function initialize(self::RadiationBase{RadiationLES}, grid, LESDat::LESData)
         imax = LESDat.imax
 
         # interpolate here
-        zc_les = get_nc_data(data, "zc")
+        zc_les = Array(get_nc_data(data, "zc"))
         meandata = mean_nc_data(data, "profiles", "dtdt_rad", imin, imax)
         self.dTdt = pyinterp(grid.zc, zc_les, meandata)
     end

--- a/src/name_aliases.jl
+++ b/src/name_aliases.jl
@@ -34,12 +34,12 @@ function get_nc_data(ds, var::String)
 
     for key in key_options
         if haskey(ds, key)
-            return Array(ds[key])
+            return ds[key]
         else
             for group_option in ["profiles", "reference", "timeseries"]
                 haskey(ds.group, group_option) || continue
                 if haskey(ds.group[group_option], key)
-                    return Array(ds.group[group_option][key])
+                    return ds.group[group_option][key]
                 end
             end
         end


### PR DESCRIPTION
I need to call some NCDataset functions on the result of `get_nc_data` before it's wrapped in `Array`. So, this PR changes `get_nc_data` to not call `Array`, and calls `Array` whenever used.

cc @haakon-e.

The way to fix future conflicts will simply be wrapping the call with `Array` (`Array(TC.get_nc_data(...))`).