### PR TITLE
Add exhaustive allocation tracking job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -167,6 +167,17 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: ":rocket: Allocations analysis (exhaustive)"
+    key: "cpu_allocations_exhaustive"
+    command:
+      - "julia --color=yes --project=test perf/allocs.jl exhaustive=true"
+    artifact_paths:
+      - "perf/allocations_output_exhaustive/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: ":rocket: Benchmark tendencies"
     key: "cpu_tendencies"
     command:

--- a/perf/alloc_per_case_with_init_io.jl
+++ b/perf/alloc_per_case_with_init_io.jl
@@ -1,0 +1,21 @@
+# Launch with `julia --project --track-allocation=user`
+if !("." in LOAD_PATH)
+    push!(LOAD_PATH, ".")
+end
+import Profile
+
+include("common.jl")
+case_name = ENV["ALLOCATION_CASE_NAME"]
+@info "Recording allocations for $case_name"
+namelist = NameList.default_namelist(case_name)
+namelist["time_stepping"]["t_max"] = 10800.0 # run for shorter time
+
+main(namelist) # compile first
+Profile.clear_malloc_data()
+main(namelist)
+
+# Quit julia (which generates .mem files), then call
+#=
+import Coverage
+allocs = Coverage.analyze_malloc("src")
+=#

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -1,3 +1,6 @@
+if !("." in LOAD_PATH)
+    push!(LOAD_PATH, ".")
+end
 import TurbulenceConvection
 const TC = TurbulenceConvection
 


### PR DESCRIPTION
This PR adds a job that more exhaustively tracks allocations (in TC.jl, and all of its _direct_ dependencies) for a shortened simulation.