### PR TITLE
Add nonlocal NN entr closure, fix entr bugs

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -36,7 +36,9 @@ function io_dictionary_diagnostics()
         "nh_pressure_b" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_diagnostics_turbconv(state).nh_pressure_b,),
         "turbulent_entrainment" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).frac_turb_entr,),
         "entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).entr_sc),
+        "nondim_entrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).nondim_entr_sc),
         "detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).detr_sc),
+        "nondim_detrainment_sc" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).nondim_detr_sc),
         "asp_ratio" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).asp_ratio),
         "massflux" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_diagnostics_turbconv(state).massflux),
     )
@@ -235,11 +237,19 @@ function compute_diagnostics!(
 
     @inbounds for k in TC.real_center_indices(grid)
         a_up_bulk_k = a_up_bulk[k]
+        diag_tc.entr_sc[k] = 0.0
+        diag_tc.nondim_entr_sc[k] = 0.0
+        diag_tc.detr_sc[k] = 0.0
+        diag_tc.nondim_detr_sc[k] = 0.0
+        diag_tc.asp_ratio[k] = 0.0
+        diag_tc.frac_turb_entr[k] = 0.0
         if a_up_bulk_k > 0.0
             @inbounds for i in 1:N_up
                 aux_up_i = aux_up[i]
                 diag_tc.entr_sc[k] += aux_up_i.area[k] * aux_up_i.entr_sc[k] / a_up_bulk_k
+                diag_tc.nondim_entr_sc[k] += aux_up_i.area[k] * aux_up_i.nondim_entr_sc[k] / a_up_bulk_k
                 diag_tc.detr_sc[k] += aux_up_i.area[k] * aux_up_i.detr_sc[k] / a_up_bulk_k
+                diag_tc.nondim_detr_sc[k] += aux_up_i.area[k] * aux_up_i.nondim_detr_sc[k] / a_up_bulk_k
                 diag_tc.asp_ratio[k] += aux_up_i.area[k] * aux_up_i.asp_ratio[k] / a_up_bulk_k
                 diag_tc.frac_turb_entr[k] += aux_up_i.area[k] * aux_up_i.frac_turb_entr[k] / a_up_bulk_k
             end
@@ -255,11 +265,16 @@ function compute_diagnostics!(
     a_up_f = copy(a_up_bulk_f)
     Ifabulk = CCO.InterpolateC2F(; a_bulk_bcs...)
     @. a_up_bulk_f = Ifabulk(a_up_bulk)
-    @inbounds for i in 1:N_up
-        a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
-        Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
-        @. a_up_f = Ifaup(aux_up[i].area)
-        @inbounds for k in TC.real_face_indices(grid)
+
+    @inbounds for k in TC.real_face_indices(grid)
+        @inbounds for i in 1:N_up
+            a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
+            Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
+            @. a_up_f = Ifaup(aux_up[i].area)
+            diag_tc_f.nh_pressure[k] = 0.0
+            diag_tc_f.nh_pressure_b[k] = 0.0
+            diag_tc_f.nh_pressure_adv[k] = 0.0
+            diag_tc_f.nh_pressure_drag[k] = 0.0
             if a_up_bulk_f[k] > 0.0
                 diag_tc_f.nh_pressure[k] += a_up_f[k] * aux_up_f[i].nh_pressure[k] / a_up_bulk_f[k]
                 diag_tc_f.nh_pressure_b[k] += a_up_f[k] * aux_up_f[i].nh_pressure_b[k] / a_up_bulk_f[k]

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -153,7 +153,7 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["turbulence"]["scheme"] = "EDMF_PrognosticTKE"
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "Linear", "FNO"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "NN_nonlocal", "Linear", "FNO"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = "deterministic"  # {"deterministic", "noisy_relaxation_process", "lognormal_scaling"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["use_local_micro"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false

--- a/src/closures/entr_detr.jl
+++ b/src/closures/entr_detr.jl
@@ -100,7 +100,6 @@ function compute_entr_detr!(
     plume_scale_height = map(1:N_up) do i
         compute_plume_scale_height(grid, state, param_set, i)
     end
-
     Ic = CCO.InterpolateF2C()
     ∇c = CCO.DivergenceF2C()
     LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(FT(0)))

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -63,6 +63,7 @@ function io_dictionary_aux()
         "eddy_viscosity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KM),
         "eddy_diffusivity" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).KH),
         "env_tke" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).tke),
+        "env_buoyancy" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).buoy),
         "env_Hvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).Hvar),
         "env_QTvar" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).QTvar),
         "env_HQTcov" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_environment(state).HQTcov),
@@ -133,7 +134,6 @@ function io_dictionary_aux()
 
         "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).dTdt_rad),
         "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).f_rad),
-
     )
     return io_dict
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -85,6 +85,7 @@ abstract type AbstractEntrDetrModel end
 abstract type AbstractNonLocalEntrDetrModel end
 struct MDEntr <: AbstractEntrDetrModel end  # existing model
 struct NNEntr <: AbstractEntrDetrModel end
+struct NNEntrNonlocal <: AbstractNonLocalEntrDetrModel end
 struct LinearEntr <: AbstractEntrDetrModel end
 struct FNOEntr <: AbstractNonLocalEntrDetrModel end
 
@@ -550,12 +551,14 @@ struct EDMF_PrognosticTKE{N_up, PM, ENT, EBGC, EC}
             "EDMF_PrognosticTKE",
             "entrainment";
             default = "moisture_deficit",
-            valid_options = ["moisture_deficit", "NN", "FNO", "Linear"],
+            valid_options = ["moisture_deficit", "NN", "NN_nonlocal", "FNO", "Linear"],
         )
         mean_entr_closure = if entr_type == "moisture_deficit"
             MDEntr()
         elseif entr_type == "NN"
             NNEntr()
+        elseif entr_type == "NN_nonlocal"
+            NNEntrNonlocal()
         elseif entr_type == "FNO"
             FNOEntr()
         elseif entr_type == "Linear"

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -162,8 +162,17 @@ face_aux_vars_edmf(FT, n_up) = (;
 ##### Diagnostic fields
 
 # Center only
-cent_diagnostic_vars_edmf(FT, n_up) =
-    (; turbconv = (; asp_ratio = FT(0), entr_sc = FT(0), detr_sc = FT(0), massflux = FT(0), frac_turb_entr = FT(0)))
+cent_diagnostic_vars_edmf(FT, n_up) = (;
+    turbconv = (;
+        asp_ratio = FT(0),
+        entr_sc = FT(0),
+        nondim_entr_sc = FT(0),
+        detr_sc = FT(0),
+        nondim_detr_sc = FT(0),
+        massflux = FT(0),
+        frac_turb_entr = FT(0),
+    ),
+)
 
 # Face only
 face_diagnostic_vars_edmf(FT, n_up) =


### PR DESCRIPTION
This PR: 
         1.) Adds a nonlocal NN entr closure type
         2.) Adds outputs to stats file needed to compute Pi groups offline and validate new closures
         3.) Addresses division by 0 in one of the Pi groups 
         4.) Fixes a bug affecting several entrainment-related outputs.
