### PR TITLE
Cleanup unused methods

### DIFF
--- a/integration_tests/utils/Cases.jl
+++ b/integration_tests/utils/Cases.jl
@@ -908,7 +908,7 @@ function initialize_forcing(self::CasesBase{TRMM_LBA}, grid::Grid, state, gm, pa
     end...)
     A = A'
 
-    self.rad = zeros(size(A, 1), length(TC.center_field(grid)))
+    self.rad = zeros(size(A, 1), grid.nz)
     self.rad .= A # store matrix in self
     ind1 = Int(trunc(10.0 / 600.0)) + 1
     ind2 = Int(ceil(10.0 / 600.0))

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -1,12 +1,3 @@
-
-function center_field(grid::Grid)
-    return zeros(grid.nz)
-end
-
-function center_field(grid::Grid, nu::Int)
-    return zeros(nu, grid.nz)
-end
-
 # A complementary struct to ClimaCore's `PlusHalf` type.
 struct Cent{I <: Integer}
     i::I

--- a/src/types.jl
+++ b/src/types.jl
@@ -557,7 +557,4 @@ mutable struct EDMF_PrognosticTKE{A1}
         )
     end
 end
-diffusivity_m(edmf::EDMF_PrognosticTKE) = edmf.KM
-diffusivity_h(edmf::EDMF_PrognosticTKE) = edmf.KH
-Ri_bulk_crit(edmf::EDMF_PrognosticTKE) = edmf.Ri_bulk_crit
 parameter_set(obj) = obj.param_set


### PR DESCRIPTION
We can now get rid of `center_field`! 🎉  ~This PR also removes get/set index support for the face-`k` indices (since they're no longer used), so that nobody can accidentally put them back in.~ We can't get rid of that support yet, since we still grab data from arrays in some surface routines.