### PR TITLE
Fix CFL dz bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"


### PR DESCRIPTION
I noticed that GHA CI was breaking, and realized that `@inbounds` is suppressed for those simulations because it's run using `Pkg.test()`. It looks like I made an indexing error in #670. This PR extracts `Δz` for cell centers and cell faces, which are needed for two different loops.