### PR TITLE
Fix GHA CI

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-import Pkg
-Pkg.develop(path = ".")
+if !("." in LOAD_PATH) # for ease of include
+    push!(LOAD_PATH, ".")
+end
 using Test
 import TurbulenceConvection
 const TC = TurbulenceConvection


### PR DESCRIPTION
Our GHA CI is broken from removing use of `LOAD_PATH` because `Pkg` is not part of TurbulenceConvection's deps. This broke because bors doesn't depend on GHA CI, which is fine.