### PR TITLE
Try stretched grids

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,6 +95,10 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --micro gaussian"
         artifact_paths: "Output.Bomex.01_gaussian/stats/comparison/*"
 
+      - label: ":partly_sunny: Bomex with stretched grid"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stretch_grid true"
+        artifact_paths: "Output.Bomex.01_stretch_grid_true/stats/comparison/*"
+
       - label: ":partly_sunny: Bomex with NN_nonlocal"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal"
         artifact_paths: "Output.Bomex.01_NN_nonlocal/stats/comparison/*"

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -142,6 +142,12 @@ function default_namelist(
     # From namelist
     namelist_defaults["grid"] = Dict()
     namelist_defaults["grid"]["dims"] = 1
+    namelist_defaults["grid"]["stretch"] = Dict()
+    namelist_defaults["grid"]["stretch"]["flag"] = false
+    namelist_defaults["grid"]["stretch"]["nz"] = 55
+    namelist_defaults["grid"]["stretch"]["dz_surf"] = 30.0
+    namelist_defaults["grid"]["stretch"]["dz_toa"] = 8000.0
+    namelist_defaults["grid"]["stretch"]["z_toa"] = 45000.0
 
     namelist_defaults["thermodynamics"] = Dict()
     namelist_defaults["thermodynamics"]["thermal_variable"] = "thetal"

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -72,18 +72,37 @@ function Simulation1d(namelist)
     cfl_limit = namelist["time_stepping"]["cfl_limit"]
     dt_min = namelist["time_stepping"]["dt_min"]
 
+    truncated_gcm_mesh = TC.parse_namelist(namelist, "grid", "stretch", "flag"; default = false)
+
     Δz = FT(namelist["grid"]["dz"])
     nz = namelist["grid"]["nz"]
     z₀, z₁ = FT(0), FT(nz * Δz)
-    domain = CC.Domains.IntervalDomain(
-        CC.Geometry.ZPoint{FT}(z₀),
-        CC.Geometry.ZPoint{FT}(z₁),
-        boundary_tags = (:bottom, :top),
-    )
-    mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
+    if truncated_gcm_mesh
+        nzₛ = namelist["grid"]["stretch"]["nz"]
+        Δzₛ_surf = FT(namelist["grid"]["stretch"]["dz_surf"])
+        Δzₛ_top = FT(namelist["grid"]["stretch"]["dz_toa"])
+        zₛ_toa = FT(namelist["grid"]["stretch"]["z_toa"])
+        stretch = CC.Meshes.GeneralizedExponentialStretching(Δzₛ_surf, Δzₛ_top)
+        domain = CC.Domains.IntervalDomain(
+            CC.Geometry.ZPoint{FT}(z₀),
+            CC.Geometry.ZPoint{FT}(zₛ_toa),
+            boundary_tags = (:bottom, :top),
+        )
+        gcm_mesh = CC.Meshes.IntervalMesh(domain, stretch; nelems = nzₛ)
+        mesh = TC.TCMeshFromGCMMesh(gcm_mesh; z_max = z₁)
+    else
+        CC.Meshes.Uniform()
+        domain = CC.Domains.IntervalDomain(
+            CC.Geometry.ZPoint{FT}(z₀),
+            CC.Geometry.ZPoint{FT}(z₁),
+            boundary_tags = (:bottom, :top),
+        )
+        mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
+    end
     grid = TC.Grid(mesh)
 
     Stats = skip_io ? nothing : NetCDFIO_Stats(namelist, grid)
+
     case_type = Cases.get_case(namelist)
     surf_ref_state = Cases.surface_ref_state(case_type, param_set, namelist)
 

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -12,6 +12,7 @@ if run_from_command_line
         "--entr"           # Try other entr-detr models
         "--stoch_entr"     # Choose type of stochastic entr-detr model
         "--calibrate_io"   # Test that calibration IO passes regression tests
+        "--stretch_grid"   # Test stretched grid option
         "--skip_io"        # Test that skipping IO passes regression tests
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
@@ -23,9 +24,11 @@ micro        = run_from_command_line ? parsed_args["micro"] : nothing
 entr         = run_from_command_line ? parsed_args["entr"] : nothing
 stoch_entr   = run_from_command_line ? parsed_args["stoch_entr"] : nothing
 calibrate_io = run_from_command_line ? parsed_args["calibrate_io"] : nothing
+stretch_grid = run_from_command_line ? parsed_args["stretch_grid"] : nothing
 skip_io      = run_from_command_line ? parsed_args["skip_io"] : nothing
 
 calibrate_io ≠ nothing && (calibrate_io = parse(Bool, calibrate_io))
+stretch_grid ≠ nothing && (stretch_grid = parse(Bool, stretch_grid))
 skip_io ≠ nothing      && (skip_io = parse(Bool, skip_io))
 #! format: on
 
@@ -53,6 +56,7 @@ suffix = uuid_suffix(micro)
 suffix *= uuid_suffix(entr)
 suffix *= uuid_suffix(stoch_entr)
 calibrate_io ≠ nothing && (suffix *= "_calibrate_io_$calibrate_io")
+stretch_grid ≠ nothing && (suffix *= "_stretch_grid_$stretch_grid")
 skip_io ≠ nothing && (suffix *= "_skip_io_$skip_io")
 
 namelist["meta"]["uuid"] = "01$suffix"
@@ -62,6 +66,7 @@ micro        ≠ nothing && (namelist["thermodynamics"]["quadrature_type"] = mic
 entr         ≠ nothing && (namelist["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = entr)
 stoch_entr   ≠ nothing && (namelist["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = stoch_entr)
 calibrate_io ≠ nothing && (namelist["stats_io"]["calibrate_io"] = calibrate_io)
+stretch_grid ≠ nothing && (namelist["grid"]["stretch"]["flag"] = stretch_grid)
 skip_io      ≠ nothing && (namelist["stats_io"]["skip"] = skip_io)
 #! format: on
 


### PR DESCRIPTION
In this PR we added an option for `GeneralizedExponentialStretching` with a grid realistic for a GCM. To make sure that the stretch grid in all cases uses similar points (to each case's vertical domain) the stretch grid is generated first for the GCM domain (45km) and we added a function `TCMeshFromGCMMesh` that takes a subset of that domain relevant for each case (i.e. 400m for GABLS and 17km for TRMM). This stretching effects the results of several cases and for now it is not the default, but appears in an addition Bomex base. 
