### PR TITLE
Use more ClimaCore operators

### DIFF
--- a/integration_tests/utils/main.jl
+++ b/integration_tests/utils/main.jl
@@ -122,6 +122,7 @@ cent_aux_vars_edmf(FT, n_up) = (;
             θ_liq_ice_tendency_precip_formation = FT(0),
             qt_tendency_precip_formation = FT(0),
             Ri = FT(0),
+            D_env = FT(0),
         ),
         up = ntuple(i -> cent_aux_vars_up(FT), n_up),
         en = (;


### PR DESCRIPTION
This PR replaces the use of in-house operators with ClimaCore operators. This should make it easier to refactor the subsequent lines that use `ccut_downwind` and `c∇_downwind`.