### PR TITLE
support output for dt < 1

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -220,7 +220,7 @@ function run(sim::Simulation1d)
             @show progress
         end
 
-        if mod(sim.TS.t, sim.Stats.frequency) == 0
+        if mod(round(Int, sim.TS.t), round(Int, sim.Stats.frequency)) == 0
             # TODO: is this the best location to call diagnostics?
             TC.compute_diagnostics!(sim.Turb, sim.GMV, grid, state, sim.Case, sim.TS)
 


### PR DESCRIPTION
When running with `dt` < 1s we generate no output. This is because our output is decided based on:

`if mod(sim.TS.t, sim.Stats.frequency) == 0
`

which  runs into rounding errors when the arguments are not integers. Seems like the namelist key is labelled frequency, but we use it in the code more like output interval. 

We could instead start using it like this (i.e. more like a frequency - "every how many steps we should do output)". This way we would avoid floating point issues:

`if mod(iter, sim.Stats.frequency) == 0
`

If we want to keep the current output specification, some ugly workaround solution could look like this:

`if (sim.TS.t - sim.Stats.frequency * div(sim.TS.t, sim.Stats.frequency, RoundNearest)) < eps(1.0) * sim.TS.t_max
`

Let me know what you think. If we go with the integer friendly way I'm not sure if I should change something more in the NetCDF io files.