### PR TITLE
Make diag dict field entry a state-accepting func

### DIFF
--- a/diagnostics/compute_diagnostics.jl
+++ b/diagnostics/compute_diagnostics.jl
@@ -21,19 +21,19 @@ are not required to compute in order to run a simulation.
 =#
 
 #! format: off
-function io_dictionary_diagnostics(diagnostics)
+function io_dictionary_diagnostics()
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
-        "nh_pressure" => (; dims = ("zf", "t"), group = "profiles", field = face_diagnostics_turbconv(diagnostics).nh_pressure),
-        "nh_pressure_adv" => (; dims = ("zf", "t"), group = "profiles", field = face_diagnostics_turbconv(diagnostics).nh_pressure_adv,),
-        "nh_pressure_drag" => (; dims = ("zf", "t"), group = "profiles", field = face_diagnostics_turbconv(diagnostics).nh_pressure_drag,),
-        "nh_pressure_b" => (; dims = ("zf", "t"), group = "profiles", field = face_diagnostics_turbconv(diagnostics).nh_pressure_b,),
-        "turbulent_entrainment" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).frac_turb_entr,),
-        "horiz_K_eddy" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).horiz_K_eddy,),
-        "entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).entr_sc),
-        "detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).detr_sc),
-        "asp_ratio" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).asp_ratio),
-        "massflux" => (; dims = ("zc", "t"), group = "profiles", field = center_diagnostics_turbconv(diagnostics).massflux),
+        "nh_pressure" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure),
+        "nh_pressure_adv" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_adv,),
+        "nh_pressure_drag" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_drag,),
+        "nh_pressure_b" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_b,),
+        "turbulent_entrainment" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).frac_turb_entr,),
+        "horiz_K_eddy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).horiz_K_eddy,),
+        "entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).entr_sc),
+        "detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).detr_sc),
+        "asp_ratio" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).asp_ratio),
+        "massflux" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).massflux),
     )
     return io_dict
 end

--- a/docs/src/PlotReferenceStates.jl
+++ b/docs/src/PlotReferenceStates.jl
@@ -31,9 +31,9 @@ function export_ref_profile(case_name::String)
 
     TC.compute_ref_state!(state, grid, param_set; ref_params...)
 
-    io_nt = TC.io_dictionary_ref_state(state)
+    io_nt = TC.io_dictionary_ref_state()
     TC.initialize_io(io_nt, Stats)
-    TC.io(io_nt, Stats)
+    TC.io(io_nt, Stats, state)
 
     NCDatasets.Dataset(joinpath(Stats.path_plus_file), "r") do ds
         zc = ds.group["profiles"]["zc"][:]

--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -309,9 +309,9 @@ function Simulation1d(namelist)
     TC.compute_ref_state!(state, grid, param_set; ref_params...)
 
     io_nt = (;
-        ref_state = TC.io_dictionary_ref_state(state),
-        aux = TC.io_dictionary_aux(state),
-        diagnostics = io_dictionary_diagnostics(diagnostics),
+        ref_state = TC.io_dictionary_ref_state(),
+        aux = TC.io_dictionary_aux(),
+        diagnostics = io_dictionary_diagnostics(),
     )
 
     return Simulation1d(io_nt, grid, state, GMV, Case, Turb, diagnostics, TS, Stats, param_set, skip_io)
@@ -367,8 +367,8 @@ function run(sim::Simulation1d)
             # TurbulenceConvection.io(sim) # #removeVarsHack
             TC.write_simulation_time(sim.Stats, TS.t) # #removeVarsHack
 
-            TC.io(sim.io_nt.diagnostics, sim.Stats)
-            TC.io(sim.io_nt.aux, sim.Stats)
+            TC.io(sim.io_nt.diagnostics, sim.Stats, diagnostics)
+            TC.io(sim.io_nt.aux, sim.Stats, state)
 
             TC.io(sim.GMV, grid, state, sim.Stats) # #removeVarsHack
             TC.io(sim.Case, grid, state, sim.Stats) # #removeVarsHack
@@ -384,7 +384,7 @@ function TurbulenceConvection.initialize_io(sim::Simulation1d)
     sim.skip_io && return nothing
     TC = TurbulenceConvection
     TC.initialize_io(sim.io_nt.ref_state, sim.Stats)
-    TC.io(sim.io_nt.ref_state, sim.Stats) # since the reference prog is static
+    TC.io(sim.io_nt.ref_state, sim.Stats, sim.state) # since the reference prog is static
 
     TC.initialize_io(sim.io_nt.aux, sim.Stats)
     TC.initialize_io(sim.io_nt.diagnostics, sim.Stats)
@@ -402,8 +402,8 @@ function TurbulenceConvection.io(sim::Simulation1d)
     TC.open_files(sim.Stats)
     TC.write_simulation_time(sim.Stats, sim.TS.t)
 
-    TC.io(sim.io_nt.aux, sim.Stats)
-    TC.io(sim.io_nt.diagnostics, sim.Stats)
+    TC.io(sim.io_nt.aux, sim.Stats, sim.state)
+    TC.io(sim.io_nt.diagnostics, sim.Stats, sim.diagnostics)
 
     # TODO: depricate
     TC.io(sim.GMV, sim.grid, sim.state, sim.Stats)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -13,124 +13,124 @@ These functions return a dictionary whose
     - `group` (`"reference"` or `"profiles"`)
 =#
 
-function io_dictionary_ref_state(state)
+function io_dictionary_ref_state()
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String}, String, Any}}
     cent_ref_state = center_ref_state # so that things nicely align :)
     io_dict = Dict{String, DT}(
-        "ρ0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(state).ρ0),
-        "ρ0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(state).ρ0),
-        "p0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(state).p0),
-        "p0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(state).p0),
-        "α0_f" => (; dims = ("zf",), group = "reference", field = face_ref_state(state).α0),
-        "α0_c" => (; dims = ("zc",), group = "reference", field = cent_ref_state(state).α0),
+        "ρ0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).ρ0),
+        "ρ0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).ρ0),
+        "p0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).p0),
+        "p0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).p0),
+        "α0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).α0),
+        "α0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).α0),
     )
     return io_dict
 end
 
 #! format: off
 # TODO: use a better name, this exports fields from the prognostic state, and the aux state.
-function io_dictionary_aux(state)
+function io_dictionary_aux()
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
-        "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).area),
-        "updraft_ql" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).q_liq),
-        "updraft_RH" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).RH),
-        "updraft_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).q_tot),
-        "updraft_w" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_bulk(state).w),
-        "updraft_temperature" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).T),
-        "updraft_thetal" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).θ_liq_ice),
-        "updraft_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).buoy),
-        "H_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).H_third_m),
-        "W_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).W_third_m),
-        "QT_third_m" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).H_third_m),
-        "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
-        "buoyancy_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).buoy),
-        "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).T),
-        "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).RH),
-        "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).s),
-        "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).q_liq),
-        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).q_ice),
-        "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).tke),
-        "Hvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).Hvar),
-        "QTvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).QTvar),
-        "HQTcov_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).HQTcov),
-        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).u),
-        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).v),
-        "w_mean" => (; dims = ("zf", "t"), group = "profiles", field = face_prog_grid_mean(state).w),
-        "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).q_tot),
-        "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_grid_mean(state).θ_liq_ice),
-        "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).KM),
-        "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).KH),
-        "env_tke" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).tke),
-        "env_Hvar" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).Hvar),
-        "env_QTvar" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).QTvar),
-        "env_HQTcov" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).HQTcov),
+        "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).area),
+        "updraft_ql" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).q_liq),
+        "updraft_RH" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).RH),
+        "updraft_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).q_tot),
+        "updraft_w" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_bulk(state).w),
+        "updraft_temperature" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).T),
+        "updraft_thetal" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).θ_liq_ice),
+        "updraft_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).buoy),
+        "H_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).H_third_m),
+        "W_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).W_third_m),
+        "QT_third_m" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).H_third_m),
+        "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
+        "buoyancy_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).buoy),
+        "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
+        "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
+        "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
+        "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),
+        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
+        "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
+        "Hvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).Hvar),
+        "QTvar_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).QTvar),
+        "HQTcov_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).HQTcov),
+        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).u),
+        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).v),
+        "w_mean" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_prog_grid_mean(state).w),
+        "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).q_tot),
+        "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).θ_liq_ice),
+        "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KM),
+        "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KH),
+        "env_tke" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).tke),
+        "env_Hvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).Hvar),
+        "env_QTvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).QTvar),
+        "env_HQTcov" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).HQTcov),
 
-        "tke_buoy" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.buoy),
-        "tke_pressure" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.press),
-        "tke_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.dissipation),
-        "tke_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.entr_gain),
-        "tke_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.detr_loss),
-        "tke_shear" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.shear),
-        "tke_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).tke.interdomain),
+        "tke_buoy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.buoy),
+        "tke_pressure" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.press),
+        "tke_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.dissipation),
+        "tke_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.entr_gain),
+        "tke_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.detr_loss),
+        "tke_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.shear),
+        "tke_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).tke.interdomain),
 
-        "Hvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.dissipation),
-        "Hvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.entr_gain),
-        "Hvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.detr_loss),
-        "Hvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.interdomain),
-        "Hvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.rain_src),
-        "Hvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).Hvar.shear),
+        "Hvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.dissipation),
+        "Hvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.entr_gain),
+        "Hvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.detr_loss),
+        "Hvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.interdomain),
+        "Hvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.rain_src),
+        "Hvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).Hvar.shear),
 
-        "QTvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.dissipation),
-        "QTvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.entr_gain),
-        "QTvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.detr_loss),
-        "QTvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.shear),
-        "QTvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.rain_src),
-        "QTvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).QTvar.interdomain),
+        "QTvar_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.dissipation),
+        "QTvar_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.entr_gain),
+        "QTvar_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.detr_loss),
+        "QTvar_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.shear),
+        "QTvar_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.rain_src),
+        "QTvar_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).QTvar.interdomain),
 
-        "HQTcov_rain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.rain_src),
-        "HQTcov_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.dissipation),
-        "HQTcov_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.entr_gain),
-        "HQTcov_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.detr_loss),
-        "HQTcov_shear" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.shear),
-        "HQTcov_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment_2m(state).HQTcov.interdomain),
+        "HQTcov_rain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.rain_src),
+        "HQTcov_dissipation" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.dissipation),
+        "HQTcov_entr_gain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.entr_gain),
+        "HQTcov_detr_loss" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.detr_loss),
+        "HQTcov_shear" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.shear),
+        "HQTcov_interdomain" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment_2m(state).HQTcov.interdomain),
 
-        "env_w" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_environment(state).w),
-        "env_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).q_tot),
-        "env_ql" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).q_liq),
-        "env_area" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).area),
-        "env_temperature" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).T),
-        "env_RH" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).RH),
-        "env_thetal" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).θ_liq_ice),
-        "env_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_environment(state).cloud_fraction),
-        "massflux_s" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_grid_mean(state).massflux_s),
-        "diffusive_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_grid_mean(state).diffusive_flux_s),
-        "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
+        "env_w" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_environment(state).w),
+        "env_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).q_tot),
+        "env_ql" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).q_liq),
+        "env_area" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).area),
+        "env_temperature" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).T),
+        "env_RH" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).RH),
+        "env_thetal" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).θ_liq_ice),
+        "env_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).cloud_fraction),
+        "massflux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s),
+        "diffusive_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).diffusive_flux_s),
+        "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
 
-        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_precipitation(state).q_rai),
-        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = center_prog_precipitation(state).q_sno),
+        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
 
-        "mixing_length" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).mixing_length),
+        "mixing_length" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).mixing_length),
 
-        "updraft_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).cloud_fraction),
+        "updraft_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).cloud_fraction),
 
-        "updraft_qt_precip" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).qt_tendency_precip_formation),
-        "updraft_thetal_precip" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_bulk(state).θ_liq_ice_tendency_precip_formation),
+        "updraft_qt_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).qt_tendency_precip_formation),
+        "updraft_thetal_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).θ_liq_ice_tendency_precip_formation),
 
-        "massflux_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).massflux_tendency_h),
-        "massflux_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).massflux_tendency_qt),
-        "diffusive_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).diffusive_tendency_h),
-        "diffusive_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).diffusive_tendency_qt),
+        "massflux_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_h),
+        "massflux_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_qt),
+        "diffusive_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).diffusive_tendency_h),
+        "diffusive_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).diffusive_tendency_qt),
 
-        "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
-        "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
+        "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
+        "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
 
-        "ed_length_scheme" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).mls),
-        "mixing_length_ratio" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).ml_ratio),
-        "entdet_balance_length" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_turbconv(state).l_entdet),
+        "ed_length_scheme" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).mls),
+        "mixing_length_ratio" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).ml_ratio),
+        "entdet_balance_length" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).l_entdet),
 
-        "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = center_aux_grid_mean(state).dTdt_rad),
-        "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = face_aux_grid_mean(state).f_rad),
+        "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).dTdt_rad),
+        "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).f_rad),
 
     )
     return io_dict
@@ -143,8 +143,8 @@ function initialize_io(io_dict::Dict, Stats::NetCDFIO_Stats)
     end
 end
 
-function io(io_dict::Dict, Stats::NetCDFIO_Stats)
+function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
     for var in keys(io_dict)
-        write_field(Stats, var, io_dict[var].field; group = io_dict[var].group)
+        write_field(Stats, var, io_dict[var].field(state); group = io_dict[var].group)
     end
 end


### PR DESCRIPTION
This is a peel-off from #473. Basically, this PR changes the diagnostics dict field entry from a reference to the input state to a function that accepts the state. As a result, `io_dictionary_diagnostics`,`io_dictionary_aux`, etc. do not need the input state, and the dict acts in a more functional way.