### PR TITLE
remove the DryMoninObukhov surface option

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -125,7 +125,7 @@ get_case_name(case_type::AbstractCaseType) = string(case_type)
 get_surface_type(::AbstractCaseType) = TC.SurfaceFixedFlux # default
 get_surface_type(::Rico) = TC.SurfaceFixedCoeffs
 get_surface_type(::GATE_III) = TC.SurfaceFixedCoeffs
-get_surface_type(::GABLS) = TC.SurfaceMoninObukhovDry
+get_surface_type(::GABLS) = TC.SurfaceMoninObukhov
 get_surface_type(::SP) = TC.SurfaceSullivanPatton
 
 get_forcing_type(::AbstractCaseType) = TC.ForcingStandard # default
@@ -1346,7 +1346,7 @@ function surface_params(case::GABLS, grid::TC.Grid, state::TC.State, param_set; 
     zrough = 0.1
 
     kwargs = (; Tsurface, qsurface, shf, lhf, zrough)
-    return TC.DryMoninObukhovSurface(FT; kwargs...)
+    return TC.MoninObukhovSurface(FT; kwargs...)
 end
 
 function initialize_forcing(self::CasesBase{GABLS}, grid::Grid, state, gm, param_set)

--- a/src/types.jl
+++ b/src/types.jl
@@ -233,16 +233,9 @@ Base.@kwdef struct sde_struct{T}
     dt::Float64
 end
 
-# SurfaceMoninObukhovDry:
-#     Needed for dry cases (qt=0). They have to be initialized with nonzero qtg for the
-#     reference profiles. This surface subroutine sets the latent heat flux to zero
-#     to prevent errors due to nonzero qtg in vars such as the obukhov_length.
-# SurfaceSullivanPatton
-#     Not fully implemented yet. Maybe not needed - Ignacio
 struct SurfaceFixedFlux end
 struct SurfaceFixedCoeffs end
 struct SurfaceMoninObukhov end
-struct SurfaceMoninObukhovDry end
 struct SurfaceSullivanPatton end
 
 abstract type FrictionVelocityType end
@@ -302,29 +295,6 @@ function FixedSurfaceCoeffs(
     CH = typeof(ch)
     CM = typeof(cm)
     return FixedSurfaceCoeffs{FT, TS, QS, CH, CM}(; Tsurface, qsurface, ch, cm, kwargs...)
-end
-
-Base.@kwdef struct DryMoninObukhovSurface{FT, TS, QS, SHF, LHF} <: AbstractSurfaceParameters{FT}
-    zrough::FT = FT(0)
-    Tsurface::TS = FT(0)
-    qsurface::QS = FT(0)
-    shf::SHF = FT(0)
-    lhf::LHF = FT(0)
-end
-
-function DryMoninObukhovSurface(
-    ::Type{FT};
-    Tsurface::FloatOrFunc{FT},
-    qsurface::FloatOrFunc{FT},
-    shf::FloatOrFunc{FT},
-    lhf::FloatOrFunc{FT},
-    kwargs...,
-) where {FT, FVT}
-    TS = typeof(Tsurface)
-    QS = typeof(qsurface)
-    SHF = typeof(shf)
-    LHF = typeof(lhf)
-    return DryMoninObukhovSurface{FT, TS, QS, SHF, LHF}(; Tsurface, qsurface, shf, lhf, kwargs...)
 end
 
 Base.@kwdef struct MoninObukhovSurface{FT, TS, QS, SHF, LHF} <: AbstractSurfaceParameters{FT}


### PR DESCRIPTION
It turns out that by setting 'qsurface=0' gabls can use MoninObukhov and obtain the same result (i.e. lhf=0) only by virtue of qsurface=0. 