### PR TITLE
Refactor `src/EDMF_Environment.jl`

### DIFF
--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -112,9 +112,8 @@ function microphysics(en_thermo::SGSQuadrature, grid::Grid, state::State, precip
                 corr = max(min(aux_en.HQTcov[k] / sqrt(aux_en.Hvar[k] * aux_en.QTvar[k]), 1), -1)
                 sd2_hq = log(corr * sqrt(aux_en.Hvar[k] * aux_en.QTvar[k]) / aux_en.θ_liq_ice[k] / aux_en.q_tot[k] + 1)
                 sd_cond_h_q = sqrt(max(sd_h * sd_h - sd2_hq * sd2_hq / sd_q / sd_q, 0))
-                mu_q =
-                    log(aux_en.q_tot[k] * aux_en.q_tot[k] / sqrt(aux_en.q_tot[k] * aux_en.q_tot[k] + aux_en.QTvar[k]))
-                mu_h = log(
+                μ_q = log(aux_en.q_tot[k] * aux_en.q_tot[k] / sqrt(aux_en.q_tot[k] * aux_en.q_tot[k] + aux_en.QTvar[k]))
+                μ_h = log(
                     aux_en.θ_liq_ice[k] * aux_en.θ_liq_ice[k] /
                     sqrt(aux_en.θ_liq_ice[k] * aux_en.θ_liq_ice[k] + aux_en.Hvar[k]),
                 )
@@ -130,7 +129,7 @@ function microphysics(en_thermo::SGSQuadrature, grid::Grid, state::State, precip
                 # TODO - change 1e-13 and 1e-10 to some epislon
                 sd_q = min(sd_q, sd_q_lim)
                 qt_var = sd_q * sd_q
-                sigma_h_star = sqrt(max(1 - corr * corr, 0)) * sd_h
+                σ_h_star = sqrt(max(1 - corr * corr, 0)) * sd_h
             end
 
             # zero outer quadrature points
@@ -143,11 +142,11 @@ function microphysics(en_thermo::SGSQuadrature, grid::Grid, state::State, precip
 
             for m_q in 1:quad_order
                 if quadrature_type isa LogNormalQuad
-                    qt_hat = exp(mu_q + sqrt2 * sd_q * abscissas[m_q])
-                    mu_h_star = mu_h + sd2_hq / sd_q / sd_q * (log(qt_hat) - mu_q)
+                    qt_hat = exp(μ_q + sqrt2 * sd_q * abscissas[m_q])
+                    μ_h_star = μ_h + sd2_hq / sd_q / sd_q * (log(qt_hat) - μ_q)
                 else
                     qt_hat = aux_en.q_tot[k] + sqrt2 * sd_q * abscissas[m_q]
-                    mu_h_star = aux_en.θ_liq_ice[k] + sqrt2 * corr * sd_h * abscissas[m_q]
+                    μ_h_star = aux_en.θ_liq_ice[k] + sqrt2 * corr * sd_h * abscissas[m_q]
                 end
 
                 # zero inner quadrature points
@@ -160,9 +159,9 @@ function microphysics(en_thermo::SGSQuadrature, grid::Grid, state::State, precip
 
                 for m_h in 1:quad_order
                     if quadrature_type isa LogNormalQuad
-                        h_hat = exp(mu_h_star + sqrt2 * sd_cond_h_q * abscissas[m_h])
+                        h_hat = exp(μ_h_star + sqrt2 * sd_cond_h_q * abscissas[m_h])
                     else
-                        h_hat = sqrt2 * sigma_h_star * abscissas[m_h] + mu_h_star
+                        h_hat = sqrt2 * σ_h_star * abscissas[m_h] + μ_h_star
                     end
 
                     # condensation


### PR DESCRIPTION
~In efforts of reducing dependence on `Cent`, we're trying to replace our `real_center_indices`/`real_face_indices` loops with broadcast expressions. One place where we have such a loop is in `src/EDMF_Environment.jl`, which happens to also be a part of the code that we'd like to try improving w.r.t. performance (it costs  about 20-30% of `∑tendencies!`).~

I spoke with @trontrytel, and we decided that renaming some of the other variables would be better in a separate PR since it affects many other places in the code. So this PR now only has the some small non-controversial name changes.