### PR TITLE
prep for FNN

### DIFF
--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -149,7 +149,7 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["turbulence"]["scheme"] = "EDMF_PrognosticTKE"
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "Linear"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "Linear", "FNN"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = "deterministic"  # {"deterministic", "noisy_relaxation_process", "lognormal_scaling"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["use_local_micro"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false

--- a/src/closures/nondimensional_exchange_functions.jl
+++ b/src/closures/nondimensional_exchange_functions.jl
@@ -78,6 +78,28 @@ function non_dimensional_function(param_set, εδ_model_vars, ::NNEntr)
 end
 
 """
+    non_dimensional_function(param_set, εδ_model_vars, ::NNEntr)
+
+Uses a fully connected Fourier neural network to predict the non-dimensional components of dynamical entrainment/detrainment.
+ - `param_set`      :: parameter set
+ - `εδ_model_vars`  :: structure containing variables
+ - `εδ_model_type`  :: NNEntr - Neural network entrainment closure
+"""
+
+function non_dimensional_function(
+    param_set::APS,
+    Π₁::AbstractArray{FT}, # inputs
+    Π₂::AbstractArray{FT}, # inputs
+    Π₃::AbstractArray{FT}, # inputs
+    Π₄::AbstractArray{FT}, # inputs
+    εδ_model_type::FNNEntr,
+) where {FT <: Real}
+    c_gen = ICP.c_gen(param_set) # see non_dimensional_function(param_set, εδ_model_vars, ::NNEntr)
+    nondim_ε, nondim_δ = OperatorFlux.operator(Π₁, Π₂, Π₃, Π₄)
+    return nondim_ε, nondim_δ
+end
+
+"""
     non_dimensional_function(param_set, εδ_model_vars, ::LinearEntr)
 
 Uses a simple linear model to predict the non-dimensional components of dynamical entrainment/detrainment.

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -39,6 +39,7 @@ cent_aux_vars_up(FT) = (;
     Π₂ = FT(0),
     Π₃ = FT(0),
     Π₄ = FT(0),
+    ε_dim = FT(0),
 )
 cent_aux_vars_edmf(FT, n_up) = (;
     turbconv = (;


### PR DESCRIPTION
I am preparing the code for using FNN in a non local way, building on what Charlie did (already merged in main but not fully ready).
To do that I have added

A function that computed entr,detr with given dimensional and non-dimensional scale.
Move fnn! function to 'non_dimensional_exhange_function.jl' where it is now called as 'non_dimensional_function' that receives a non_localFNNEntr model type
in reviewing this please try to follow the trajectory of
update_aux -> compute_entr_detr!(FNNEntr::AbstractNonLocalEntrDetrModel) and 'entr_detr_given_scales'