### PR TITLE
Add changelog to TagBot GHA

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -13,3 +13,55 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          changelog: |
+            ## {{ package }} {{ version }}
+            {% if previous_release %}
+            [Diff since {{ previous_release }}]({{ compare_url }})
+            {% endif %}
+            {% if custom %}
+            {{ custom }}
+            {% endif %}
+            ### 📢 API Changes:
+            {% if issues %}
+            {% for issue in issues if 'API' in issue.labels %}
+            - {{ issue.title }} (#{{ issue.number }})
+            {% endfor %}
+            {% endif %}
+            {% if pulls %}
+            {% for pull in pulls if 'API' in pull.labels %}
+            - {{ pull.title }} (#{{ pull.number }}) (@{{ pull.author.username }})
+            {% endfor %}
+            {% endif %}
+            ### 🚀 Features
+            {% if issues %}
+            {% for issue in issues if 'enhancement' in issue.labels or 'feature' in issue.labels %}
+            - {{ issue.title }} (#{{ issue.number }})
+            {% endfor %}
+            {% endif %}
+            {% if pulls %}
+            {% for pull in pulls if 'enhancement' in pull.labels or 'feature' in pull.labels %}
+            - {{ pull.title }} (#{{ pull.number }}) (@{{ pull.author.username }})
+            {% endfor %}
+            {% endif %}
+            ### 📑 Documentation
+            {% if issues %}
+            {% for issue in issues if 'documentation' in issue.labels %}
+            - {{ issue.title }} (#{{ issue.number }})
+            {% endfor %}
+            {% endif %}
+            {% if pulls %}
+            {% for pull in pulls if 'documentation' in pull.labels %}
+            - {{ pull.title }} (#{{ pull.number }}) (@{{ pull.author.username }})
+            {% endfor %}
+            {% endif %}
+            ### 🐛 Fixes
+            {% if issues %}
+            {% for issue in issues if 'bug' in issue.labels or 'bugfix' in issue.labels %}
+            - {{ issue.title }} (#{{ issue.number }})
+            {% endfor %}
+            {% endif %}
+            {% if pulls %}
+            {% for pull in pulls if 'bug' in pull.labels or 'bugfix' in pull.labels %}
+            - {{ pull.title }} (#{{ pull.number }}) (@{{ pull.author.username }})
+            {% endfor %}
+            {% endif %}


### PR DESCRIPTION
This PR adds a changelog to the tagbot, so that we don't need to manually go through the PRs for the release notes. I'm not sure if the strings need an exact match or not (e.g., `'bug' in in issue.labels`, where the label may be `bug :bug:`).