### PR TITLE
Move cloud base, top, and cover to diagnostics

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -31,7 +31,6 @@ function affect_io!(integrator)
     TC.io(io_nt.aux, Stats, state)
     TC.io(io_nt.diagnostics, Stats, diagnostics)
 
-    TC.io(gm, grid, state, Stats) # #removeVarsHack
     TC.io(case, grid, state, Stats) # #removeVarsHack
     TC.io(edmf, grid, state, Stats) # #removeVarsHack
 

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -52,6 +52,7 @@ function initialize_covariance(edmf::TC.EDMF_PrognosticTKE, grid, state, gm, Cas
 end
 
 function initialize_updrafts(edmf, grid, state, up::TC.UpdraftVariables, gm::TC.GridMeanVariables)
+    N_up = TC.n_updrafts(edmf)
     kc_surf = TC.kc_surface(grid)
     aux_up = TC.center_aux_updrafts(state)
     prog_gm = TC.center_prog_grid_mean(state)
@@ -61,7 +62,7 @@ function initialize_updrafts(edmf, grid, state, up::TC.UpdraftVariables, gm::TC.
     prog_up = TC.center_prog_updrafts(state)
     prog_up_f = TC.face_prog_updrafts(state)
     ρ0_c = TC.center_ref_state(state).ρ0
-    @inbounds for i in 1:(up.n_updrafts)
+    @inbounds for i in 1:N_up
         @inbounds for k in TC.real_face_indices(grid)
             aux_up_f[i].w[k] = 0
             prog_up_f[i].ρaw[k] = 0
@@ -167,7 +168,8 @@ function initialize_updrafts_DryBubble(edmf, grid, state, up::TC.UpdraftVariable
     Area_in = TC.pyinterp(grid.zc, z_in, Area_in)
     θ_liq_in = TC.pyinterp(grid.zc, z_in, θ_liq_in)
     T_in = TC.pyinterp(grid.zc, z_in, T_in)
-    @inbounds for i in 1:(up.n_updrafts)
+    N_up = TC.n_updrafts(edmf)
+    @inbounds for i in 1:N_up
         @inbounds for k in TC.real_face_indices(grid)
             if minimum(z_in) <= grid.zf[k] <= maximum(z_in)
                 aux_up_f[i].w[k] = 0.0

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -70,17 +70,17 @@ function Simulation1d(namelist)
     edmf = TC.EDMF_PrognosticTKE(namelist, grid, param_set)
     TS = TC.TimeStepping(namelist)
 
-    n_updrafts = edmf.n_updrafts
+    N_up = TC.n_updrafts(edmf)
 
     cspace = TC.center_space(grid)
     fspace = TC.face_space(grid)
 
-    cent_prog_fields() = TC.FieldFromNamedTuple(cspace, cent_prognostic_vars(FT, n_updrafts))
-    face_prog_fields() = TC.FieldFromNamedTuple(fspace, face_prognostic_vars(FT, n_updrafts))
-    aux_cent_fields = TC.FieldFromNamedTuple(cspace, cent_aux_vars(FT, n_updrafts))
-    aux_face_fields = TC.FieldFromNamedTuple(fspace, face_aux_vars(FT, n_updrafts))
-    diagnostic_cent_fields = TC.FieldFromNamedTuple(cspace, cent_diagnostic_vars(FT, n_updrafts))
-    diagnostic_face_fields = TC.FieldFromNamedTuple(fspace, face_diagnostic_vars(FT, n_updrafts))
+    cent_prog_fields() = TC.FieldFromNamedTuple(cspace, cent_prognostic_vars(FT, N_up))
+    face_prog_fields() = TC.FieldFromNamedTuple(fspace, face_prognostic_vars(FT, N_up))
+    aux_cent_fields = TC.FieldFromNamedTuple(cspace, cent_aux_vars(FT, N_up))
+    aux_face_fields = TC.FieldFromNamedTuple(fspace, face_aux_vars(FT, N_up))
+    diagnostic_cent_fields = TC.FieldFromNamedTuple(cspace, cent_diagnostic_vars(FT, N_up))
+    diagnostic_face_fields = TC.FieldFromNamedTuple(fspace, face_diagnostic_vars(FT, N_up))
 
     prog = CC.Fields.FieldVector(cent = cent_prog_fields(), face = face_prog_fields())
     aux = CC.Fields.FieldVector(cent = aux_cent_fields, face = aux_face_fields)
@@ -148,7 +148,6 @@ function TurbulenceConvection.initialize(sim::Simulation1d, namelist)
     TC.io(sim.io_nt.diagnostics, sim.Stats, sim.diagnostics)
 
     # TODO: depricate
-    TC.io(sim.gm, sim.grid, state, sim.Stats)
     TC.io(sim.Case, sim.grid, state, sim.Stats)
     TC.io(sim.edmf, sim.grid, state, sim.Stats)
     TC.close_files(sim.Stats)

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -9,6 +9,7 @@ function compute_precipitation_formation_tendencies(
     dt,
     param_set,
 )
+    N_up = n_updrafts(up)
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
     aux_up = center_aux_updrafts(state)
@@ -16,7 +17,7 @@ function compute_precipitation_formation_tendencies(
     prog_pr = center_prog_precipitation(state)
     tendencies_pr = center_tendencies_precipitation(state)
 
-    @inbounds for i in 1:(up.n_updrafts)
+    @inbounds for i in 1:N_up
         @inbounds for k in real_center_indices(grid)
             T_up = aux_up[i].T[k]
             q_tot_up = aux_up[i].q_tot[k]
@@ -44,7 +45,7 @@ function compute_precipitation_formation_tendencies(
     @inbounds for k in real_center_indices(grid)
         aux_bulk.θ_liq_ice_tendency_precip_formation[k] = 0
         aux_bulk.qt_tendency_precip_formation[k] = 0
-        @inbounds for i in 1:(up.n_updrafts)
+        @inbounds for i in 1:N_up
             aux_bulk.θ_liq_ice_tendency_precip_formation[k] += aux_up[i].θ_liq_ice_tendency_precip_formation[k]
             aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
         end

--- a/src/io.jl
+++ b/src/io.jl
@@ -3,7 +3,6 @@
 initialize_io(self::ForcingBase, Stats) = nothing
 
 initialize_io(self::RadiationBase, Stats::NetCDFIO_Stats) = nothing
-io(self::RadiationBase, grid, state, Stats::NetCDFIO_Stats) = nothing
 
 function initialize_io(en::EnvironmentVariables, Stats::NetCDFIO_Stats)
     add_ts(Stats, "env_cloud_base")
@@ -14,22 +13,12 @@ function initialize_io(en::EnvironmentVariables, Stats::NetCDFIO_Stats)
     return
 end
 
-function io(en::EnvironmentVariables, grid, state, Stats::NetCDFIO_Stats)
-    # Assuming amximum overlap in environmental clouds
-    write_ts(Stats, "env_cloud_cover", en.cloud_cover)
-    write_ts(Stats, "env_cloud_base", en.cloud_base)
-    write_ts(Stats, "env_cloud_top", en.cloud_top)
-    return
-end
-
 function initialize_io(precip::PrecipVariables, Stats::NetCDFIO_Stats)
     add_ts(Stats, "rwp_mean")
     add_ts(Stats, "swp_mean")
     add_ts(Stats, "cutoff_precipitation_rate")
     return
 end
-
-io(precip::PrecipVariables, grid, state, Stats::NetCDFIO_Stats) = nothing
 
 function initialize_io(up::UpdraftVariables, Stats::NetCDFIO_Stats)
 
@@ -41,30 +30,12 @@ function initialize_io(up::UpdraftVariables, Stats::NetCDFIO_Stats)
     return
 end
 
-function io(up::UpdraftVariables, grid, state, Stats::NetCDFIO_Stats)
-    # Note definition of cloud cover : each updraft is associated with a cloud cover equal to the maximum
-    # area fraction of the updraft where ql > 0. Each updraft is assumed to have maximum overlap with respect to
-    # itup (i.e. no consideration of tilting due to shear) while the updraft classes are assumed to have no overlap
-    # at all. Thus total updraft cover is the sum of each updraft"s cover
-    write_ts(Stats, "updraft_cloud_cover", sum(up.cloud_cover))
-    write_ts(Stats, "updraft_cloud_base", minimum(abs.(up.cloud_base)))
-    write_ts(Stats, "updraft_cloud_top", maximum(abs.(up.cloud_top)))
-    return
-end
-
 function initialize_io(gm::GridMeanVariables, Stats::NetCDFIO_Stats)
     add_ts(Stats, "lwp_mean")
     add_ts(Stats, "iwp_mean")
     add_ts(Stats, "cloud_base_mean")
     add_ts(Stats, "cloud_top_mean")
     add_ts(Stats, "cloud_cover_mean")
-    return
-end
-
-function io(gm::GridMeanVariables, grid, state, Stats::NetCDFIO_Stats)
-    write_ts(Stats, "cloud_cover_mean", gm.cloud_cover)
-    write_ts(Stats, "cloud_base_mean", gm.cloud_base)
-    write_ts(Stats, "cloud_top_mean", gm.cloud_top)
     return
 end
 
@@ -80,9 +51,6 @@ function initialize_io(edmf::EDMF_PrognosticTKE, Stats::NetCDFIO_Stats)
 end
 
 function io(edmf::EDMF_PrognosticTKE, grid, state, Stats::NetCDFIO_Stats)
-    io(edmf.UpdVar, grid, state, Stats)
-    io(edmf.EnvVar, grid, state, Stats)
-    io(edmf.Precip, grid, state, Stats)
     write_ts(Stats, "rd", StatsBase.mean(edmf.pressure_plume_spacing))
     return
 end


### PR DESCRIPTION
This PR removes the cloud base, cloud top, and cloud cover from various data structures and computes them on-the-fly in  `compute_diagnostics!`. This allows us to make some of the types immutable.

This PR also removes the `n_updrafts` field from the `UpdraftVariables` struct and puts it in the type space so that loops are able to be unrolled.