### PR TITLE
Cache gauss quad in sgs env thermo

### DIFF
--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -69,9 +69,8 @@ function sgs_mean(en_thermo::EnvironmentThermodynamics, grid, state, en, precip,
 end
 
 function sgs_quadrature(en_thermo::EnvironmentThermodynamics, grid, state, en, precip, dt, param_set)
-    # TODO: double check this python-> julia translation
-    # a, w = np.polynomial.hermite.hermgauss(en_thermo.quadrature_order)
-    a, w = FastGaussQuadrature.gausshermite(en_thermo.quadrature_order)
+    a = en_thermo.a
+    w = en_thermo.w
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
     aux_en = center_aux_environment(state)

--- a/src/types.jl
+++ b/src/types.jl
@@ -223,13 +223,19 @@ function EnvironmentVariables(namelist, grid::Grid)
     return EnvironmentVariables(; EnvThermo_scheme)
 end
 
-struct EnvironmentThermodynamics
+struct EnvironmentThermodynamics{A, W}
     quadrature_order::Int
     quadrature_type::String
+    a::A
+    w::W
     function EnvironmentThermodynamics(namelist, grid::Grid)
         quadrature_order = parse_namelist(namelist, "thermodynamics", "quadrature_order"; default = 3)
         quadrature_type = parse_namelist(namelist, "thermodynamics", "quadrature_type"; default = "gaussian")
-        return new(quadrature_order, quadrature_type)
+        # TODO: double check this python-> julia translation
+        # a, w = np.polynomial.hermite.hermgauss(quadrature_order)
+        a, w = FastGaussQuadrature.gausshermite(quadrature_order)
+        a, w = SA.SVector{quadrature_order}(a), SA.SVector{quadrature_order}(w)
+        return new{typeof(a), typeof(w)}(quadrature_order, quadrature_type, a, w)
     end
 end
 


### PR DESCRIPTION
`a, w = FastGaussQuadrature.gausshermite(en_thermo.quadrature_order)` runs through a relatively complicated looking code path. I think it's fast because it's fully precompilable, but it takes a surprising amount of space on the flame graph in the tendencies evaluation, so this PR caches it and moves it to initialization.