### PR TITLE
Reduce allocations, move some variables to climacore fields

### DIFF
--- a/integration_tests/utils/Cases.jl
+++ b/integration_tests/utils/Cases.jl
@@ -600,7 +600,7 @@ function initialize_profiles(self::CasesBase{Rico}, grid::Grid, gm, state)
         ts = TC.thermo_state_pθq(param_set, p0[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
         aux_tc.θ_virt[k] = TD.virtual_pottemp(ts)
     end
-    zi = 0.6 * get_inversion(param_set, aux_tc.θ_virt, prog_gm.u, prog_gm.v, grid, 0.2)
+    zi = 0.6 * get_inversion(grid, state, param_set, 0.2)
 
     @inbounds for k in real_center_indices(grid)
         z = grid.zc[k]

--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -99,9 +99,11 @@ cent_aux_vars_edmf(FT, n_up) = (;
             cloud_fraction = FT(0),
             θ_liq_ice_tendency_precip_formation = FT(0),
             qt_tendency_precip_formation = FT(0),
+            Ri = FT(0),
         ),
         up = ntuple(i -> cent_aux_vars_up(FT), n_up),
         en = (;
+            w = FT(0),
             area = FT(0),
             q_tot = FT(0),
             q_liq = FT(0),
@@ -138,6 +140,8 @@ cent_aux_vars_edmf(FT, n_up) = (;
         KH = FT(0),
         mixing_length = FT(0),
         θ_virt = FT(0),
+        ∇ρ_ae_K∇ϕ = FT(0),
+        ρaew_en_ϕ = FT(0),
     ),
 )
 cent_aux_vars(FT, n_up) = (; aux_vars_ref_state(FT)..., cent_aux_vars_gm(FT)..., cent_aux_vars_edmf(FT, n_up)...)
@@ -151,6 +155,8 @@ face_aux_vars_edmf(FT, n_up) = (;
         bulk = (; w = FT(0)),
         ρ_ae_KM = FT(0),
         ρ_ae_KH = FT(0),
+        ρ_ae_K = FT(0),
+        ρ_ae_K∇ϕ = FT(0),
         en = (; w = FT(0)),
         up = ntuple(i -> face_aux_vars_up(FT), n_up),
     ),

--- a/src/Surface.jl
+++ b/src/Surface.jl
@@ -5,7 +5,7 @@
 function free_convection_windspeed(surf::SurfaceBase, grid, state, gm::GridMeanVariables, param_set, ::BaseCase)
     prog_gm = center_prog_grid_mean(state)
     aux_tc = center_aux_turbconv(state)
-    zi = get_inversion(param_set, aux_tc.θ_virt, prog_gm.u, prog_gm.v, grid, surf.Ri_bulk_crit)
+    zi = get_inversion(grid, state, param_set, surf.Ri_bulk_crit)
     wstar = get_wstar(surf.bflux, zi) # yair here zi in TRMM should be adjusted
     surf.windspeed = sqrt(surf.windspeed * surf.windspeed + (1.2 * wstar) * (1.2 * wstar))
     return

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -839,15 +839,15 @@ function compute_en_tendencies!(edmf, grid::Grid, state, param_set, TS, covar_sy
     covar = getproperty(aux_en, covar_sym)
     aux_covar = getproperty(aux_en_2m, covar_sym)
     aux_up = center_aux_updrafts(state)
-    w_en = face_aux_environment(state).w
-    w_en_c = center_field(grid)
+    w_en_f = face_aux_environment(state).w
+    w_en = center_aux_environment(state).w
     c_d = CPEDMF.c_d(param_set)
     is_tke = covar_sym == :tke
 
 
-    ρ_ae_K = face_field(grid)
-    ρ_ae_K∇ϕ = face_field(grid)
-    ∇ρ_ae_K∇ϕ = center_field(grid)
+    ρ_ae_K = face_aux_turbconv(state).ρ_ae_K
+    ρ_ae_K∇ϕ = face_aux_turbconv(state).ρ_ae_K∇ϕ
+    ∇ρ_ae_K∇ϕ = center_aux_turbconv(state).∇ρ_ae_K∇ϕ
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
     aux_tc = center_aux_turbconv(state)
@@ -872,12 +872,12 @@ function compute_en_tendencies!(edmf, grid::Grid, state, param_set, TS, covar_sy
     pressure_plume_spacing = edmf.pressure_plume_spacing
     entr_sc = edmf.entr_sc
 
-    ρaew_en_ϕ = center_field(grid)
+    ρaew_en_ϕ = center_aux_turbconv(state).ρaew_en_ϕ
     FT = eltype(grid)
 
     @inbounds for k in real_center_indices(grid)
-        w_en_c[k] = interpf2c(w_en, grid, k)
-        ρaew_en_ϕ[k] = ρ0_c[k] * aux_en.area[k] * w_en_c[k] * covar[k]
+        w_en[k] = interpf2c(w_en_f, grid, k)
+        ρaew_en_ϕ[k] = ρ0_c[k] * aux_en.area[k] * w_en[k] * covar[k]
     end
 
     kc_surf = kc_surface(grid)

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -219,7 +219,7 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
     #! format: on
 
     # TODO - use this inversion in free_convection_windspeed and not compute zi twice
-    edmf.zi = get_inversion(param_set, aux_tc.θ_virt, prog_gm.u, prog_gm.v, grid, surface.Ri_bulk_crit)
+    edmf.zi = get_inversion(grid, state, param_set, surface.Ri_bulk_crit)
 
     update_surface(Case, grid, state, gm, TS, param_set)
     update_forcing(Case, grid, state, gm, TS, param_set)


### PR DESCRIPTION
This PR converts some variables to ClimaCore fields in the aux state, so that they're not dynamically allocated during tendency evaluations.