### PR TITLE
Error on aborted simulations after solution export

### DIFF
--- a/integration_tests/ARM_SGP.jl
+++ b/integration_tests/ARM_SGP.jl
@@ -16,7 +16,7 @@ case_name = "ARM_SGP"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Bomex.jl
+++ b/integration_tests/Bomex.jl
@@ -16,7 +16,7 @@ case_name = "Bomex"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/DYCOMS_RF01.jl
+++ b/integration_tests/DYCOMS_RF01.jl
@@ -16,7 +16,7 @@ case_name = "DYCOMS_RF01"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/DryBubble.jl
+++ b/integration_tests/DryBubble.jl
@@ -16,7 +16,7 @@ case_name = "DryBubble"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse =
     compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 900, t_stop = 1000)

--- a/integration_tests/GABLS.jl
+++ b/integration_tests/GABLS.jl
@@ -16,7 +16,7 @@ case_name = "GABLS"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/GATE_III.jl
+++ b/integration_tests/GATE_III.jl
@@ -12,7 +12,7 @@ import .NameList
 println("Running GATE_III...")
 namelist = default_namelist("GATE_III")
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 @testset "GATE_III" begin end
 

--- a/integration_tests/LES_driven_SCM.jl
+++ b/integration_tests/LES_driven_SCM.jl
@@ -16,7 +16,7 @@ case_name = "LES_driven_SCM"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Nieuwstadt.jl
+++ b/integration_tests/Nieuwstadt.jl
@@ -16,7 +16,7 @@ case_name = "Nieuwstadt"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/Rico.jl
+++ b/integration_tests/Rico.jl
@@ -16,7 +16,7 @@ case_name = "Rico"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/SP.jl
+++ b/integration_tests/SP.jl
@@ -16,7 +16,7 @@ case_name = "SP"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse =
     compute_mse_wrapper(case_name, best_mse, ds_tc_filename; plot_comparison = true, t_start = 0, t_stop = 2 * 3600)

--- a/integration_tests/Soares.jl
+++ b/integration_tests/Soares.jl
@@ -16,7 +16,7 @@ case_name = "Soares"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/TRMM_LBA.jl
+++ b/integration_tests/TRMM_LBA.jl
@@ -16,7 +16,7 @@ case_name = "TRMM_LBA"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/life_cycle_Tan2018.jl
+++ b/integration_tests/life_cycle_Tan2018.jl
@@ -16,7 +16,7 @@ case_name = "life_cycle_Tan2018"
 println("Running $case_name...")
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01"
-ds_tc_filename = @time main(namelist; time_run = true)
+ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
 computed_mse = compute_mse_wrapper(
     case_name,

--- a/integration_tests/utils/post_run_tests.jl
+++ b/integration_tests/utils/post_run_tests.jl
@@ -20,3 +20,10 @@
     end
     nothing
 end
+
+@testset "Simulation completion" begin
+    # Test that the simulation has actually finished,
+    # and not aborted early.
+    @test !(return_code == :simulation_aborted)
+    @test return_code == :success
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
     println("Running $case_name...")
     namelist = NameList.default_namelist(case_name)
     namelist["meta"]["uuid"] = "01"
-    ds_tc_filename = @time main(namelist; time_run = true)
+    ds_tc_filename, return_code = @time main(namelist; time_run = true)
 
     computed_mse = compute_mse_wrapper(
         case_name,


### PR DESCRIPTION
This PR moves the error on early aborted simulations to _after_ the solution is exported. This way we can more easily look at the solution / data to see what went wrong. [Discussed here](https://github.com/CliMA/TurbulenceConvection.jl/issues/574#issuecomment-972920070).

I'm hoping that this will shed light on #577.