### PR TITLE
Reduce number of inference triggers

### DIFF
--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -39,7 +39,7 @@ function initialize_covariance(edmf::TC.EDMF_PrognosticTKE, grid, state, gm, Cas
     aux_en.tke .= aux_gm.tke
     prog_en.ρatke .= aux_en.tke .* ρ0_c .* ae
 
-    TC.get_GMV_CoVar(edmf, grid, state, :tke, :w)
+    TC.get_GMV_CoVar(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
     aux_gm.Hvar .= aux_gm.Hvar[kc_surf] .* aux_gm.tke
     aux_gm.QTvar .= aux_gm.QTvar[kc_surf] .* aux_gm.tke
     aux_gm.HQTcov .= aux_gm.HQTcov[kc_surf] .* aux_gm.tke

--- a/perf/inference_triggers.jl
+++ b/perf/inference_triggers.jl
@@ -1,6 +1,7 @@
 if !("." in LOAD_PATH) # for easier local testing
     push!(LOAD_PATH, ".")
 end
+using Test
 import SnoopCompileCore
 import TurbulenceConvection
 tc_dir_glob = dirname(dirname(pathof(TurbulenceConvection)))
@@ -39,4 +40,8 @@ tc_trigs = first(pmtrigs).second
 for tc_trig in tc_trigs
     println("-------------")
     summary(tc_trig)
+end
+
+@testset "Number of inference triggers" begin
+    @test length(tc_trigs) ≤ 2
 end

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -1,4 +1,4 @@
-function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid, state, Case, param_set, t, Δt)
+function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Case, param_set::APS, t::Real, Δt::Real)
     #####
     ##### Unpack common variables
     #####
@@ -228,9 +228,9 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid, state, Case, param_set,
     #####
     #####  diagnose_GMV_moments
     #####
-    get_GMV_CoVar(edmf, grid, state, :Hvar, :θ_liq_ice)
-    get_GMV_CoVar(edmf, grid, state, :QTvar, :q_tot)
-    get_GMV_CoVar(edmf, grid, state, :HQTcov, :θ_liq_ice, :q_tot)
+    get_GMV_CoVar(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    get_GMV_CoVar(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    get_GMV_CoVar(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
 
     # TODO - use this inversion in free_convection_windspeed and not compute zi twice
     edmf.zi = get_inversion(grid, state, param_set, surface.Ri_bulk_crit)
@@ -484,10 +484,10 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid, state, Case, param_set,
     compute_covariance_shear(edmf, grid, state, gm, Val(:Hvar), Val(:θ_liq_ice))
     compute_covariance_shear(edmf, grid, state, gm, Val(:QTvar), Val(:q_tot))
     compute_covariance_shear(edmf, grid, state, gm, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
-    compute_covariance_dissipation(edmf, grid, state, :tke, param_set)
-    compute_covariance_dissipation(edmf, grid, state, :Hvar, param_set)
-    compute_covariance_dissipation(edmf, grid, state, :QTvar, param_set)
-    compute_covariance_dissipation(edmf, grid, state, :HQTcov, param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:tke), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:Hvar), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:QTvar), param_set)
+    compute_covariance_dissipation(edmf, grid, state, Val(:HQTcov), param_set)
 
     # TODO defined again in compute_covariance_shear and compute_covaraince
     @inbounds for k in real_center_indices(grid)
@@ -497,7 +497,7 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid, state, Case, param_set,
         aux_en_2m.HQTcov.rain_src[k] = ρ0_c[k] * aux_en.area[k] * aux_en.HQTcov_rain_dt[k]
     end
 
-    get_GMV_CoVar(edmf, grid, state, :tke, :w)
+    get_GMV_CoVar(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
 
     compute_diffusive_fluxes(edmf, grid, state, gm, Case, param_set)
 


### PR DESCRIPTION
It turns out that passing `Symbol`s through `Val` has the effect of reducing the number of inference triggers (from 4 to 2 🎉 ). This PR passes several symbols through with `Val`, adds some type annotations, removes a re-defined CC operator and hoists a `getproperty` call outside of some broadcast statements.

This PR also adds a test to `perf/inference_triggers.jl` so that we don't accidentally introduce new ones.