### PR TITLE
Reduce use of GridMeanVariables in TC

### DIFF
--- a/driver/Surface.jl
+++ b/driver/Surface.jl
@@ -9,7 +9,6 @@ function get_surface(
     surf_params::TC.FixedSurfaceFlux,
     grid::TC.Grid,
     state::TC.State,
-    gm::TC.GridMeanVariables,
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )
@@ -81,7 +80,6 @@ function get_surface(
     surf_params::TC.FixedSurfaceCoeffs,
     grid::TC.Grid,
     state::TC.State,
-    gm::TC.GridMeanVariables,
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )
@@ -140,7 +138,6 @@ function get_surface(
     surf_params::TC.MoninObukhovSurface,
     grid::TC.Grid,
     state::TC.State,
-    gm::TC.GridMeanVariables,
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )
@@ -199,7 +196,6 @@ function get_surface(
     surf_params::TC.SullivanPattonSurface,
     grid::TC.Grid,
     state::TC.State,
-    gm::TC.GridMeanVariables,
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -31,7 +31,7 @@ function affect_io!(integrator)
     io(io_nt.aux, Stats, state)
     io(io_nt.diagnostics, Stats, diagnostics)
 
-    surf = get_surface(case.surf_params, grid, state, gm, t, param_set)
+    surf = get_surface(case.surf_params, grid, state, t, param_set)
     io(surf, case.surf_params, grid, state, Stats, t)
 
     ODE.u_modified!(integrator, false) # We're legitamately not mutating `u` (the state vector)
@@ -42,7 +42,7 @@ function affect_filter!(integrator)
     t = integrator.t
     param_set = TC.parameter_set(gm)
     state = TC.State(integrator.u, aux, integrator.du)
-    surf = get_surface(case.surf_params, grid, state, gm, t, param_set)
+    surf = get_surface(case.surf_params, grid, state, t, param_set)
     TC.affect_filter!(edmf, grid, state, gm, surf, case.casename, t)
 
     # We're lying to OrdinaryDiffEq.jl, in order to avoid

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -137,7 +137,7 @@ function compute_diagnostics!(
     precip_model = edmf.precip_model
     diag_tc = center_diagnostics_turbconv(diagnostics)
     diag_tc_f = face_diagnostics_turbconv(diagnostics)
-    surf = get_surface(case.surf_params, grid, state, gm, t, param_set)
+    surf = get_surface(case.surf_params, grid, state, t, param_set)
 
     @inbounds for k in TC.real_center_indices(grid)
         ts = TD.PhaseEquil_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
@@ -295,7 +295,7 @@ function compute_diagnostics!(
     TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     TC.compute_covariance_interdomain_src(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
 
-    TC.update_cloud_frac(edmf, grid, state, gm)
+    TC.update_cloud_frac(edmf, grid, state)
 
 
     write_ts(Stats, "lwp_mean", sum(ρ0_c .* aux_gm.q_liq))

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -137,12 +137,12 @@ function initialize(sim::Simulation1d)
     FT = eltype(sim.grid)
     t = FT(0)
     Cases.initialize_profiles(sim.case, sim.grid, sim.gm, state)
-    satadjust(sim.gm, sim.grid, sim.state)
+    satadjust(sim.param_set, sim.grid, sim.state)
 
     Cases.initialize_forcing(sim.case, sim.grid, state, sim.gm, sim.param_set)
     Cases.initialize_radiation(sim.case, sim.grid, state, sim.gm, sim.param_set)
 
-    initialize_edmf(sim.edmf, sim.grid, state, sim.case, sim.gm, t)
+    initialize_edmf(sim.edmf, sim.grid, state, sim.case, sim.param_set, t)
 
     sim.skip_io && return nothing
     initialize_io(sim.io_nt.ref_state, sim.Stats)
@@ -162,7 +162,7 @@ function initialize(sim::Simulation1d)
     io(sim.io_nt.diagnostics, sim.Stats, sim.diagnostics)
 
     # TODO: deprecate
-    surf = get_surface(sim.case.surf_params, sim.grid, state, sim.gm, t, sim.param_set)
+    surf = get_surface(sim.case.surf_params, sim.grid, state, t, sim.param_set)
     io(surf, sim.case.surf_params, sim.grid, state, sim.Stats, t)
     close_files(sim.Stats)
 

--- a/src/EDMF_Precipitation.jl
+++ b/src/EDMF_Precipitation.jl
@@ -6,7 +6,7 @@ compute_precipitation_advection_tendencies(
     edmf::EDMFModel,
     grid::Grid,
     state::State,
-    gm::GridMeanVariables,
+    param_set::APS,
 ) = nothing
 
 function compute_precipitation_advection_tendencies(
@@ -14,7 +14,7 @@ function compute_precipitation_advection_tendencies(
     edmf::EDMFModel,
     grid::Grid,
     state::State,
-    gm::GridMeanVariables,
+    param_set::APS,
 )
     FT = eltype(grid)
 
@@ -24,7 +24,7 @@ function compute_precipitation_advection_tendencies(
     aux_tc = center_aux_turbconv(state)
 
     # helper to calculate the rain velocity
-    # TODO: assuming gm.W = 0
+    # TODO: assuming w_gm = 0
     # TODO: verify translation
     term_vel_rain = aux_tc.term_vel_rain
     term_vel_snow = aux_tc.term_vel_snow
@@ -54,12 +54,11 @@ compute_precipitation_sink_tendencies(
     ::AbstractPrecipitationModel,
     grid::Grid,
     state::State,
-    gm::GridMeanVariables,
+    param_set::APS,
     Δt::Real,
 ) = nothing
 
-function compute_precipitation_sink_tendencies(::Clima1M, grid::Grid, state::State, gm::GridMeanVariables, Δt::Real)
-    param_set = parameter_set(gm)
+function compute_precipitation_sink_tendencies(::Clima1M, grid::Grid, state::State, param_set::APS, Δt::Real)
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
     aux_gm = center_aux_grid_mean(state)

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -1,5 +1,5 @@
 
-function update_cloud_frac(edmf::EDMFModel, grid::Grid, state::State, gm::GridMeanVariables)
+function update_cloud_frac(edmf::EDMFModel, grid::Grid, state::State)
     # update grid-mean cloud fraction and cloud cover
     aux_bulk = center_aux_bulk(state)
     aux_gm = center_aux_grid_mean(state)
@@ -27,7 +27,7 @@ function compute_les_Γᵣ(
     end
 end
 
-function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, gm::GridMeanVariables)
+function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase)
     N_up = n_updrafts(edmf)
     tendencies_gm = center_tendencies_grid_mean(state)
     FT = eltype(grid)
@@ -109,14 +109,7 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     return nothing
 end
 
-function compute_diffusive_fluxes(
-    edmf::EDMFModel,
-    grid::Grid,
-    state::State,
-    gm::GridMeanVariables,
-    surf::SurfaceBase,
-    param_set::APS,
-)
+function compute_diffusive_fluxes(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
     FT = eltype(grid)
     ρ0_f = face_ref_state(state).ρ0
     aux_bulk = center_aux_bulk(state)
@@ -167,6 +160,7 @@ function affect_filter!(
     casename::String,
     t::Real,
 )
+    param_set = parameter_set(gm)
     # TODO: figure out why this filter kills the DryBubble results if called at t = 0.
     if casename == "DryBubble" && !(t > 0)
         return nothing
@@ -175,8 +169,8 @@ function affect_filter!(
     ###
     ### Filters
     ###
-    set_edmf_surface_bc(edmf, grid, state, surf, gm)
-    filter_updraft_vars(edmf, grid, state, surf, gm)
+    set_edmf_surface_bc(edmf, grid, state, surf, param_set)
+    filter_updraft_vars(edmf, grid, state, surf)
 
     @inbounds for k in real_center_indices(grid)
         prog_en.ρatke[k] = max(prog_en.ρatke[k], 0.0)
@@ -188,8 +182,7 @@ function affect_filter!(
     return nothing
 end
 
-function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, gm::GridMeanVariables)
-    param_set = parameter_set(gm)
+function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
@@ -335,9 +328,8 @@ function compute_plume_scale_height(grid::Grid{FT}, state::State, param_set::APS
     return max(updraft_top, H_up_min)
 end
 
-function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, gm::GridMeanVariables, surf::SurfaceBase)
+function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param_set::APS, surf::SurfaceBase)
     N_up = n_updrafts(edmf)
-    param_set = parameter_set(gm)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
     FT = eltype(grid)
@@ -435,9 +427,8 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, gm::G
     return nothing
 end
 
-function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, gm::GridMeanVariables)
+function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase)
     N_up = n_updrafts(edmf)
-    param_set = parameter_set(gm)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
     FT = eltype(grid)
@@ -501,7 +492,6 @@ function compute_covariance_shear(
     edmf::EDMFModel,
     grid::Grid,
     state::State,
-    gm::GridMeanVariables,
     ::Val{covar_sym},
     ::Val{ϕ_en_sym},
     ::Val{ψ_en_sym},

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -1,6 +1,5 @@
 function update_aux!(
     edmf::EDMFModel,
-    gm::GridMeanVariables,
     grid::Grid,
     state::State,
     case::CasesBase,
@@ -232,7 +231,7 @@ function update_aux!(
         Ifu = CCO.InterpolateC2F(; a_up_bcs...)
         @. aux_tc_f.bulk.w += ifelse(Ifb(aux_bulk.area) > 0, Ifu(a_up) * aux_up_f[i].w / Ifb(aux_bulk.area), FT(0))
     end
-    # Assuming gm.W = 0!
+    # Assuming w_gm = 0!
     @. aux_en_f.w = -Ifb(aux_bulk.area) / (1 - Ifb(aux_bulk.area)) * aux_tc_f.bulk.w
 
     #####
@@ -398,10 +397,10 @@ function update_aux!(
     compute_covariance_entr(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
     compute_covariance_entr(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
     compute_covariance_entr(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:tke), Val(:w), Val(:w))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:QTvar), Val(:q_tot), Val(:q_tot))
-    compute_covariance_shear(edmf, grid, state, gm, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
+    compute_covariance_shear(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
+    compute_covariance_shear(edmf, grid, state, Val(:Hvar), Val(:θ_liq_ice), Val(:θ_liq_ice))
+    compute_covariance_shear(edmf, grid, state, Val(:QTvar), Val(:q_tot), Val(:q_tot))
+    compute_covariance_shear(edmf, grid, state, Val(:HQTcov), Val(:θ_liq_ice), Val(:q_tot))
     compute_covariance_dissipation(edmf, grid, state, Val(:tke), param_set)
     compute_covariance_dissipation(edmf, grid, state, Val(:Hvar), param_set)
     compute_covariance_dissipation(edmf, grid, state, Val(:QTvar), param_set)
@@ -417,13 +416,13 @@ function update_aux!(
 
     get_GMV_CoVar(edmf, grid, state, Val(:tke), Val(:w), Val(:w))
 
-    compute_diffusive_fluxes(edmf, grid, state, gm, surf, param_set)
+    compute_diffusive_fluxes(edmf, grid, state, surf, param_set)
 
 
     # TODO: use dispatch
     if edmf.precip_model isa Clima1M
         # helper to calculate the rain velocity
-        # TODO: assuming gm.W = 0
+        # TODO: assuming w_gm = 0
         # TODO: verify translation
         term_vel_rain = aux_tc.term_vel_rain
         term_vel_snow = aux_tc.term_vel_snow


### PR DESCRIPTION
I think this should make inter-oping with a dycore easier.