### PR TITLE
Time runs, which should be, ideally, non-allocating

### DIFF
--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -16,7 +16,7 @@ case_name = "ARM_SGP"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -16,7 +16,7 @@ case_name = "Bomex"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -16,7 +16,7 @@ case_name = "DYCOMS_RF01"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/DryBubble.jl
+++ b/integration_tests/DryBubble.jl
@@ -16,7 +16,7 @@ case_name = "DryBubble"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse =
     compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 900, t_stop = 1000)

--- a/integration_tests/GABLS.jl
+++ b/integration_tests/GABLS.jl
@@ -16,7 +16,7 @@ case_name = "GABLS"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/GATE_III.jl
+++ b/integration_tests/GATE_III.jl
@@ -12,6 +12,6 @@ import .NameList
 println("Running GATE_III...")
 namelist = default_namelist("GATE_III")
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 @testset "GATE_III" begin end

--- a/integration_tests/LES_driven_SCM.jl
+++ b/integration_tests/LES_driven_SCM.jl
@@ -16,7 +16,7 @@ case_name = "LES_driven_SCM"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Nieuwstadt.jl
+++ b/integration_tests/Nieuwstadt.jl
@@ -16,7 +16,7 @@ case_name = "Nieuwstadt"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -16,7 +16,7 @@ case_name = "Rico"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/SP.jl
+++ b/integration_tests/SP.jl
@@ -16,7 +16,7 @@ case_name = "SP"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse =
     compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 0, t_stop = 2 * 3600)

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -16,7 +16,7 @@ case_name = "Soares"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -16,7 +16,7 @@ case_name = "TRMM_LBA"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/life_cycle_Tan2018.jl
+++ b/integration_tests/life_cycle_Tan2018.jl
@@ -16,7 +16,7 @@ case_name = "life_cycle_Tan2018"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist)
+ds_tc_filename = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
     println("Running $case_name...")
     namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
-    ds_tc_filename = @time main(namelist)
+    ds_tc_filename = @time main(namelist; time_run = true)
 
     computed_mse = compute_mse_wrapper(
         case_name,


### PR DESCRIPTION
This PR adds the `@time` macro to the call to `run`, which should hopefully be non-allocating. This should make it easier to monitor allocations as we start to move all allocations outside of the tendency computation function.