### PR TITLE
End updraft top search when no updraft is found.

### DIFF
--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -511,6 +511,8 @@ function update_aux!(edmf::EDMF_PrognosticTKE{N_up}, gm, grid, state, Case, para
         @inbounds for k in real_center_indices(grid)
             if aux_up[i].area[k] > 1e-3
                 up.updraft_top[i] = max(up.updraft_top[i], grid.zc[k])
+            else
+                break
             end
         end
     end


### PR DESCRIPTION
Since we might not want to put resources into changing grid traversal or search over the ClimaCore grid (#640), this should be an easy way to reduce unnecessary checks. We can end the search as soon as we hit a height with no updraft because updrafts are always defined from z_surface to some z, without reappearance above. This definition of updraft is consistent with our use of updraft height in the sub grid pressure closures.