### PR TITLE
fix: convert namelist arrays to SVector

### DIFF
--- a/driver/main.jl
+++ b/driver/main.jl
@@ -18,6 +18,7 @@ import SciMLBase
 
 import OrdinaryDiffEq
 const ODE = OrdinaryDiffEq
+import StaticArrays: SVector
 
 const tc_dir = dirname(dirname(pathof(TurbulenceConvection)))
 
@@ -605,6 +606,9 @@ nc_results_file(stats::TC.NetCDFIO_Stats) = stats.path_plus_file
 nc_results_file(::Nothing) = @info "The simulation was run without IO, so no nc files were exported"
 
 function main1d(namelist; time_run = true)
+    # TODO: generalize convesion of arrays from namelist to `SVector`s.
+    _p = namelist["turbulence"]["EDMF_PrognosticTKE"]["general_ent_params"]
+    namelist["turbulence"]["EDMF_PrognosticTKE"]["general_ent_params"] = SVector{length(_p)}(_p)
     sim = Simulation1d(namelist)
     TurbulenceConvection.initialize(sim, namelist)
     if time_run


### PR DESCRIPTION
quick-fix to convert the `general_ent_params` parameter to an SVector after being read from file. This is required for the `isbits` check in parameter_set.jl:L89 to succeed:
https://github.com/CliMA/TurbulenceConvection.jl/blob/2bc91f6b63c4de7919827040cb74cb58633d16db/driver/parameter_set.jl#L88-L93

The PR fixes an issue where TC.jl will error if run from terminal since reading of lists in the namelist file is converted to a general Array, not a static SVector.

fixes a bug introduced in #635.