### PR TITLE
Use turbconv instead of tc in dycore api

### DIFF
--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -574,7 +574,7 @@ function construct_tridiag_diffusion_en(
     c = center_field(grid)
     ρ0_c = center_ref_state(state).ρ0
     ρ0_f = face_ref_state(state).ρ0
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     w_en = face_aux_environment(state).w
     aux_up_f = face_aux_updrafts(state)
     prog_en = center_prog_environment(state)
@@ -584,8 +584,8 @@ function construct_tridiag_diffusion_en(
     rho_ae_K_m = face_field(grid)
     w_en_c = center_field(grid)
     D_env = 0.0
-    KM = center_aux_tc(state).KM
-    KH = center_aux_tc(state).KH
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
 
     aeK = is_tke ? ae .* KM : ae .* KH
     aeK_bcs = (; bottom = SetValue(aeK[kc_surf]), top = SetValue(aeK[kc_toa]))

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -64,7 +64,7 @@ function io(edmf::EDMF_PrognosticTKE, grid, state, Stats::NetCDFIO_Stats, TS::Ti
     io(edmf.EnvVar, grid, state, Stats)
     io(edmf.Precip, grid, state, Stats, edmf.UpdThermo, edmf.EnvThermo, TS)
 
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     aux_up = center_aux_updrafts(state)
     a_up_bulk = aux_tc.bulk.area
 
@@ -155,7 +155,7 @@ function update_radiation end
 
 function update_cloud_frac(edmf::EDMF_PrognosticTKE, grid, state, gm::GridMeanVariables)
     # update grid-mean cloud fraction and cloud cover
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     aux_gm = center_aux_grid_mean(state)
     aux_en = center_aux_environment(state)
     a_up_bulk = aux_tc.bulk.area
@@ -185,7 +185,7 @@ function compute_gm_tendencies!(edmf::EDMF_PrognosticTKE, grid, state, Case, gm,
     kc_surf = kc_surface(grid)
     up = edmf.UpdVar
     en = edmf.EnvVar
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ae = 1 .- aux_tc.bulk.area # area of environment
 
     @inbounds for k in real_center_indices(grid)
@@ -336,12 +336,12 @@ function compute_diffusive_fluxes(
     param_set,
 )
     ρ0_f = face_ref_state(state).ρ0
-    aux_tc = center_aux_tc(state)
-    aux_tc_f = face_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
+    aux_tc_f = face_aux_turbconv(state)
     aux_en = center_aux_environment(state)
     aux_en.area .= 1 .- aux_tc.bulk.area # area of environment
-    KM = center_aux_tc(state).KM
-    KH = center_aux_tc(state).KH
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
     aeKM = aux_en.area .* KM
     aeKH = aux_en.area .* KH
     kc_surf = kc_surface(grid)
@@ -559,7 +559,7 @@ end
 # if covar_e.name is not "tke".
 function get_GMV_CoVar(edmf::EDMF_PrognosticTKE, grid, state, covar_sym::Symbol, ϕ_sym::Symbol, ψ_sym::Symbol = ϕ_sym)
 
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ae = 1 .- aux_tc.bulk.area
     is_tke = covar_sym == :tke
     tke_factor = is_tke ? 0.5 : 1
@@ -805,9 +805,9 @@ function compute_covariance_shear(
     en_var2_sym::Symbol = en_var1_sym,
 )
 
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ae = 1 .- aux_tc.bulk.area # area of environment
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ρ0_c = center_ref_state(state).ρ0
     prog_gm = center_prog_grid_mean(state)
     is_tke = covar_sym == :tke
@@ -1001,7 +1001,7 @@ end
 function compute_covariance_dissipation(edmf::EDMF_PrognosticTKE, grid, state, covar_sym::Symbol, param_set)
     en = edmf.EnvVar
     c_d = CPEDMF.c_d(param_set)
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ae = 1 .- aux_tc.bulk.area
     ρ0_c = center_ref_state(state).ρ0
     prog_en = center_prog_environment(state)
@@ -1060,7 +1060,7 @@ function GMV_third_m(edmf::EDMF_PrognosticTKE, grid, state, covar_en_sym::Symbol
 
     up = edmf.UpdVar
     en = edmf.EnvVar
-    aux_tc = center_aux_tc(state)
+    aux_tc = center_aux_turbconv(state)
     ae = 1 .- aux_tc.bulk.area
     aux_up_f = face_aux_updrafts(state)
     is_tke = covar_en_sym == :tke

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -35,14 +35,14 @@ end
 function io_dictionary_aux(state)
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
-        "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.area),
-        "updraft_ql" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.q_liq),
-        "updraft_RH" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.RH),
-        "updraft_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.q_tot),
-        "updraft_w" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_tc(state).bulk.w),
-        "updraft_temperature" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.T),
-        "updraft_thetal" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.θ_liq_ice),
-        "updraft_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).bulk.buoy),
+        "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.area),
+        "updraft_ql" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.q_liq),
+        "updraft_RH" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.RH),
+        "updraft_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.q_tot),
+        "updraft_w" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_turbconv(state).bulk.w),
+        "updraft_temperature" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.T),
+        "updraft_thetal" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.θ_liq_ice),
+        "updraft_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).bulk.buoy),
         "H_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).H_third_m),
         "W_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).W_third_m),
         "QT_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).H_third_m),
@@ -62,8 +62,8 @@ function io_dictionary_aux(state)
         "w_mean" => (; dims = ("zf", "t"), group = "profiles", field = face_prog_grid_mean(state).w),
         "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).q_tot),
         "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).θ_liq_ice),
-        "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).KM),
-        "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_tc(state).KH),
+        "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).KM),
+        "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).KH),
         "env_tke" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_environment(state).tke),
         "env_Hvar" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_environment(state).Hvar),
         "env_QTvar" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_environment(state).QTvar),
@@ -150,7 +150,7 @@ function compute_diagnostics!(edmf, gm, grid, state, Case, TS)
     aux_gm = center_aux_grid_mean(state)
     aux_en = center_aux_environment(state)
     aux_up = center_aux_updrafts(state)
-    aux_tc_f = face_aux_tc(state)
+    aux_tc_f = face_aux_turbconv(state)
     aux_gm_f = face_aux_grid_mean(state)
     kc_toa = kc_top_of_atmos(grid)
     gm.cloud_base = grid.zc[kc_toa]

--- a/src/dycore_api.jl
+++ b/src/dycore_api.jl
@@ -21,20 +21,24 @@ we're not sure how the data structures / flow control will shake out.
 
 """ Prognostic fields for the host model """
 prognostic(state, fl) = getproperty(state.prog, field_loc(fl))
+
 center_prog_grid_mean(state) = prognostic(state, CentField())
 face_prog_grid_mean(state) = prognostic(state, FaceField())
 
 """ Auxiliary fields for the host model """
 aux(state, fl) = getproperty(state.aux, field_loc(fl))
+
 center_aux_grid_mean(state) = aux(state, CentField())
 face_aux_grid_mean(state) = aux(state, FaceField())
 
 """ Tendency fields for the host model """
 tendencies(state, fl) = getproperty(state.tendencies, field_loc(fl))
+
 center_tendencies_grid_mean(state) = tendencies(state, CentField())
 
 """ Reference state fields for the host model """
 ref_state(state, fl) = aux(state, fl).ref_state
+
 face_ref_state(state) = ref_state(state, FaceField())
 center_ref_state(state) = ref_state(state, CentField())
 
@@ -43,16 +47,18 @@ center_ref_state(state) = ref_state(state, CentField())
 #####
 
 #= Prognostic fields for TurbulenceConvection =#
-prognostic_tc(state, fl) = prognostic(state, fl).turbconv
-center_prog_updrafts(state) = prognostic_tc(state, CentField()).up
-face_prog_updrafts(state) = prognostic_tc(state, FaceField()).up
-center_prog_environment(state) = prognostic_tc(state, CentField()).en
-center_prog_precipitation(state) = prognostic_tc(state, CentField()).pr
+prognostic_turbconv(state, fl) = prognostic(state, fl).turbconv
+
+center_prog_updrafts(state) = prognostic_turbconv(state, CentField()).up
+face_prog_updrafts(state) = prognostic_turbconv(state, FaceField()).up
+center_prog_environment(state) = prognostic_turbconv(state, CentField()).en
+center_prog_precipitation(state) = prognostic_turbconv(state, CentField()).pr
 
 #= Auxiliary fields for TurbulenceConvection =#
 aux_turbconv(state, fl) = aux(state, fl).turbconv
-center_aux_tc(state) = aux_turbconv(state, CentField())
-face_aux_tc(state) = aux_turbconv(state, FaceField())
+
+center_aux_turbconv(state) = aux_turbconv(state, CentField())
+face_aux_turbconv(state) = aux_turbconv(state, FaceField())
 center_aux_updrafts(state) = aux_turbconv(state, CentField()).up
 face_aux_updrafts(state) = aux_turbconv(state, FaceField()).up
 center_aux_environment(state) = aux_turbconv(state, CentField()).en
@@ -60,10 +66,11 @@ center_aux_environment_2m(state) = aux_turbconv(state, CentField()).en_2m
 face_aux_environment(state) = aux_turbconv(state, FaceField()).en
 
 #= Tendency fields for TurbulenceConvection =#
-tendencies_tc(state, fl) = tendencies(state, fl).turbconv
-center_tendencies_tc(state) = tendencies_tc(state, CentField())
-face_tendencies_tc(state) = tendencies_tc(state, FaceField())
-center_tendencies_updrafts(state) = tendencies_tc(state, CentField()).up
-center_tendencies_environment(state) = tendencies_tc(state, CentField()).en
-center_tendencies_precipitation(state) = tendencies_tc(state, CentField()).pr
-face_tendencies_updrafts(state) = tendencies_tc(state, FaceField()).up
+tendencies_turbconv(state, fl) = tendencies(state, fl).turbconv
+
+center_tendencies_turbconv(state) = tendencies_turbconv(state, CentField())
+face_tendencies_turbconv(state) = tendencies_turbconv(state, FaceField())
+center_tendencies_updrafts(state) = tendencies_turbconv(state, CentField()).up
+center_tendencies_environment(state) = tendencies_turbconv(state, CentField()).en
+center_tendencies_precipitation(state) = tendencies_turbconv(state, CentField()).pr
+face_tendencies_updrafts(state) = tendencies_turbconv(state, FaceField()).up

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -14,8 +14,8 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     α0_c = center_ref_state(state).α0
     g = CPP.grav(param_set)
     c_m = CPEDMF.c_m(param_set)
-    KM = center_aux_tc(state).KM
-    KH = center_aux_tc(state).KH
+    KM = center_aux_turbconv(state).KM
+    KH = center_aux_turbconv(state).KH
     surface = Case.Sur
     obukhov_length = surface.obukhov_length
     FT = eltype(grid)
@@ -26,8 +26,8 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     aux_en = center_aux_environment(state)
     aux_en_f = face_aux_environment(state)
     aux_gm = center_aux_grid_mean(state)
-    aux_tc_f = face_aux_tc(state)
-    aux_tc = center_aux_tc(state)
+    aux_tc_f = face_aux_turbconv(state)
+    aux_tc = center_aux_turbconv(state)
     prog_en = center_prog_environment(state)
     aux_en_2m = center_aux_environment_2m(state)
     prog_up = center_prog_updrafts(state)


### PR DESCRIPTION
I just realized that we were using `_tc` for the turbconv dycore api. I think I'd prefer that these methods are verbose, since they're things that the host model will be required to overload, and they should be clear and descriptive.