### PR TITLE
Make reference_params return a thermo state

### DIFF
--- a/docs/src/PlotReferenceStates.jl
+++ b/docs/src/PlotReferenceStates.jl
@@ -24,7 +24,7 @@ function export_ref_profile(case_name::String)
     grid = TC.Grid(FT(namelist["grid"]["dz"]), namelist["grid"]["nz"])
     Stats = NetCDFIO_Stats(namelist, grid)
     case = Cases.get_case(namelist)
-    ref_params = Cases.reference_params(case, grid, param_set, namelist)
+    surf_ref_state = Cases.surface_ref_state(case, grid, param_set, namelist)
 
     aux_vars(FT) = (; ref_state = (ρ0 = FT(0), α0 = FT(0), p0 = FT(0)))
     aux_cent_fields = TC.FieldFromNamedTuple(TC.center_space(grid), aux_vars(FT))
@@ -33,7 +33,7 @@ function export_ref_profile(case_name::String)
     aux = CC.Fields.FieldVector(cent = aux_cent_fields, face = aux_face_fields)
     state = (; aux)
 
-    compute_ref_state!(state, grid, param_set; ref_params...)
+    compute_ref_state!(state, grid, param_set; ts_g = surf_ref_state)
 
     io_nt = TC.io_dictionary_ref_state()
     initialize_io(io_nt, Stats)

--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -172,11 +172,11 @@ initialize_forcing(self::CasesBase, grid::Grid, state, param_set) = initialize(s
 ForcingBase(case::Soares, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, apply_subsidence = false)
 
-function reference_params(::Soares, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::Soares, grid::Grid, param_set::APS, namelist)
     Pg = 1000.0 * 100.0
     qtg = 5.0e-3
     Tg = 300.0
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{Soares}, grid::Grid, param_set, state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -221,11 +221,11 @@ end
 ForcingBase(case::Nieuwstadt, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, apply_subsidence = false)
 
-function reference_params(::Nieuwstadt, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::Nieuwstadt, grid::Grid, param_set::APS, namelist)
     Pg = 1000.0 * 100.0
     Tg = 300.0
     qtg = 1.0e-12 # Total water mixing ratio
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{Nieuwstadt}, grid::Grid, param_set, state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -268,11 +268,11 @@ end
 ForcingBase(case::Bomex, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, apply_subsidence = true, coriolis_param = 0.376e-4) #= s^{-1} =#
 
-function reference_params(::Bomex, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::Bomex, grid::Grid, param_set::APS, namelist)
     Pg = 1.015e5 #Pressure at ground
     Tg = 300.4 #Temperature at ground
     qtg = 0.02245#Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{Bomex}, grid::Grid, param_set, state)
@@ -348,11 +348,11 @@ end
 ForcingBase(case::life_cycle_Tan2018, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, apply_subsidence = true, coriolis_param = 0.376e-4) #= s^{-1} =#
 
-function reference_params(::life_cycle_Tan2018, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::life_cycle_Tan2018, grid::Grid, param_set::APS, namelist)
     Pg = 1.015e5  #Pressure at ground
     Tg = 300.4  #Temperature at ground
     qtg = 0.02245   #Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{life_cycle_Tan2018}, grid::Grid, param_set, state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -450,13 +450,13 @@ function ForcingBase(case::Rico, param_set::APS; kwargs...)
     ) #= s^{-1} =#
 end
 
-function reference_params(::Rico, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::Rico, grid::Grid, param_set::APS, namelist)
     molmass_ratio = CPP.molmass_ratio(param_set)
     Pg = 1.0154e5  #Pressure at ground
     Tg = 299.8  #Temperature at ground
     pvg = TD.saturation_vapor_pressure(param_set, Tg, TD.Liquid())
     qtg = (1 / molmass_ratio) * pvg / (Pg - pvg)   #Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{Rico}, grid::Grid, param_set, state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -552,13 +552,13 @@ end
 ForcingBase(case::TRMM_LBA, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, apply_subsidence = false, kwargs...)
 
-function reference_params(::TRMM_LBA, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::TRMM_LBA, grid::Grid, param_set::APS, namelist)
     molmass_ratio = CPP.molmass_ratio(param_set)
     Pg = 991.3 * 100  #Pressure at ground
     Tg = 296.85   # surface values for reference state (RS) which outputs p0 rho0 alpha0
     pvg = TD.saturation_vapor_pressure(param_set, Tg, TD.Liquid())
     qtg = (1 / molmass_ratio) * pvg / (Pg - pvg) #Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{TRMM_LBA}, grid::Grid, param_set, state)
     p0 = TC.center_ref_state(state).p0
@@ -640,11 +640,11 @@ end
 ForcingBase(case::ARM_SGP, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, apply_subsidence = false, coriolis_param = 8.5e-5)
 
-function reference_params(::ARM_SGP, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::ARM_SGP, grid::Grid, param_set::APS, namelist)
     Pg = 970.0 * 100 #Pressure at ground
     Tg = 299.0   # surface values for reference state (RS) which outputs p0 rho0 alpha0
     qtg = 15.2 / 1000 #Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{ARM_SGP}, grid::Grid, param_set, state)
@@ -723,11 +723,11 @@ end
 ForcingBase(case::GATE_III, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, apply_subsidence = false)
 
-function reference_params(::GATE_III, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::GATE_III, grid::Grid, param_set::APS, namelist)
     Pg = 1013.0 * 100  #Pressure at ground
     Tg = 299.184   # surface values for reference state (RS) which outputs p0 rho0 alpha0
     qtg = 16.5 / 1000 #Total water mixing ratio at surface
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{GATE_III}, grid::Grid, param_set, state)
@@ -776,13 +776,13 @@ end
 ##### DYCOMS_RF01
 #####
 
-function reference_params(::DYCOMS_RF01, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::DYCOMS_RF01, grid::Grid, param_set::APS, namelist)
     Pg = 1017.8 * 100.0
     qtg = 9.0 / 1000.0
-    theta_surface = 289.0
-    ts = TD.PhaseEquil_pθq(param_set, Pg, theta_surface, qtg)
+    θ_surf = 289.0
+    ts = TD.PhaseEquil_pθq(param_set, Pg, θ_surf, qtg)
     Tg = TD.air_temperature(ts)
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{DYCOMS_RF01}, grid::Grid, param_set, state)
@@ -861,13 +861,13 @@ end
 ##### DYCOMS_RF02
 #####
 
-function reference_params(::DYCOMS_RF02, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::DYCOMS_RF02, grid::Grid, param_set::APS, namelist)
     Pg = 1017.8 * 100.0
     qtg = 9.0 / 1000.0
-    theta_surface = 288.3
-    ts = TD.PhaseEquil_pθq(param_set, Pg, theta_surface, qtg)
+    θ_surf = 288.3
+    ts = TD.PhaseEquil_pθq(param_set, Pg, θ_surf, qtg)
     Tg = TD.air_temperature(ts)
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{DYCOMS_RF02}, grid::Grid, param_set, state)
@@ -959,11 +959,11 @@ function ForcingBase(case::GABLS, param_set::APS; kwargs...)
     )
 end
 
-function reference_params(::GABLS, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::GABLS, grid::Grid, param_set::APS, namelist)
     Pg = 1.0e5  #Pressure at ground,
     Tg = 265.0  #Temperature at ground,
     qtg = 0.0
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 function initialize_profiles(self::CasesBase{GABLS}, grid::Grid, param_set, state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -1025,11 +1025,11 @@ function ForcingBase(case::SP, param_set::APS; kwargs...)
     )
 end
 
-function reference_params(::SP, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::SP, grid::Grid, param_set::APS, namelist)
     Pg = 1.0e5  #Pressure at ground
     Tg = 300.0  #Temperature at ground
     qtg = 1.0e-4   #Total water mixing ratio at TC. if set to 0, alpha0, rho0, p0 are NaN.
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{SP}, grid::Grid, param_set, state)
@@ -1062,11 +1062,11 @@ end
 ForcingBase(case::DryBubble, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, apply_subsidence = false)
 
-function reference_params(::DryBubble, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::DryBubble, grid::Grid, param_set::APS, namelist)
     Pg = 1.0e5  #Pressure at ground
     Tg = 296.0
     qtg = 1.0e-5
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{DryBubble}, grid::Grid, param_set, state)
@@ -1131,7 +1131,7 @@ function ForcingBase(case::LES_driven_SCM, param_set::APS; nudge_tau)
     )
 end
 
-function reference_params(::LES_driven_SCM, grid::Grid, param_set::APS, namelist)
+function surface_ref_state(::LES_driven_SCM, grid::Grid, param_set::APS, namelist)
     les_filename = namelist["meta"]["lesfile"]
 
     Pg, Tg, qtg = NC.Dataset(les_filename, "r") do data
@@ -1143,7 +1143,7 @@ function reference_params(::LES_driven_SCM, grid::Grid, param_set::APS, namelist
         qtg = ql_ground + qv_ground + qi_ground #Total water mixing ratio at surface
         (Pg, Tg, qtg)
     end
-    return (; Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
 end
 
 function initialize_profiles(self::CasesBase{LES_driven_SCM}, grid::Grid, param_set, state)

--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -110,19 +110,19 @@ face_prognostic_vars(FT, n_up) = (; w = FT(0), TC.face_prognostic_vars_edmf(FT, 
         state,
         grid::Grid,
         param_set::PS;
-        Pg::FT,
-        Tg::FT,
-        qtg::FT,
-    ) where {PS, FT}
+        ts_g,
+    ) where {PS}
 
 TODO: add better docs once the API converges
 
 The reference profiles, given
  - `grid` the grid
  - `param_set` the parameter set
+ - `ts_g` the surface reference state (a thermodynamic state)
 """
-function compute_ref_state!(state, grid::TC.Grid, param_set::PS; Pg::FT, Tg::FT, qtg::FT) where {PS, FT}
+function compute_ref_state!(state, grid::TC.Grid, param_set::PS; ts_g) where {PS}
 
+    FT = eltype(grid)
     p0_c = TC.center_ref_state(state).p0
     ρ0_c = TC.center_ref_state(state).ρ0
     α0_c = TC.center_ref_state(state).α0
@@ -130,9 +130,9 @@ function compute_ref_state!(state, grid::TC.Grid, param_set::PS; Pg::FT, Tg::FT,
     ρ0_f = TC.face_ref_state(state).ρ0
     α0_f = TC.face_ref_state(state).α0
 
-    q_pt_g = TD.PhasePartition(qtg)
-    ts_g = TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    qtg = TD.total_specific_humidity(ts_g)
     θ_liq_ice_g = TD.liquid_ice_pottemp(ts_g)
+    Pg = TD.air_pressure(ts_g)
 
     # We are integrating the log pressure so need to take the log of the
     # surface pressure

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -71,7 +71,7 @@ function Simulation1d(namelist)
 
     Stats = skip_io ? nothing : NetCDFIO_Stats(namelist, grid)
     case_type = Cases.get_case(namelist)
-    ref_params = Cases.reference_params(case_type, grid, param_set, namelist)
+    surf_ref_state = Cases.surface_ref_state(case_type, grid, param_set, namelist)
 
     Fo = TC.ForcingBase(case_type, param_set; Cases.forcing_kwargs(case_type, namelist)...)
     Rad = TC.RadiationBase(case_type)
@@ -97,7 +97,7 @@ function Simulation1d(namelist)
 
     # `nothing` goes into State because OrdinaryDiffEq.jl owns tendencies.
     state = TC.State(prog, aux, nothing)
-    compute_ref_state!(state, grid, param_set; ref_params...)
+    compute_ref_state!(state, grid, param_set; ts_g = surf_ref_state)
 
     Ri_bulk_crit = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     spk = Cases.surface_param_kwargs(case_type, namelist)


### PR DESCRIPTION
This is a sub-step to refactor `surface_params` so that it doesn't require the entire state.