### PR TITLE
Change update interface, rename to step

### DIFF
--- a/perf/common.jl
+++ b/perf/common.jl
@@ -13,8 +13,14 @@ TurbulenceConvection.io(sim::Simulation1d) = nothing
 update_n(sim, N::Int) = update_n(sim, Val(N))
 
 function update_n(sim, ::Val{N}) where {N}
+    grid = sim.grid
+    TS = sim.TS
+    prog = sim.state.prog
+    aux = sim.state.aux
+    tendencies = sim.state.tendencies
+    params = (; edmf = sim.Turb, grid = grid, gm = sim.GMV, case = sim.Case, TS = TS, aux = aux)
     for i in 1:N
-        TC.update(sim.Turb, sim.grid, sim.state, sim.GMV, sim.Case, sim.TS)
+        TC.step!(tendencies, prog, params, TS.t)
     end
     return nothing
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -565,3 +565,9 @@ mutable struct EDMF_PrognosticTKE{N_up, A1}
     end
 end
 parameter_set(obj) = obj.param_set
+
+struct State{P, A, T}
+    prog::P
+    aux::A
+    tendencies::T
+end


### PR DESCRIPTION
This is a prep PR for #473. This PR
 - renames `update` to `step!`
 - Changes the `step!` interface to be compatible with OrdinaryDiffEq.jl
 - Moves the `State` definition into TC.jl `src/`, so that we can pass its properties into a local struct and continue using the dycore API