### PR TITLE
Rm CCO redef, more type space, +hoist, type annot

### DIFF
--- a/diagnostics/compute_diagnostics.jl
+++ b/diagnostics/compute_diagnostics.jl
@@ -214,9 +214,9 @@ function compute_diagnostics!(edmf, gm, grid, state, diagnostics, Case, Stats)
     TC.GMV_third_m(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:QT_third_m))
     TC.GMV_third_m(edmf, grid, state, Val(:tke), Val(:w), Val(:W_third_m))
 
-    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:tke), Val(:w))
-    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice))
-    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:QTvar), Val(:q_tot))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
 
     TC.update_cloud_frac(edmf, grid, state, gm)

--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -927,7 +927,7 @@ function initialize_forcing(self::CasesBase{TRMM_LBA}, grid::Grid, state, gm, pa
     end...)
     A = A'
 
-    self.rad = zeros(size(A, 1), grid.nz)
+    self.rad = zeros(size(A, 1), TC.n_cells(grid))
     self.rad .= A # store matrix in self
     ind1 = Int(trunc(10.0 / 600.0)) + 1
     ind2 = Int(ceil(10.0 / 600.0))

--- a/perf/inference_triggers.jl
+++ b/perf/inference_triggers.jl
@@ -43,5 +43,9 @@ for tc_trig in tc_trigs
 end
 
 @testset "Number of inference triggers" begin
+    # These tests are not strictly needed,
+    # but they will hopefully prevent performance
+    # regressions
     @test length(tc_trigs) ≤ 2
+    @test length(itrigs) ≤ 36
 end

--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -47,7 +47,7 @@ function microphysics(::SGSMean, grid::Grid, state::State, precip_model::Abstrac
         tendencies_pr.q_rai[k] += mph.qr_tendency * aux_en.area[k]
         tendencies_pr.q_sno[k] += mph.qs_tendency * aux_en.area[k]
     end
-    return
+    return nothing
 end
 
 function microphysics(en_thermo::SGSQuadrature, grid, state, precip_model, Δt, param_set)
@@ -291,5 +291,5 @@ function microphysics(en_thermo::SGSQuadrature, grid, state, precip_model, Δt, 
         end
     end
 
-    return
+    return nothing
 end

--- a/src/EDMF_Precipitation.jl
+++ b/src/EDMF_Precipitation.jl
@@ -31,7 +31,7 @@ function compute_precipitation_advection_tendencies(::Clima1M, edmf, grid, state
 
     @. tendencies_pr.q_rai += aux_tc.qr_tendency_advection
     @. tendencies_pr.q_sno += aux_tc.qs_tendency_advection
-    return
+    return nothing
 end
 
 """
@@ -100,5 +100,5 @@ function compute_precipitation_sink_tendencies(::Clima1M, grid, state, gm, Δt::
                 S_qs_melt * L_f * (1.0 + R_m / c_vm)
             )
     end
-    return
+    return nothing
 end

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -50,5 +50,5 @@ function compute_precipitation_formation_tendencies(
             aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
         end
     end
-    return
+    return nothing
 end

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -20,11 +20,10 @@ Base.:-(zp1::CC.Geometry.ZPoint, zp2::CC.Geometry.ZPoint) = Base.:-(zp1.z, zp2.z
 Base.convert(::Type{Float64}, zp::CC.Geometry.ZPoint) = zp.z
 
 
-struct Grid{FT, CS, FS, SC, SF}
+struct Grid{FT, NZ, CS, FS, SC, SF}
     zmin::FT
     zmax::FT
     Δz::FT
-    nz::Int
     cs::CS
     fs::FS
     zc::SC
@@ -51,15 +50,17 @@ struct Grid{FT, CS, FS, SC, SF}
         FS = typeof(fs)
         SC = typeof(zc)
         SF = typeof(zf)
-        return new{FT, CS, FS, SC, SF}(zmin, zmax, Δz, nz, cs, fs, zc, zf)
+        return new{FT, nz, CS, FS, SC, SF}(zmin, zmax, Δz, cs, fs, zc, zf)
     end
 end
+
+n_cells(::Grid{FT, NZ}) where {FT, NZ} = NZ
 
 # Index of the first interior cell above the surface
 kc_surface(grid::Grid) = Cent(1)
 kf_surface(grid::Grid) = CCO.PlusHalf(1)
-kc_top_of_atmos(grid::Grid) = Cent(grid.nz)
-kf_top_of_atmos(grid::Grid) = CCO.PlusHalf(grid.nz + 1)
+kc_top_of_atmos(grid::Grid) = Cent(n_cells(grid))
+kf_top_of_atmos(grid::Grid) = CCO.PlusHalf(n_cells(grid) + 1)
 
 is_surface_center(grid::Grid, k) = k == kc_surface(grid)
 is_toa_center(grid::Grid, k) = k == kc_top_of_atmos(grid)

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -65,16 +65,16 @@ mutable struct NetCDFIO_Stats
 
             # Set profile dimensions
             profile_grp = NC.defGroup(root_grp, "profiles")
-            NC.defDim(profile_grp, "zf", grid.nz + 1)
-            NC.defDim(profile_grp, "zc", grid.nz)
+            NC.defDim(profile_grp, "zf", n_cells(grid) + 1)
+            NC.defDim(profile_grp, "zc", n_cells(grid))
             NC.defDim(profile_grp, "t", Inf)
             NC.defVar(profile_grp, "zf", zf, ("zf",))
             NC.defVar(profile_grp, "zc", zc, ("zc",))
             NC.defVar(profile_grp, "t", Float64, ("t",))
 
             reference_grp = NC.defGroup(root_grp, "reference")
-            NC.defDim(reference_grp, "zf", grid.nz + 1)
-            NC.defDim(reference_grp, "zc", grid.nz)
+            NC.defDim(reference_grp, "zf", n_cells(grid) + 1)
+            NC.defDim(reference_grp, "zc", n_cells(grid))
             NC.defVar(reference_grp, "zf", zf, ("zf",))
             NC.defVar(reference_grp, "zc", zc, ("zc",))
 

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -476,13 +476,13 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
         @. tke_press += (Ic(w_en) - Ic(w_up)) * Ic(nh_press)
     end
 
-    compute_covariance_entr(edmf, grid, state, Val(:tke), Val(:w))
-    compute_covariance_entr(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice))
-    compute_covariance_entr(edmf, grid, state, Val(:QTvar), Val(:q_tot))
+    compute_covariance_entr(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    compute_covariance_entr(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    compute_covariance_entr(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     compute_covariance_entr(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:tke), Val(:w))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:Hvar), Val(:θ_liq_ice))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:QTvar), Val(:q_tot))
+    compute_covariance_shear(edmf, grid, state, gm, Val(:tke), Val(:w), Val(:w))
+    compute_covariance_shear(edmf, grid, state, gm, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    compute_covariance_shear(edmf, grid, state, gm, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     compute_covariance_shear(edmf, grid, state, gm, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
     compute_covariance_dissipation(edmf, grid, state, Val(:tke), param_set)
     compute_covariance_dissipation(edmf, grid, state, Val(:Hvar), param_set)
@@ -527,4 +527,5 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
         end
     end
 
+    return nothing
 end


### PR DESCRIPTION
In efforts to further reduce inference triggers, I tried [Cthulhu-ing](https://github.com/JuliaDebug/Cthulhu.jl) into `solve`, and while these changes do not further reduce the inference triggers, `Cthulhu` seems to throw fewer warnings / `Any`s. So, let's merge this. The code hoisting is coming along for the ride.