### PR TITLE
Make precip variables ClimaCore fields, rm unused funcs, cleanup

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -112,6 +112,10 @@ cent_aux_vars_edmf(FT, n_up) = (;
             QTvar = FT(0),
             HQTcov = FT(0),
         ),
+        θ_liq_ice_tendency_rain_evap = FT(0),
+        qt_tendency_rain_evap = FT(0),
+        qr_tendency_rain_evap = FT(0),
+        qr_tendency_advection = FT(0),
         en_2m = (;
             tke = cent_aux_vars_en_2m(FT),
             Hvar = cent_aux_vars_en_2m(FT),

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -96,11 +96,11 @@ function compute_gm_tendencies!(edmf::EDMF_PrognosticTKE, grid, state, Case, gm,
         tendencies_gm.q_tot[k] +=
             edmf.UpdThermo.qt_tendency_rain_formation_tot[k] +
             edmf.EnvThermo.qt_tendency_rain_formation[k] +
-            edmf.PrecipPhys.qt_tendency_rain_evap[k]
+            aux_tc.qt_tendency_rain_evap[k]
         tendencies_gm.θ_liq_ice[k] +=
             edmf.UpdThermo.θ_liq_ice_tendency_rain_formation_tot[k] +
             edmf.EnvThermo.θ_liq_ice_tendency_rain_formation[k] +
-            edmf.PrecipPhys.θ_liq_ice_tendency_rain_evap[k]
+            aux_tc.θ_liq_ice_tendency_rain_evap[k]
     end
 
     aux_up_f = face_aux_updrafts(state)

--- a/src/types.jl
+++ b/src/types.jl
@@ -200,24 +200,7 @@ function PrecipVariables(namelist, grid::Grid)
     return PrecipVariables(; precipitation_model)
 end
 
-struct PrecipPhysics{T}
-    θ_liq_ice_tendency_rain_evap::T
-    qt_tendency_rain_evap::T
-    qr_tendency_rain_evap::T
-    qr_tendency_advection::T
-    function PrecipPhysics(grid::Grid)
-        θ_liq_ice_tendency_rain_evap = center_field(grid)
-        qt_tendency_rain_evap = center_field(grid)
-        qr_tendency_rain_evap = center_field(grid)
-        qr_tendency_advection = center_field(grid)
-        return new{typeof(θ_liq_ice_tendency_rain_evap)}(
-            θ_liq_ice_tendency_rain_evap,
-            qt_tendency_rain_evap,
-            qr_tendency_rain_evap,
-            qr_tendency_advection,
-        )
-    end
-end
+struct PrecipPhysics end
 
 mutable struct UpdraftVariables{A1}
     n_updrafts::Int
@@ -604,7 +587,7 @@ mutable struct EDMF_PrognosticTKE{A1, A2}
         # Create the class for precipitation
         Precip = PrecipVariables(namelist, grid)
         # Create the class for precipitation physics
-        PrecipPhys = PrecipPhysics(grid)
+        PrecipPhys = PrecipPhysics()
 
         # Create the updraft variable class (major diagnostic and prognostic variables)
         UpdVar = UpdraftVariables(n_updrafts, namelist, grid)


### PR DESCRIPTION
This PR
 - Makes several precipitation variables ClimaCore fields
 - Removes unused functions

I think that, for now, we can keep these tendencies (which are effectively saved for diagnostics) in `aux`. In the long run, I envision having functions that we can accumulate tendencies inside `compute_tendencies`, and they can be computed separately (using the same machinery) in the diagnostics.