### PR TITLE
Use NC.dimnames to determine face/center

### DIFF
--- a/integration_tests/utils/compute_mse.jl
+++ b/integration_tests/utils/compute_mse.jl
@@ -222,15 +222,18 @@ function compute_mse(case_name, best_mse, plot_dir; ds_dict, plot_comparison = t
         missing_tcc_var = data_tcc_arr == nothing
         missing_scm_var = data_scm_arr == nothing
 
-        if TC.is_face_field(tc_var)
+        coord_name = first(NC.dimnames(data_tcc_arr))
+        coord_name == "zf" || coord_name == "zc" || error("Bad coord_name")
+
+        if coord_name == "zf"
             z_tcc = z_tcc_f
-        else
+        elseif coord_name == "zc"
             z_tcc = z_tcc_c
         end
         if have_tc_main
-            if TC.is_face_field(tc_var)
+            if coord_name == "zf"
                 z_tcm = z_tcm_f
-            else
+            elseif coord_name == "zc"
                 z_tcm = z_tcm_c
             end
         else


### PR DESCRIPTION
This is getting peeled off from #423. This PR changes the way that we determine whether we should use cell face vs cell center coordinates by examining the `NCDatasets.dimnames`. I'm not sure that this is part of their public API, but it'll only be used in one place at the moment, and the information is likely to exist somewhere in the NC file.

We can't get rid of `is_face_field` yet because it's still used for determining the coordinates for ordinary Array-backed variables.