### PR TITLE
Add masked operators, remove vanish sd grad

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -214,7 +214,7 @@ face_aux_vars_edmf(FT, n_up) = (;
         ρ_ae_KH = FT(0),
         ρ_ae_K = FT(0),
         ρ_ae_K∇ϕ = FT(0),
-        en = (; w = FT(0), sat = (; θ_liq_ice = FT(0), q_tot = FT(0)), unsat = (; θ_virt = FT(0))),
+        en = (; w = FT(0)),
         up = ntuple(i -> face_aux_vars_up(FT), n_up),
         massflux_h = FT(0),
         massflux_qt = FT(0),

--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -184,6 +184,9 @@ cent_aux_vars_edmf(FT, n_up) = (;
         ∂θv∂z = FT(0),
         ∂qt∂z = FT(0),
         ∂θl∂z = FT(0),
+        ∂θv∂z_unsat = FT(0),
+        ∂qt∂z_sat = FT(0),
+        ∂θl∂z_sat = FT(0),
         l_entdet = FT(0),
         ϕ_gm = FT(0), # temporary for grid-mean variables
         ϕ_gm_cov = FT(0), # temporary for grid-mean covariance variables
@@ -211,7 +214,7 @@ face_aux_vars_edmf(FT, n_up) = (;
         ρ_ae_KH = FT(0),
         ρ_ae_K = FT(0),
         ρ_ae_K∇ϕ = FT(0),
-        en = (; w = FT(0)),
+        en = (; w = FT(0), sat = (; θ_liq_ice = FT(0), q_tot = FT(0)), unsat = (; θ_virt = FT(0))),
         up = ntuple(i -> face_aux_vars_up(FT), n_up),
         massflux_h = FT(0),
         massflux_qt = FT(0),

--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -463,25 +463,6 @@ mask = Bool[0, 0, 0, 1, 1, 1, 0, 0, 1, 1]
 shrunken_mask = Bool[0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
 @test shrink_mask(mask) == shrunken_mask
 ```
-
-Here is some pseudo code to demo how this is intended
-to be used in practice:
-```julia
-# mask ∈ cell center
-# sm ∈ cell center field
-# θc ∈ cell center field
-# θf ∈ cell face field
-# ∇θdefault ∈ cell center field (representing the default gradient outside valid subdomains)
-
-import ClimaCore as CC
-import ClimaCore.Operators as CCO
-If = CCO.InterpolateC2F(; bottom = CCO.Extrapolate(), top = CCO.Extrapolate())
-∇c = CCO.DivergenceF2C()
-wvec = CC.Geometry.WVector
-@. sm .= shrink_mask(vec(mask))
-@. θf = If(θc)
-@. ∇θc = ∇c(θf) * sm + (1 - sm) * ∇θdefault
-```
 """
 function shrink_mask(mask)
     return map(enumerate(mask)) do (i, m)

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -366,14 +366,14 @@ function update_aux!(edmf, gm, grid, state, Case, param_set, TS)
 
     # Since NaN*0 ≠ 0, we need to conditionally replace
     # our gradients by their default values.
-    @. ∂qt∂z_sat_new = ∇c(wvec(If(aux_en_sat.q_tot)))
-    @. ∂θl∂z_sat_new = ∇c(wvec(If(aux_en_sat.θ_liq_ice)))
-    @. ∂θv∂z_unsat_new = ∇c(wvec(If(aux_en_unsat.θ_virt)))
+    @. ∂qt∂z_sat = ∇c(wvec(If(aux_en_sat.q_tot)))
+    @. ∂θl∂z_sat = ∇c(wvec(If(aux_en_sat.θ_liq_ice)))
+    @. ∂θv∂z_unsat = ∇c(wvec(If(aux_en_unsat.θ_virt)))
     for k in real_center_indices(grid)
         if shm[k] == 0
-            ∂qt∂z_sat_new[k] = ∂qt∂z[k]
-            ∂θl∂z_sat_new[k] = ∂θl∂z[k]
-            ∂θv∂z_unsat_new[k] = ∂θv∂z[k]
+            ∂qt∂z_sat[k] = ∂qt∂z[k]
+            ∂θl∂z_sat[k] = ∂θl∂z[k]
+            ∂θv∂z_unsat[k] = ∂θv∂z[k]
         end
     end
 

--- a/test/clima_core_extensions.jl
+++ b/test/clima_core_extensions.jl
@@ -40,4 +40,3 @@ for k in TC.real_face_indices(grid)
         @test_throws ErrorException state.cent.turbconv.up[i].Area[k] = 2
     end
 end
-

--- a/test/clima_core_extensions.jl
+++ b/test/clima_core_extensions.jl
@@ -41,11 +41,3 @@ for k in TC.real_face_indices(grid)
     end
 end
 
-@testset "Submask iterator" begin
-    mask = Bool[0, 0, 0, 1, 1, 1, 0, 0, 1, 1]
-
-    sm = collect(TC.SubMasks(mask))
-
-    @test sm[1] == 4:6
-    @test sm[2] == 9:10
-end

--- a/test/clima_core_extensions.jl
+++ b/test/clima_core_extensions.jl
@@ -40,3 +40,12 @@ for k in TC.real_face_indices(grid)
         @test_throws ErrorException state.cent.turbconv.up[i].Area[k] = 2
     end
 end
+
+@testset "Submask iterator" begin
+    mask = Bool[0, 0, 0, 1, 1, 1, 0, 0, 1, 1]
+
+    sm = collect(TC.SubMasks(mask))
+
+    @test sm[1] == 4:6
+    @test sm[2] == 9:10
+end


### PR DESCRIPTION
This PR removes the `c∇_vanishing_subdomain` operators and adds `masked_interpolate!` which, together with ClimaCore operators, can serve the same purpose.

This was the quick and dirty way to use the existing infrastructure, but it's certainly not performant, and needs to be revisited.