### PR TITLE
Add explicit show to last tree element

### DIFF
--- a/perf/invalidations.jl
+++ b/perf/invalidations.jl
@@ -21,7 +21,7 @@ import SnoopCompile
 trees = SnoopCompile.invalidation_trees(invalidations);
 @show length(SnoopCompile.uinvalidated(invalidations))
 
-methinvs = trees[end]
+show(trees[end])
 
 # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
 ENV["GKSwstype"] = "nul"


### PR DESCRIPTION
Missed in #673. I'm not sure how to suppress the output in the `SnoopCompile.invalidation_trees(invalidations)` call.