### PR TITLE
Fix update_aux inconsistencies

### DIFF
--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -84,14 +84,18 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     #####
     ##### diagnose_GMV_moments
     #####
-    #! format: off
+
     get_GMV_CoVar(edmf, grid, state, :Hvar, :θ_liq_ice)
     get_GMV_CoVar(edmf, grid, state, :QTvar, :q_tot)
     get_GMV_CoVar(edmf, grid, state, :HQTcov, :θ_liq_ice, :q_tot)
     GMV_third_m(edmf, grid, state, :Hvar, :θ_liq_ice, :H_third_m)
     GMV_third_m(edmf, grid, state, :QTvar, :q_tot, :QT_third_m)
     GMV_third_m(edmf, grid, state, :tke, :w, :W_third_m)
-    #! format: on
+
+    #####
+    ##### update_GMV_diagnostics
+    #####
+    satadjust(gm, grid, state)
 
     #####
     ##### decompose_environment
@@ -217,16 +221,6 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     update_forcing(Case, grid, state, gm, TS, param_set)
     update_radiation(Case, grid, state, gm, TS, param_set)
 
-    #####
-    ##### update_GMV_diagnostics
-    #####
-    a_up_bulk = aux_tc.bulk.area
-    @inbounds for k in real_center_indices(grid)
-        aux_gm.q_liq[k] = (a_up_bulk[k] * aux_tc.bulk.q_liq[k] + (1 - a_up_bulk[k]) * aux_en.q_liq[k])
-        aux_gm.q_ice[k] = (a_up_bulk[k] * aux_tc.bulk.q_ice[k] + (1 - a_up_bulk[k]) * aux_en.q_ice[k])
-        aux_gm.T[k] = (a_up_bulk[k] * aux_tc.bulk.T[k] + (1 - a_up_bulk[k]) * aux_en.T[k])
-        aux_gm.buoy[k] = (a_up_bulk[k] * aux_tc.bulk.buoy[k] + (1 - a_up_bulk[k]) * aux_en.buoy[k])
-    end
     compute_pressure_plume_spacing(edmf, param_set)
 
     #####


### PR DESCRIPTION
Similar to #417, this PR computes some grid mean quantities before they are referenced. To do this, we rely on using thermodynamic relations instead of the domain decomposition relations.

This does add a saturation adjustment, but this will likely be needed anyway, and can be performed by the dycore in the long run.