### PR TITLE
Remove several unused edmf variables

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -1534,7 +1534,6 @@ function initialize_profiles(self::CasesBase{DryBubble}, grid::Grid, gm, state)
         prog_gm.u[k] = 0.01
     end
 
-    n_updrafts = 1
     # initialize Grid Mean Profiles of thetali and qt
     #! format: off
     z_in = arr_type([

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -153,7 +153,6 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit" # "moisture_deficit" or "NN"
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["extrapolate_buoyancy"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["use_local_micro"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["calculate_tke"] = true
@@ -162,7 +161,6 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_buoy"] = "normalmode"
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_drag"] = "normalmode"
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_asp_label"] = "const"
 
     namelist_defaults["output"] = Dict()
     namelist_defaults["output"]["output_root"] = "./"

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -362,8 +362,6 @@ function compute_updraft_surface_bc(edmf::EDMF_PrognosticTKE, grid::Grid, state:
 
     if Case.Sur.bflux > 0.0
         a_total = edmf.surface_area
-        edmf.entr_surface_bc = 1 / zLL
-        edmf.detr_surface_bc = 0.0
         a_ = a_total / N_up
         @inbounds for i in 1:N_up
             surface_scalar_coeff =
@@ -374,8 +372,6 @@ function compute_updraft_surface_bc(edmf::EDMF_PrognosticTKE, grid::Grid, state:
             edmf.qt_surface_bc[i] = prog_gm.q_tot[kc_surf] + surface_scalar_coeff * sqrt(qt_var)
         end
     else
-        edmf.entr_surface_bc = 0.0
-        edmf.detr_surface_bc = 1 / zLL
         @inbounds for i in 1:N_up
             edmf.area_surface_bc[i] = 0
             edmf.w_surface_bc[i] = 0.0

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -232,9 +232,6 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
     get_GMV_CoVar(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     get_GMV_CoVar(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
 
-    # TODO - use this inversion in free_convection_windspeed and not compute zi twice
-    edmf.zi = get_inversion(grid, state, param_set, surface.Ri_bulk_crit)
-
     update_surface(Case, grid, state, gm, t, param_set)
     update_forcing(Case, grid, state, gm, t, param_set)
     update_radiation(Case, grid, state, gm, t, param_set)


### PR DESCRIPTION
This PR removes several unused EDMF variables-- some are
 - simply never assigned / used
 - only assigned then never used
 - never used, but also appear as InternalClimaParameters (search `ICP.`)

This PR gets us a reasonable step towards immutable types. We only have
 - `SurfaceBase` (may be a bit tough)
 - `CasesBase` (should be relatively easy once `SurfaceBase` is immutable)
 - `sde_struct` (being fixed in #682)
 - `EDMF_PrognosticTKE` (for which `dt_max` is the only remaining mutating field)

I imagine `edmf.zi = get_inversion(grid, state, param_set, surface.Ri_bulk_crit)` is the most controversial removal, but it's not used! I think `zi` is computed locally and used in other places on the fly, which is perfectly fine.