### PR TITLE
Add DYCOMS_RF02 case

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,17 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: ":partly_sunny: DYCOMS_RF02"
+    key: "cpu_dycoms_rf02"
+    command:
+      - "julia --color=yes --project=test integration_tests/DYCOMS_RF02.jl"
+    artifact_paths:
+      - "Output.DYCOMS_RF02.01/stats/comparison/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: ":partly_sunny: GABLS"
     key: "cpu_gabls"
     command:

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -107,3 +107,14 @@
   year = {2009},
   publisher = {Wiley Online Library}
 }
+
+@article{Ackerman2009,
+  title = {Large-Eddy Simulations of a Drizzling, Stratocumulus-Topped Marine Boundary Layer},
+  author = {Andrew S. Ackerman and Margreet C. vanZanten and Bjorn Stevens and Verica Savic-Jovcic and Christopher S. Bretherton and Andreas Chlond and Jean-Christophe Golaz and Hongli Jiang and Marat Khairoutdinov and Steven K. Krueger and David C. Lewellen and Adrian Lock and Chin-Hoh Moeng and Kozo Nakamura and Markus D. Petters and Jefferson R. Snider and Sonja Weinbrecht and Mike Zulauf},
+  journal = {Monthly Weather Review},
+  volume = {137},
+  number = {3},
+  year = {2009},
+  pages = {1083--1110},
+  doi = {10.1175/2008MWR2582.1}
+}

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -190,6 +190,8 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
         namelist = GATE_III(namelist_defaults)
     elseif case_name == "DYCOMS_RF01"
         namelist = DYCOMS_RF01(namelist_defaults)
+    elseif case_name == "DYCOMS_RF02"
+        namelist = DYCOMS_RF02(namelist_defaults)
     elseif case_name == "GABLS"
         namelist = GABLS(namelist_defaults)
     elseif case_name == "SP"
@@ -361,6 +363,27 @@ function DYCOMS_RF01(namelist_defaults)
 
     namelist["meta"]["simname"] = "DYCOMS_RF01"
     namelist["meta"]["casename"] = "DYCOMS_RF01"
+
+    return namelist
+end
+function DYCOMS_RF02(namelist_defaults)
+
+    namelist = deepcopy(namelist_defaults)
+
+    namelist["meta"]["casename"] = "DYCOMS_RF02"
+
+    namelist["grid"]["nz"] = 30
+    namelist["grid"]["dz"] = 50
+
+    namelist["time_stepping"]["adapt_dt"] = true
+    namelist["time_stepping"]["t_max"] = 60 * 60 * 6.0
+    namelist["time_stepping"]["dt_max"] = 4.0
+    namelist["time_stepping"]["dt_min"] = 1.0
+
+    namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+
+    namelist["meta"]["simname"] = "DYCOMS_RF02"
+    namelist["meta"]["casename"] = "DYCOMS_RF02"
 
     return namelist
 end

--- a/integration_tests/DYCOMS_RF02.jl
+++ b/integration_tests/DYCOMS_RF02.jl
@@ -1,0 +1,40 @@
+import Pkg
+Pkg.develop(path = ".")
+import TurbulenceConvection
+using Test
+
+const tc_dir = dirname(dirname(pathof(TurbulenceConvection)))
+include(joinpath(tc_dir, "driver", "main.jl"))
+include(joinpath(tc_dir, "driver", "generate_namelist.jl"))
+include(joinpath(tc_dir, "post_processing", "compute_mse.jl"))
+include(joinpath(tc_dir, "post_processing", "mse_tables.jl"))
+import .NameList
+
+best_mse = all_best_mse["DYCOMS_RF02"]
+
+case_name = "DYCOMS_RF02"
+println("Running $case_name...")
+namelist = NameList.default_namelist(case_name)
+namelist["meta"]["uuid"] = "01"
+ds_tc_filename, return_code = main(namelist)
+
+computed_mse = compute_mse_wrapper(
+    case_name,
+    best_mse,
+    ds_tc_filename;
+    plot_comparison = true,
+    t_start = 4 * 3600,
+    t_stop = 6 * 3600,
+)
+
+open("computed_mse_$case_name.json", "w") do io
+    JSON.print(io, computed_mse)
+end
+
+@testset "DYCOMS_RF02" begin
+    for k in keys(best_mse)
+        test_mse(computed_mse, best_mse, k)
+    end
+    include(joinpath(tc_dir, "post_processing", "post_run_tests.jl"))
+    nothing
+end

--- a/post_processing/Artifacts.toml
+++ b/post_processing/Artifacts.toml
@@ -1,5 +1,5 @@
 [PyCLES_output]
-git-tree-sha1 = "4a54eb3dfa48035d7a4318005963408a4e94c6d5"
+git-tree-sha1 = "c2d323fb412d1250182be3aeadf9d94e816550a0"
 
 [SCAMPy_output]
 git-tree-sha1 = "6b82611f969d3cf99102baa7d898e3c759cf014c"

--- a/post_processing/compute_mse.jl
+++ b/post_processing/compute_mse.jl
@@ -28,6 +28,7 @@ PyCLES_output_dataset = AW.ArtifactWrapper(
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc", filename = "DYCOMS_RF01.nc",),
+    AW.ArtifactFile(url = "https://caltech.box.com/shared/static/dgie1774uw5ot8mmrmp46nauhb3ervgp.nc", filename = "DYCOMS_RF02.nc",),
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/ivo4751camlph6u3k68ftmb1dl4z7uox.nc", filename = "TRMM_LBA.nc",),
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/4osqp0jpt4cny8fq2ukimgfnyi787vsy.nc", filename = "ARM_SGP.nc",),
     AW.ArtifactFile(url = "https://caltech.box.com/shared/static/jci8l11qetlioab4cxf5myr1r492prk6.nc", filename = "Bomex.nc",),

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -60,6 +60,22 @@ all_best_mse["DYCOMS_RF01"]["thetal_mean"] = 7.642054391010214e-5
 all_best_mse["DYCOMS_RF01"]["Hvar_mean"] = 1288.1546409185898
 all_best_mse["DYCOMS_RF01"]["QTvar_mean"] = 518.833475529373
 #
+all_best_mse["DYCOMS_RF02"] = OrderedCollections.OrderedDict()
+all_best_mse["DYCOMS_RF02"]["qt_mean"] = 0.07061626448507657
+all_best_mse["DYCOMS_RF02"]["ql_mean"] = 3.9702026751687347
+all_best_mse["DYCOMS_RF02"]["qr_mean"] = 3.7535267184726644
+all_best_mse["DYCOMS_RF02"]["updraft_area"] = 28.2466090899223
+all_best_mse["DYCOMS_RF02"]["updraft_w"] = 7.999061662392943
+all_best_mse["DYCOMS_RF02"]["updraft_qt"] = 5.0918816005111545
+all_best_mse["DYCOMS_RF02"]["updraft_thetal"] = 40.54948793296486
+all_best_mse["DYCOMS_RF02"]["v_mean"] = 42.9772055770869
+all_best_mse["DYCOMS_RF02"]["u_mean"] = 20.12106315849818
+all_best_mse["DYCOMS_RF02"]["tke_mean"] = 21.491477409531274
+all_best_mse["DYCOMS_RF02"]["temperature_mean"] = 2.3721074344072174e-5
+all_best_mse["DYCOMS_RF02"]["thetal_mean"] = 2.6849939819093862e-5
+all_best_mse["DYCOMS_RF02"]["Hvar_mean"] = 1464.8702014639657
+all_best_mse["DYCOMS_RF02"]["QTvar_mean"] = 512.8319511829964
+#
 all_best_mse["GABLS"] = OrderedCollections.OrderedDict()
 all_best_mse["GABLS"]["updraft_thetal"] = 0.0
 all_best_mse["GABLS"]["v_mean"] = 0.0

--- a/utils/print_new_mse.jl
+++ b/utils/print_new_mse.jl
@@ -6,6 +6,7 @@ all_cases = [
     "Bomex",
     "DryBubble",
     "DYCOMS_RF01",
+    "DYCOMS_RF02",
     "GABLS",
     "GATE_III",
     "life_cycle_Tan2018",


### PR DESCRIPTION
This adds a drizzling Sc test case. Currently the LES data is generated with SB microphysics scheme. Once I'm done with implementing the CliMA 1-moment scheme we should switch the dataset