### PR TITLE
Allow for non-local entr-detr models

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -81,13 +81,17 @@ end
 
 Base.eltype(::GeneralizedEntr{FT}) where {FT} = FT
 
-struct MDEntr end  # existing model
-struct NNEntr end
-struct LinearEntr end
-Base.@kwdef struct NoisyRelaxationProcess{MT}
+abstract type AbstractEntrDetrModel end
+abstract type AbstractNonLocalEntrDetrModel end
+struct MDEntr <: AbstractEntrDetrModel end  # existing model
+struct NNEntr <: AbstractEntrDetrModel end
+struct LinearEntr <: AbstractEntrDetrModel end
+struct FNNEntr <: AbstractNonLocalEntrDetrModel end
+
+Base.@kwdef struct NoisyRelaxationProcess{MT} <: AbstractEntrDetrModel
     mean_model::MT
 end
-Base.@kwdef struct LogNormalScalingProcess{MT}
+Base.@kwdef struct LogNormalScalingProcess{MT} <: AbstractEntrDetrModel
     mean_model::MT
 end
 
@@ -546,12 +550,14 @@ struct EDMF_PrognosticTKE{N_up, PM, ENT, EBGC, EC}
             "EDMF_PrognosticTKE",
             "entrainment";
             default = "moisture_deficit",
-            valid_options = ["moisture_deficit", "NN", "Linear"],
+            valid_options = ["moisture_deficit", "NN", "FNN", "Linear"],
         )
         mean_entr_closure = if entr_type == "moisture_deficit"
             MDEntr()
         elseif entr_type == "NN"
             NNEntr()
+        elseif entr_type == "FNN"
+            FNNEntr()
         elseif entr_type == "Linear"
             LinearEntr()
         else

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -35,6 +35,10 @@ cent_aux_vars_up(FT) = (;
     entr_turb_dyn = FT(0),
     detr_turb_dyn = FT(0),
     asp_ratio = FT(0),
+    Π₁ = FT(0),
+    Π₂ = FT(0),
+    Π₃ = FT(0),
+    Π₄ = FT(0),
 )
 cent_aux_vars_edmf(FT, n_up) = (;
     turbconv = (;


### PR DESCRIPTION
This PR preps some of the entr-detr modeling.

We are duplicating some code here, we could alternatively change the original code to accept the pi groups, if that would help simplify the second part of the entr-detr closure. Regardless, this should help encapsulate / overload the existing entr-detr closures