### PR TITLE
Improve func findability, hoist code, renaming

### DIFF
--- a/diagnostics/compute_diagnostics.jl
+++ b/diagnostics/compute_diagnostics.jl
@@ -52,7 +52,7 @@ diagnostics and still run, at which point we'll be able to export
 the state, auxiliary fields (which the state does depend on), and
 tendencies.
 =#
-function compute_diagnostics!(edmf, gm, grid, state, diagnostics, Case, Stats)
+function compute_diagnostics!(edmf, gm, grid, state, diagnostics, Stats)
     FT = eltype(grid)
     N_up = TC.n_updrafts(edmf)
     ρ0_c = TC.center_ref_state(state).ρ0

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -20,7 +20,7 @@ function affect_io!(integrator)
 
     param_set = TC.parameter_set(gm)
     # TODO: is this the best location to call diagnostics?
-    compute_diagnostics!(edmf, gm, grid, state, diagnostics, case, Stats)
+    compute_diagnostics!(edmf, gm, grid, state, diagnostics, Stats)
 
     # TODO: remove `vars` hack that avoids
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
@@ -41,7 +41,7 @@ function affect_filter!(integrator)
     UnPack.@unpack edmf, grid, gm, aux, case = integrator.p
     t = integrator.t
     state = TC.State(integrator.u, aux, integrator.du)
-    TC.affect_filter!(edmf, grid, state, gm, case, t)
+    TC.affect_filter!(edmf, grid, state, gm, case.surf, case.casename, t)
 
     # We're lying to OrdinaryDiffEq.jl, in order to avoid
     # paying for an additional `∑tendencies!` call, which is required

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -3,9 +3,17 @@ const TC = TurbulenceConvection
 import Thermodynamics
 const TD = Thermodynamics
 
-function initialize_edmf(edmf::TC.EDMF_PrognosticTKE, grid, state, Case, gm::TC.GridMeanVariables, t::Real)
-    initialize_covariance(edmf, grid, state, gm, Case)
+function initialize_edmf(
+    edmf::TC.EDMF_PrognosticTKE,
+    grid::TC.Grid,
+    state::TC.State,
+    case,
+    gm::TC.GridMeanVariables,
+    t::Real,
+)
+    initialize_covariance(edmf, grid, state)
     up = edmf.UpdVar
+    surf = case.surf
     param_set = TC.parameter_set(gm)
     aux_tc = TC.center_aux_turbconv(state)
     prog_gm = TC.center_prog_grid_mean(state)
@@ -15,18 +23,18 @@ function initialize_edmf(edmf::TC.EDMF_PrognosticTKE, grid, state, Case, gm::TC.
         ts = TC.thermo_state_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
         aux_tc.θ_virt[k] = TD.virtual_pottemp(ts)
     end
-    TC.update_surface(Case, grid, state, gm, t, param_set)
-    TC.compute_updraft_surface_bc(edmf, grid, state, Case)
-    if Case.casename == "DryBubble"
+    TC.update_surface(case, grid, state, gm, t, param_set)
+    TC.compute_updraft_surface_bc(edmf, grid, state, surf)
+    if case.casename == "DryBubble"
         initialize_updrafts_DryBubble(edmf, grid, state, up, gm)
     else
         initialize_updrafts(edmf, grid, state, up, gm)
     end
-    TC.set_edmf_surface_bc(edmf, grid, state, up, Case.Sur)
+    TC.set_edmf_surface_bc(edmf, grid, state, up, surf)
     return
 end
 
-function initialize_covariance(edmf::TC.EDMF_PrognosticTKE, grid, state, gm, Case)
+function initialize_covariance(edmf::TC.EDMF_PrognosticTKE, grid::TC.Grid, state::TC.State)
 
     kc_surf = TC.kc_surface(grid)
     aux_gm = TC.center_aux_grid_mean(state)

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -19,7 +19,7 @@ function update_n(sim, tendencies, ::Val{N}) where {N}
     TS = sim.TS
     prog = sim.state.prog
     aux = sim.state.aux
-    params = (; edmf = sim.edmf, grid = grid, gm = sim.gm, case = sim.Case, TS = TS, aux = aux)
+    params = (; edmf = sim.edmf, grid = grid, gm = sim.gm, case = sim.case, TS = TS, aux = aux)
     for i in 1:N
         TC.∑tendencies!(tendencies, prog, params, TS.t)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -338,7 +338,7 @@ Base.@kwdef mutable struct CasesBase{T, S, F, R, SR, RMAT, LESDataT}
     casename::String = "default_casename"
     inversion_option::String = "default_inversion_option"
     les_filename::String = "None"
-    Sur::S
+    surf::S
     Fo::F
     Rad::R
     rad_time::SR
@@ -348,8 +348,8 @@ Base.@kwdef mutable struct CasesBase{T, S, F, R, SR, RMAT, LESDataT}
     LESDat::LESDataT
 end
 
-function CasesBase(case::T; Sur, Fo, Rad, rad_time = stepR, rad = zeros(1, 1), LESDat = nothing, kwargs...) where {T}
-    S = typeof(Sur)
+function CasesBase(case::T; surf, Fo, Rad, rad_time = stepR, rad = zeros(1, 1), LESDat = nothing, kwargs...) where {T}
+    S = typeof(surf)
     F = typeof(Fo)
     R = typeof(Rad)
     SR = typeof(rad_time)
@@ -358,7 +358,7 @@ function CasesBase(case::T; Sur, Fo, Rad, rad_time = stepR, rad = zeros(1, 1), L
     CasesBase{T, S, F, R, SR, RMAT, LESDataT}(;
         case = case,
         casename = string(nameof(T)),
-        Sur,
+        surf,
         Fo,
         Rad,
         rad_time,

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -1,4 +1,4 @@
-function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Case, param_set::APS, t::Real, Δt::Real)
+function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, case, param_set::APS, t::Real, Δt::Real)
     #####
     ##### Unpack common variables
     #####
@@ -15,8 +15,8 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
     c_m = CPEDMF.c_m(param_set)
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
-    surface = Case.Sur
-    obukhov_length = surface.obukhov_length
+    surf = case.surf
+    obukhov_length = surf.obukhov_length
     FT = eltype(grid)
     prog_gm = center_prog_grid_mean(state)
     prog_gm_f = face_prog_grid_mean(state)
@@ -232,9 +232,9 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
     get_GMV_CoVar(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     get_GMV_CoVar(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
 
-    update_surface(Case, grid, state, gm, t, param_set)
-    update_forcing(Case, grid, state, gm, t, param_set)
-    update_radiation(Case, grid, state, gm, t, param_set)
+    update_surface(case, grid, state, gm, t, param_set)
+    update_forcing(case, grid, state, gm, t, param_set)
+    update_radiation(case, grid, state, gm, t, param_set)
 
     compute_pressure_plume_spacing(edmf, param_set)
 
@@ -440,7 +440,7 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
             z = grid.zc[k].z,
             obukhov_length = obukhov_length,
             tke_surf = aux_en.tke[kc_surf],
-            ustar = surface.ustar,
+            ustar = surf.ustar,
             Pr = aux_tc.prandtl_nvec[k],
             p0 = p0_c[k],
             ∇b = bg,
@@ -496,7 +496,7 @@ function update_aux!(edmf::EDMF_PrognosticTKE, gm, grid::Grid, state::State, Cas
 
     get_GMV_CoVar(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
 
-    compute_diffusive_fluxes(edmf, grid, state, gm, Case, param_set)
+    compute_diffusive_fluxes(edmf, grid, state, gm, surf, param_set)
 
 
     # TODO: use dispatch


### PR DESCRIPTION
This is a prep PR for making `SurfaceBase` immutable (by splitting it into separate types that contain surface constants, and revamping methods for computing other surface variables).