### PR TITLE
Make virtual temperature a ClimaCore field

### DIFF
--- a/integration_tests/utils/initial_conditions.jl
+++ b/integration_tests/utils/initial_conditions.jl
@@ -1,10 +1,19 @@
 import TurbulenceConvection
 const TC = TurbulenceConvection
+import Thermodynamics
+const TD = Thermodynamics
 
 function initialize_edmf(edmf::TC.EDMF_PrognosticTKE, grid, state, Case, gm::TC.GridMeanVariables, TS::TC.TimeStepping)
     initialize_covariance(edmf, grid, state, gm, Case)
     up = edmf.UpdVar
     param_set = TC.parameter_set(gm)
+    aux_tc = TC.center_aux_turbconv(state)
+    prog_gm = TC.center_prog_grid_mean(state)
+    p0_c = TC.center_ref_state(state).p0
+    @inbounds for k in TC.real_center_indices(grid)
+        ts = TC.thermo_state_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
+        aux_tc.θ_virt[k] = TD.virtual_pottemp(ts)
+    end
     TC.update_surface(Case, grid, state, gm, TS, param_set)
     TC.compute_updraft_surface_bc(edmf, grid, state, Case)
     if Case.casename == "DryBubble"

--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -126,6 +126,7 @@ cent_aux_vars_edmf(FT, n_up) = (;
         KM = FT(0),
         KH = FT(0),
         mixing_length = FT(0),
+        θ_virt = FT(0),
     ),
 )
 cent_aux_vars(FT, n_up) = (; aux_vars_ref_state(FT)..., cent_aux_vars_gm(FT)..., cent_aux_vars_edmf(FT, n_up)...)

--- a/src/Surface.jl
+++ b/src/Surface.jl
@@ -3,16 +3,9 @@
 #####
 
 function free_convection_windspeed(surf::SurfaceBase, grid, state, gm::GridMeanVariables, param_set, ::BaseCase)
-    θ_ρ = center_field(grid)
-    p0_c = center_ref_state(state).p0
     prog_gm = center_prog_grid_mean(state)
-
-    # Need to get θ_ρ
-    @inbounds for k in real_center_indices(grid)
-        ts = thermo_state_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
-        θ_ρ[k] = TD.virtual_pottemp(ts)
-    end
-    zi = get_inversion(param_set, θ_ρ, prog_gm.u, prog_gm.v, grid, surf.Ri_bulk_crit)
+    aux_tc = center_aux_turbconv(state)
+    zi = get_inversion(param_set, aux_tc.θ_virt, prog_gm.u, prog_gm.v, grid, surf.Ri_bulk_crit)
     wstar = get_wstar(surf.bflux, zi) # yair here zi in TRMM should be adjusted
     surf.windspeed = sqrt(surf.windspeed * surf.windspeed + (1.2 * wstar) * (1.2 * wstar))
     return
@@ -156,13 +149,13 @@ function update(surf::SurfaceBase{SurfaceMoninObukhov}, grid, state, gm::GridMea
     h_star = TD.liquid_ice_pottemp_given_pressure(param_set, surf.Tsurface, Pg, phase_part)
 
     ts_g = thermo_state_pθq(param_set, Pg, h_star, surf.qsurface)
-    θ_ρ_g = TD.virtual_pottemp(ts_g)
+    θ_virt_g = TD.virtual_pottemp(ts_g)
 
     ts_b = thermo_state_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, surf.qsurface)
-    θ_ρ_b = TD.virtual_pottemp(ts_b)
+    θ_virt_b = TD.virtual_pottemp(ts_b)
 
     surf.windspeed = sqrt(u_gm_surf^2 + v_gm_surf^2)
-    Nb2 = g / θ_ρ_g * (θ_ρ_b - θ_ρ_g) / zb
+    Nb2 = g / θ_virt_g * (θ_virt_b - θ_virt_g) / zb
     Ri = Nb2 * zb * zb / (surf.windspeed * surf.windspeed)
 
     surf.cm, surf.ch, surf.obukhov_length = exchange_coefficients_byun(param_set, Ri, zb, surf.zrough)
@@ -209,13 +202,13 @@ function update(surf::SurfaceBase{SurfaceMoninObukhovDry}, grid, state, gm::Grid
     h_star = TD.liquid_ice_pottemp_given_pressure(param_set, surf.Tsurface, Pg, phase_part)
 
     ts_g = thermo_state_pθq(param_set, Pg, h_star, surf.qsurface)
-    θ_ρ_g = TD.virtual_pottemp(ts_g)
+    θ_virt_g = TD.virtual_pottemp(ts_g)
 
     ts_b = thermo_state_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, surf.qsurface)
-    θ_ρ_b = TD.virtual_pottemp(ts_b)
+    θ_virt_b = TD.virtual_pottemp(ts_b)
 
     surf.windspeed = sqrt(u_gm_surf^2 + v_gm_surf^2)
-    Nb2 = g / θ_ρ_g * (θ_ρ_b - θ_ρ_g) / zb
+    Nb2 = g / θ_virt_g * (θ_virt_b - θ_virt_g) / zb
     Ri = Nb2 * zb * zb / (surf.windspeed * surf.windspeed)
 
     surf.cm, surf.ch, surf.obukhov_length = exchange_coefficients_byun(param_set, Ri, zb, surf.zrough)
@@ -268,13 +261,13 @@ function update(surf::SurfaceBase{SurfaceSullivanPatton}, grid, state, gm::GridM
     h_star = TD.liquid_ice_pottemp_given_pressure(param_set, surf.Tsurface, Pg, phase_part)
 
     ts_g = thermo_state_pθq(param_set, Pg, h_star, surf.qsurface)
-    θ_ρ_g = TD.virtual_pottemp(ts_g)
+    θ_virt_g = TD.virtual_pottemp(ts_g)
 
     ts_b = thermo_state_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, surf.qsurface)
-    θ_ρ_b = TD.virtual_pottemp(ts_b)
+    θ_virt_b = TD.virtual_pottemp(ts_b)
 
     surf.windspeed = sqrt(u_gm_surf^2 + v_gm_surf^2)
-    Nb2 = g / θ_ρ_g * (θ_ρ_b - θ_ρ_g) / zb
+    Nb2 = g / θ_virt_g * (θ_virt_b - θ_virt_g) / zb
     Ri = Nb2 * zb * zb / (surf.windspeed * surf.windspeed)
 
     surf.cm, surf.ch, surf.obukhov_length = exchange_coefficients_byun(param_set, Ri, zb, surf.zrough)

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -9,21 +9,21 @@ function buoyancy_c(param_set, ρ0, ρ)
 end
 
 # BL height
-function get_inversion(param_set, θ_ρ, u, v, grid::Grid, Ri_bulk_crit)
+function get_inversion(param_set, θ_virt, u, v, grid::Grid, Ri_bulk_crit)
     g = CPP.grav(param_set)
     kc_surf = kc_surface(grid)
-    θ_ρ_b = θ_ρ[kc_surf]
+    θ_virt_b = θ_virt[kc_surf]
     Ri_bulk = center_field(grid)
     z_c = grid.zc
 
     # test if we need to look at the free convective limit
     if (u[kc_surf]^2 + v[kc_surf]^2) <= 0.01
-        kmask = map(k -> (k, θ_ρ[k] > θ_ρ_b), real_center_indices(grid))
+        kmask = map(k -> (k, θ_virt[k] > θ_virt_b), real_center_indices(grid))
         k_star = first(kmask[findlast(km -> km[2], kmask)])
-        ∇θ_ρ = c∇_upwind(θ_ρ, grid, k_star; bottom = SetGradient(0), top = FreeBoundary())
-        h = (θ_ρ_b - θ_ρ[k_star - 1]) / ∇θ_ρ + z_c[k_star - 1]
+        ∇θ_virt = c∇_upwind(θ_virt, grid, k_star; bottom = SetGradient(0), top = FreeBoundary())
+        h = (θ_virt_b - θ_virt[k_star - 1]) / ∇θ_virt + z_c[k_star - 1]
     else
-        Ri_bulk_fn(k) = g * (θ_ρ[k] - θ_ρ_b) * z_c[k] / θ_ρ_b / (u[k] * u[k] + v[k] * v[k])
+        Ri_bulk_fn(k) = g * (θ_virt[k] - θ_virt_b) * z_c[k] / θ_virt_b / (u[k] * u[k] + v[k] * v[k])
 
         Ri_bulk .= map(k -> Ri_bulk_fn(k), real_center_indices(grid))
         kmask = map(k -> (k, Ri_bulk_fn(k) > Ri_bulk_crit), real_center_indices(grid))

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -204,12 +204,11 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
         aux_en.buoy[k] -= aux_gm.buoy[k]
     end
     # TODO - use this inversion in free_convection_windspeed and not compute zi twice
-    θ_ρ = center_field(grid)
     @inbounds for k in real_center_indices(grid)
         ts = thermo_state_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
-        θ_ρ[k] = TD.virtual_pottemp(ts)
+        aux_tc.θ_virt[k] = TD.virtual_pottemp(ts)
     end
-    edmf.zi = get_inversion(param_set, θ_ρ, prog_gm.u, prog_gm.v, grid, surface.Ri_bulk_crit)
+    edmf.zi = get_inversion(param_set, aux_tc.θ_virt, prog_gm.u, prog_gm.v, grid, surface.Ri_bulk_crit)
 
     update_surface(Case, grid, state, gm, TS, param_set)
     update_forcing(Case, grid, state, gm, TS, param_set)


### PR DESCRIPTION
This PR
 - Makes virtual temperature a ClimaCore field
 - Renames θ_ρ -> θ_virt
 - Moves `θ_virt` computation in `free_convection_windspeed` to initialization, and re-use computation from `update_aux!` (saves a call to saturation adjustment in some cases).