### PR TITLE
Expose parameters, enforce consistency.

### DIFF
--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -77,8 +77,6 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["meta"]["uuid"] = basename(tempname())
 
     namelist_defaults["turbulence"] = Dict()
-    namelist_defaults["turbulence"]["Ri_bulk_crit"] = 0.2
-    namelist_defaults["turbulence"]["prandtl_number_0"] = 0.74
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"] = Dict()
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.1
@@ -87,7 +85,10 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_ed_coeff"] = 0.14
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_diss_coeff"] = 0.22
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["static_stab_coeff"] = 0.4
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["tke_surf_scale"] = 3.75
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_scale"] = 53.0 / 13.0
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"] = 0.74
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"] = 0.25
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_ub"] = 0.1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_rm"] = 1.5
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["l_max"] = 1.0e6

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -28,7 +28,7 @@ function initialize_edmf(
     else
         initialize_updrafts(edmf, grid, state, gm, surf)
     end
-    TC.set_edmf_surface_bc(edmf, grid, state, surf)
+    TC.set_edmf_surface_bc(edmf, grid, state, surf, gm)
     return
 end
 

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -90,7 +90,7 @@ function Simulation1d(namelist)
     state = TC.State(prog, aux, nothing)
     compute_ref_state!(state, grid, param_set; ref_params...)
 
-    Ri_bulk_crit = namelist["turbulence"]["Ri_bulk_crit"]
+    Ri_bulk_crit = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     spk = Cases.surface_param_kwargs(case_type, namelist)
     surf_params = Cases.surface_params(case_type, grid, state, param_set; Ri_bulk_crit = Ri_bulk_crit, spk...)
     inversion_type = Cases.inversion_type(case_type)

--- a/driver/parameter_set.jl
+++ b/driver/parameter_set.jl
@@ -24,7 +24,6 @@ CLIMAParameters.Atmos.EDMF.α_b(ps::EarthParameterSet) = ps.nt.α_b # factor mul
 CLIMAParameters.Atmos.EDMF.α_a(ps::EarthParameterSet) = ps.nt.α_a # factor multiplier for pressure advection
 CLIMAParameters.Atmos.EDMF.α_d(ps::EarthParameterSet) = ps.nt.α_d # factor multiplier for pressure drag
 CLIMAParameters.Atmos.EDMF.H_up_min(ps::EarthParameterSet) = ps.nt.H_up_min # minimum updraft top to avoid zero division in pressure drag and turb-entr
-CLIMAParameters.Atmos.EDMF.ω_pr(ps::EarthParameterSet) = ps.nt.ω_pr # experiment scale factor for turbulent Prandtl number
 CLIMAParameters.Atmos.EDMF.c_δ(ps::EarthParameterSet) = ps.nt.c_δ # factor multiplier for moist term in entrainment/detrainment
 CLIMAParameters.Atmos.EDMF.β(ps::EarthParameterSet) = ps.nt.β # sorting power for ad-hoc moisture detrainment function
 CLIMAParameters.Atmos.EDMF.χ(ps::EarthParameterSet) = ps.nt.χ # fraction of updraft air for buoyancy mixing in entrainment/detrainment (0≤χ≤1)
@@ -35,7 +34,11 @@ CLIMAParameters.Atmos.EDMF.μ_0(ps::EarthParameterSet) = ps.nt.μ_0 # dimensiona
 # mixing length parameters
 CLIMAParameters.Atmos.EDMF.c_m(ps::EarthParameterSet) = ps.nt.c_m # tke diffusivity coefficient
 CLIMAParameters.Atmos.EDMF.c_d(ps::EarthParameterSet) = ps.nt.c_d # tke dissipation coefficient
-CLIMAParameters.Atmos.EDMF.Pr_n(ps::EarthParameterSet) = ps.nt.Pr_n # tke dissipation coefficient
+CLIMAParameters.Atmos.EDMF.c_b(ps::EarthParameterSet) = ps.nt.c_b # static stability coefficient
+CLIMAParameters.Atmos.EDMF.κ_star²(ps::EarthParameterSet) = ps.nt.κ_star² # Ratio of TKE to squared friction velocity in surface layer
+CLIMAParameters.Atmos.EDMF.Pr_n(ps::EarthParameterSet) = ps.nt.Pr_n # turbulent Prandtl number in neutral conditions
+CLIMAParameters.Atmos.EDMF.ω_pr(ps::EarthParameterSet) = ps.nt.ω_pr # cospectral budget factor for turbulent Prandtl number
+CLIMAParameters.Atmos.EDMF.Ri_c(ps::EarthParameterSet) = ps.nt.Ri_c # critical Richardson number
 CLIMAParameters.Atmos.EDMF.smin_ub(ps::EarthParameterSet) = ps.nt.smin_ub #  lower limit for smin function
 CLIMAParameters.Atmos.EDMF.smin_rm(ps::EarthParameterSet) = ps.nt.smin_rm #  upper ratio limit for smin function
 
@@ -73,8 +76,10 @@ function create_parameter_set(namelist)
         β_lim = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "area_limiter_power"),
         c_m = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_ed_coeff"),
         c_d = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_diss_coeff"),
-        c_b = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "static_stab_coeff"; default = 0.4), # this is here due to an value error in CliMAParmaeters.jl
-        Pr_n = TC.parse_namelist(namelist, "turbulence", "prandtl_number_0"), # this is here due to an value error in CliMAParmaeters.jl
+        c_b = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "static_stab_coeff"; default = 0.4), # this is here due to a value error in CliMAParmameters.jl
+        κ_star² = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_surf_scale"),
+        Pr_n = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Prandtl_number_0"),
+        Ri_c = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Ri_crit"),
         smin_ub = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_ub"),
         smin_rm = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_rm"),
         l_max = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "l_max"; default = 1.0e6),

--- a/src/Turbulence_PrognosticTKE.jl
+++ b/src/Turbulence_PrognosticTKE.jl
@@ -193,7 +193,7 @@ function affect_filter!(
     ###
     ### Filters
     ###
-    set_edmf_surface_bc(edmf, grid, state, surf)
+    set_edmf_surface_bc(edmf, grid, state, surf, gm)
     filter_updraft_vars(edmf, grid, state, surf, gm)
 
     @inbounds for k in real_center_indices(grid)
@@ -206,7 +206,14 @@ function affect_filter!(
     return nothing
 end
 
-function set_edmf_surface_bc(edmf::EDMF_PrognosticTKE, grid::Grid, state::State, surf::SurfaceBase)
+function set_edmf_surface_bc(
+    edmf::EDMF_PrognosticTKE,
+    grid::Grid,
+    state::State,
+    surf::SurfaceBase,
+    gm::GridMeanVariables,
+)
+    param_set = parameter_set(gm)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
@@ -237,7 +244,7 @@ function set_edmf_surface_bc(edmf::EDMF_PrognosticTKE, grid::Grid, state::State,
 
     ρ0_ae = ρ0_c[kc_surf] * ae[kc_surf]
 
-    prog_en.ρatke[kc_surf] = ρ0_ae * get_surface_tke(surf.ustar, zLL, surf.obukhov_length)
+    prog_en.ρatke[kc_surf] = ρ0_ae * get_surface_tke(param_set, surf.ustar, zLL, surf.obukhov_length)
     prog_en.ρaHvar[kc_surf] = ρ0_ae * get_surface_variance(flux1 * α0LL, flux1 * α0LL, ustar, zLL, oblength)
     prog_en.ρaQTvar[kc_surf] = ρ0_ae * get_surface_variance(flux2 * α0LL, flux2 * α0LL, ustar, zLL, oblength)
     prog_en.ρaHQTcov[kc_surf] = ρ0_ae * get_surface_variance(flux1 * α0LL, flux2 * α0LL, ustar, zLL, oblength)

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -49,12 +49,12 @@ function get_mixing_tau(zi::FT, wstar::FT) where {FT}
 end
 
 # MO scaling of near surface tke and scalar variance
-
-function get_surface_tke(ustar::FT, zLL::FT, oblength::FT) where {FT}
+function get_surface_tke(param_set::APS, ustar::FT, zLL::FT, oblength::FT) where {FT}
+    κ_star²::FT = CPEDMF.κ_star²(param_set)
     if oblength < 0
-        return ((FT(3.75) + cbrt(zLL / oblength * zLL / oblength)) * ustar * ustar)
+        return ((κ_star² + cbrt(zLL / oblength * zLL / oblength)) * ustar * ustar)
     else
-        return (FT(3.75) * ustar * ustar)
+        return κ_star² * ustar * ustar
     end
 end
 function get_surface_variance(flux1::FT, flux2::FT, ustar::FT, zLL::FT, oblength::FT) where {FT}
@@ -67,15 +67,17 @@ function get_surface_variance(flux1::FT, flux2::FT, ustar::FT, zLL::FT, oblength
     end
 end
 
-function gradient_Richardson_number(∂b∂z::FT, Shear²::FT, ϵ::FT) where {FT}
-    return min(∂b∂z / max(Shear², ϵ), FT(0.25))
+function gradient_Richardson_number(param_set::APS, ∂b∂z::FT, Shear²::FT, ϵ::FT) where {FT}
+    Ri_c::FT = CPEDMF.Ri_c(param_set)
+    return min(∂b∂z / max(Shear², ϵ), Ri_c)
 end
 
+# Turbulent Prandtl number given the obukhov length sign and the gradient Richardson number
 function turbulent_Prandtl_number(param_set::APS, obukhov_length::FT, ∇Ri::FT) where {FT}
     ω_pr::FT = CPEDMF.ω_pr(param_set)
     Pr_n::FT = CPEDMF.Pr_n(param_set)
     if obukhov_length > 0 && ∇Ri > 0 #stable
-        # CSB (Dan Li, 2019), with Pr_neutral=0.74 and w1=40.0/13.0
+        # CSB (Dan Li, 2019, eq. 75), where ω_pr = ω_1 + 1 = 53.0/13.0
         prandtl_nvec = Pr_n * (2 * ∇Ri / (1 + ω_pr * ∇Ri - sqrt((1 + ω_pr * ∇Ri)^2 - 4 * ∇Ri)))
     else
         prandtl_nvec = Pr_n

--- a/src/types.jl
+++ b/src/types.jl
@@ -458,7 +458,7 @@ struct EDMF_PrognosticTKE{N_up, PM, ENT, EBGC, EC, SDES}
     entr_closure::EC
     function EDMF_PrognosticTKE(namelist, grid::Grid, param_set::PS) where {PS}
         # get values from namelist
-        prandtl_number = namelist["turbulence"]["prandtl_number_0"]
+        prandtl_number = namelist["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"]
 
         # Set the number of updrafts (1)
         n_updrafts = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "updraft_number"; default = 1)

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -441,7 +441,7 @@ function update_aux!(
 
         # Limiting stratification scale (Deardorff, 1976)
         # compute ∇Ri and Pr
-        ∇_Ri = gradient_Richardson_number(bg.∂b∂z, Shear²[k], eps(0.0))
+        ∇_Ri = gradient_Richardson_number(param_set, bg.∂b∂z, Shear²[k], eps(0.0))
         aux_tc.prandtl_nvec[k] = turbulent_Prandtl_number(param_set, obukhov_length, ∇_Ri)
 
         ml_model = MinDisspLen{FT}(;


### PR DESCRIPTION
This PR:

- Fixes an inconsistency in the critical Richardson number, which was hardcoded in one of the functions.
- Exposes Ri_c and Pr_t for calibration by moving them to the EDMF_Turbulence_... dictionary. These are after all empirical values.
- Gets Ri_c and a few other parameters from ClimaParameters.
- Exposes kappa_star^2, which was previously hardcoded.

