### PR TITLE
Use OrdinaryDiffEq.jl for timestepping, rearrange update_aux!, and remove buoyancy extrapolation

### DIFF
--- a/integration_tests/utils/generate_namelist.jl
+++ b/integration_tests/utils/generate_namelist.jl
@@ -139,7 +139,6 @@ function default_namelist(case_name::String)
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["extrapolate_buoyancy"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["use_local_micro"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["calculate_tke"] = true

--- a/src/types.jl
+++ b/src/types.jl
@@ -499,7 +499,6 @@ mutable struct EDMF_PrognosticTKE{A1, A2, IE}
     n_updrafts::Int
     drag_sign::Int
     asp_label
-    extrapolate_buoyancy::Bool
     surface_area::Float64
     max_area::Float64
     aspect_ratio::Float64
@@ -586,9 +585,6 @@ mutable struct EDMF_PrognosticTKE{A1, A2, IE}
             "pressure_closure_asp_label";
             default = "const",
         )
-
-        extrapolate_buoyancy =
-            parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "extrapolate_buoyancy"; default = true)
 
         # Get values from namelist
         # set defaults at some point?
@@ -745,7 +741,6 @@ mutable struct EDMF_PrognosticTKE{A1, A2, IE}
             n_updrafts,
             drag_sign,
             asp_label,
-            extrapolate_buoyancy,
             surface_area,
             max_area,
             aspect_ratio,

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -84,14 +84,15 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     #####
     ##### diagnose_GMV_moments
     #####
-    #! format: off
+
     get_GMV_CoVar(edmf, grid, state, :Hvar, :θ_liq_ice)
     get_GMV_CoVar(edmf, grid, state, :QTvar, :q_tot)
     get_GMV_CoVar(edmf, grid, state, :HQTcov, :θ_liq_ice, :q_tot)
     GMV_third_m(edmf, grid, state, :Hvar, :θ_liq_ice, :H_third_m)
     GMV_third_m(edmf, grid, state, :QTvar, :q_tot, :QT_third_m)
     GMV_third_m(edmf, grid, state, :tke, :w, :W_third_m)
-    #! format: on
+
+    satadjust(gm, grid, state)
 
     #####
     ##### decompose_environment
@@ -115,6 +116,26 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     end
 
     @inbounds for k in real_center_indices(grid)
+
+        #####
+        ##### updraft buoyancy
+        #####
+
+        @inbounds for i in 1:(up.n_updrafts)
+            if aux_up[i].area[k] > 0.0
+                ts_up = thermo_state_pθq(param_set, p0_c[k], aux_up[i].θ_liq_ice[k], aux_up[i].q_tot[k])
+                aux_up[i].q_liq[k] = TD.liquid_specific_humidity(ts_up)
+                aux_up[i].q_ice[k] = TD.ice_specific_humidity(ts_up)
+                aux_up[i].T[k] = TD.air_temperature(ts_up)
+                ρ = TD.air_density(ts_up)
+                aux_up[i].buoy[k] = buoyancy_c(param_set, ρ0_c[k], ρ)
+                aux_up[i].RH[k] = TD.relative_humidity(ts_up)
+            else
+                aux_up[i].buoy[k] = aux_en.buoy[k]
+                aux_up[i].RH[k] = aux_en.RH[k]
+            end
+        end
+
         a_bulk_c = aux_tc.bulk.area[k]
         aux_tc.bulk.q_tot[k] = 0
         aux_tc.bulk.q_liq[k] = 0
@@ -167,35 +188,8 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
         aux_en.RH[k] = TD.relative_humidity(ts_en)
 
         #####
-        ##### buoyancy
+        ##### grid mean buoyancy
         #####
-
-        @inbounds for i in 1:(up.n_updrafts)
-            if aux_up[i].area[k] > 0.0
-                ts_up = thermo_state_pθq(param_set, p0_c[k], aux_up[i].θ_liq_ice[k], aux_up[i].q_tot[k])
-                aux_up[i].q_liq[k] = TD.liquid_specific_humidity(ts_up)
-                aux_up[i].q_ice[k] = TD.ice_specific_humidity(ts_up)
-                aux_up[i].T[k] = TD.air_temperature(ts_up)
-                ρ = TD.air_density(ts_up)
-                aux_up[i].buoy[k] = buoyancy_c(param_set, ρ0_c[k], ρ)
-                aux_up[i].RH[k] = TD.relative_humidity(ts_up)
-            elseif k > kc_surf
-                if aux_up[i].area[k - 1] > 0.0 && edmf.extrapolate_buoyancy
-                    qt = aux_up[i].q_tot[k - 1]
-                    h = aux_up[i].θ_liq_ice[k - 1]
-                    ts_up = thermo_state_pθq(param_set, p0_c[k], h, qt)
-                    ρ = TD.air_density(ts_up)
-                    aux_up[i].buoy[k] = buoyancy_c(param_set, ρ0_c[k], ρ)
-                    aux_up[i].RH[k] = TD.relative_humidity(ts_up)
-                else
-                    aux_up[i].buoy[k] = aux_en.buoy[k]
-                    aux_up[i].RH[k] = aux_en.RH[k]
-                end
-            else
-                aux_up[i].buoy[k] = aux_en.buoy[k]
-                aux_up[i].RH[k] = aux_en.RH[k]
-            end
-        end
 
         aux_gm.buoy[k] = (1.0 - aux_tc.bulk.area[k]) * aux_en.buoy[k]
         @inbounds for i in 1:(up.n_updrafts)
@@ -225,7 +219,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     @inbounds for k in real_center_indices(grid)
         aux_gm.q_liq[k] = (a_up_bulk[k] * aux_tc.bulk.q_liq[k] + (1 - a_up_bulk[k]) * aux_en.q_liq[k])
         aux_gm.q_ice[k] = (a_up_bulk[k] * aux_tc.bulk.q_ice[k] + (1 - a_up_bulk[k]) * aux_en.q_ice[k])
-        aux_gm.T[k] = (a_up_bulk[k] * aux_tc.bulk.T[k] + (1 - a_up_bulk[k]) * aux_en.T[k])
+        # aux_gm.T[k] = (a_up_bulk[k] * aux_tc.bulk.T[k] + (1 - a_up_bulk[k]) * aux_en.T[k])
         aux_gm.buoy[k] = (a_up_bulk[k] * aux_tc.bulk.buoy[k] + (1 - a_up_bulk[k]) * aux_en.buoy[k])
     end
     compute_pressure_plume_spacing(edmf, param_set)


### PR DESCRIPTION
#417 inspired me to see what would happen if, when trying to use OrdinaryDiffEq for time stepping, we also try to remove buoyancy extrapolation and rearrange the update_aux! calls.