### PR TITLE
Compute updraft_top on-the-fly

### DIFF
--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -120,5 +120,41 @@ Base.iterate(fi::Base.Iterators.Reverse{T}, state = Nstop) where {Nstart, Nstop,
 face_space(grid::Grid) = grid.fs
 center_space(grid::Grid) = grid.cs
 
+#=
+    findfirst_center
+    findlast_center
+    findfirst_face
+    findlast_face
+
+Grid-aware find-first / find-last indices with
+surface/toa (respectively) as the default index
+=#
+
+function findfirst_center(f::Function, grid::Grid)
+    RI = real_center_indices(grid)
+    k = findfirst(f, RI)
+    return RI[isnothing(k) ? kc_surface(grid).i : k]
+end
+function findlast_center(f::Function, grid::Grid)
+    RI = real_center_indices(grid)
+    k = findlast(f, RI)
+    return RI[isnothing(k) ? kc_top_of_atmos(grid).i : k]
+end
+z_findfirst_center(f::F, grid::Grid) where {F} = grid.zc[findfirst_center(f, grid)].z
+z_findlast_center(f::F, grid::Grid) where {F} = grid.zc[findlast_center(f, grid)].z
+
+function findfirst_face(f::F, grid::Grid) where {F}
+    RI = real_face_indices(grid)
+    k = findfirst(f, RI)
+    return RI[isnothing(k) ? kf_surface(grid).i : k]
+end
+function findlast_face(f::F, grid::Grid) where {F}
+    RI = real_face_indices(grid)
+    k = findlast(f, RI)
+    return RI[isnothing(k) ? kf_top_of_atmos(grid).i : k]
+end
+z_findfirst_face(f::F, grid::Grid) where {F} = grid.zf[findfirst_face(f, grid)].z
+z_findlast_face(f::F, grid::Grid) where {F} = grid.zf[findlast_face(f, grid)].z
+
 
 Base.eltype(::Grid{FT}) where {FT} = FT

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -445,14 +445,19 @@ function get_GMV_CoVar(
     return nothing
 end
 
-function compute_pressure_plume_spacing(edmf::EDMF_PrognosticTKE, grid::Grid, param_set::APS)
+function compute_updraft_top(grid::Grid{FT}, state::State, i::Int)::FT where {FT}
+    aux_up = center_aux_updrafts(state)
+    return z_findlast_center(k -> aux_up[i].area[k] > 1e-3, grid)
+end
+
+function compute_pressure_plume_spacing(edmf::EDMF_PrognosticTKE, grid::Grid, state::State, param_set::APS)
 
     FT = eltype(grid)
     N_up = n_updrafts(edmf)
     H_up_min::FT = CPEDMF.H_up_min(param_set)
     @inbounds for i in 1:N_up
-        edmf.pressure_plume_spacing[i] =
-            max(edmf.aspect_ratio * edmf.UpdVar.updraft_top[i], H_up_min * edmf.aspect_ratio)
+        updraft_top = compute_updraft_top(grid, state, i)
+        edmf.pressure_plume_spacing[i] = max(edmf.aspect_ratio * updraft_top, H_up_min * edmf.aspect_ratio)
     end
     return nothing
 end

--- a/src/closures/perturbation_pressure.jl
+++ b/src/closures/perturbation_pressure.jl
@@ -10,7 +10,7 @@ for updraft i following [He2020](@cite), given:
  - `asp_ratio`: the specific aspect ratio of the updraft
  - `bcs`: a `NamedTuple` of BCs with updraft area fraction and buoyancy entries
 """
-function nh_pressure_buoy(param_set::APS, a_up, b_up, ρ0, asp_ratio::FT, bcs) where {FT}
+function nh_pressure_buoy(param_set::APS, a_up, b_up, ρ0, asp_ratio::FT, bcs) where {FT <: Real}
     Ifb = CCO.InterpolateC2F(; bcs.b_up...)
     Ifa = CCO.InterpolateC2F(; bcs.a_up...)
 
@@ -32,7 +32,7 @@ for updraft i following [He2020](@cite), given:
  - `w_up`: updraft vertical velocity
  - `bcs`: a `NamedTuple` of BCs with updraft velocity and area fraction entries
 """
-function nh_pressure_adv(param_set::APS, updraft_top::FT, a_up, ρ0, w_up, bcs) where {FT}
+function nh_pressure_adv(param_set::APS, updraft_top::FT, a_up, ρ0, w_up, bcs) where {FT <: Real}
 
     Ifa = CCO.InterpolateC2F(; bcs.a_up...)
     Ifc = CCO.InterpolateF2C()
@@ -56,7 +56,7 @@ for updraft i following [He2020](@cite), given:
  - `w_en`: environment vertical velocity
  - `bcs`: a `NamedTuple` of BCs with an updraft area fraction entry
 """
-function nh_pressure_drag(param_set::APS, updraft_top::FT, a_up, ρ0, w_up, w_en, bcs) where {FT}
+function nh_pressure_drag(param_set::APS, updraft_top::FT, a_up, ρ0, w_up, w_en, bcs) where {FT <: Real}
 
     Ifa = CCO.InterpolateC2F(; bcs.a_up...)
     α_d::FT = CPEDMF.α_d(param_set)

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -24,8 +24,7 @@ function get_inversion(grid::Grid, state, param_set, Ri_bulk_crit)
     # test if we need to look at the free convective limit
     if (u[kc_surf]^2 + v[kc_surf]^2) <= 0.01
         ∇θ_virt = center_aux_turbconv(state).ϕ_temporary
-        k_star = findlast(k -> θ_virt[k] > θ_virt_b, real_center_indices(grid))
-        k_star = real_center_indices(grid)[k_star]
+        k_star = findlast_center(k -> θ_virt[k] > θ_virt_b, grid)
         LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(θ_virt[kc_surf]))
         @. ∇θ_virt = ∇c(wvec(LB(θ_virt)))
         h = (θ_virt_b - θ_virt[k_star - 1]) / ∇θ_virt[k_star] + z_c[k_star - 1]
@@ -36,8 +35,7 @@ function get_inversion(grid::Grid, state, param_set, Ri_bulk_crit)
         @inbounds for k in real_center_indices(grid)
             Ri_bulk[k] = Ri_bulk_fn(k)
         end
-        k_star = findlast(k -> Ri_bulk_fn(k) > Ri_bulk_crit, real_center_indices(grid))
-        k_star = real_center_indices(grid)[k_star]
+        k_star = findlast_center(k -> Ri_bulk_fn(k) > Ri_bulk_crit, grid)
         LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(Ri_bulk[kc_surf]))
         @. ∇Ri_bulk = ∇c(wvec(LB(Ri_bulk)))
         h = (Ri_bulk_crit - Ri_bulk[k_star - 1]) / ∇Ri_bulk[k_star] + z_c[k_star - 1]

--- a/src/types.jl
+++ b/src/types.jl
@@ -181,12 +181,9 @@ struct NoPrecipitation <: AbstractPrecipitationModel end
 struct CutoffPrecipitation <: AbstractPrecipitationModel end
 struct Clima1M <: AbstractPrecipitationModel end
 
-struct UpdraftVariables{A1, N_up}
-    updraft_top::A1
+struct UpdraftVariables{N_up}
     function UpdraftVariables(N_up, namelist)
-        # cloud and precipitation diagnostics for output
-        updraft_top = zeros(N_up)
-        return new{typeof(updraft_top), N_up}(updraft_top)
+        return new{N_up}()
     end
 end
 
@@ -632,7 +629,7 @@ struct EDMF_PrognosticTKE{N_up, A1, PM, ENT, EBGC, EC, SDES, UPVAR}
 end
 parameter_set(obj) = obj.param_set
 n_updrafts(::EDMF_PrognosticTKE{N_up}) where {N_up} = N_up
-n_updrafts(::UpdraftVariables{A, N_up}) where {A, N_up} = N_up
+n_updrafts(::UpdraftVariables{N_up}) where {N_up} = N_up
 
 struct State{P, A, T}
     prog::P

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -246,17 +246,7 @@ function update_aux!(
     update_forcing(case, grid, state, gm, t, param_set)
     update_radiation(case, grid, state, gm, t, param_set)
 
-    @inbounds for i in 1:N_up
-        up.updraft_top[i] = 0.0
-
-        @inbounds for k in real_center_indices(grid)
-            if aux_up[i].area[k] > 1e-3
-                up.updraft_top[i] = max(up.updraft_top[i], grid.zc[k])
-            end
-        end
-    end
-
-    compute_pressure_plume_spacing(edmf, grid, param_set)
+    compute_pressure_plume_spacing(edmf, grid, state, param_set)
 
     #####
     ##### compute_updraft_closures
@@ -331,7 +321,6 @@ function update_aux!(
         a_up = aux_up[i].area
         w_up = aux_up_f[i].w
         w_en = aux_en_f.w
-        updraft_top = up.updraft_top[i]
         asp_ratio = 1.0
 
         b_bcs = (; bottom = CCO.SetValue(b_up[kc_surf]), top = CCO.SetValue(b_up[kc_toa]))
@@ -343,6 +332,7 @@ function update_aux!(
         nh_press_adv = aux_up_f[i].nh_pressure_adv
         nh_press_drag = aux_up_f[i].nh_pressure_drag
 
+        updraft_top = compute_updraft_top(grid, state, i)
         nh_press_buoy .= nh_pressure_buoy(param_set, a_up, b_up, ρ0_f, asp_ratio, bcs)
         nh_press_adv .= nh_pressure_adv(param_set, updraft_top, a_up, ρ0_f, w_up, bcs)
         nh_press_drag .= nh_pressure_drag(param_set, updraft_top, a_up, ρ0_f, w_up, w_en, bcs)


### PR DESCRIPTION
This PR changes things so that we compute `updraft_top` on the fly. Advantages: we're guaranteed to use the latest information (which resulted in the bugfix in #716), and autodiff may work without issues. In addition, doing this for the remaining arrays in `EDMF_PrognosticTKE` will result in `EDMF_PrognosticTKE` becoming `isbits`, which means it will be gpu compatible.