### PR TITLE
Unfuse some TC tendency functions

### DIFF
--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -221,6 +221,17 @@ function ∑tendencies!(tendencies::FV, prog::FV, params::NT, t::Real) where {NT
     parent(tends_face) .= 0
     parent(tends_cent) .= 0
     # compute tendencies
+
+    en_thermo = edmf.en_thermo
+    precip_model = edmf.precip_model
+
+    # compute tendencies
+    # causes division error in dry bubble first time step
+    TC.compute_precipitation_formation_tendencies(grid, state, edmf, precip_model, Δt, param_set)
+    TC.microphysics(en_thermo, grid, state, precip_model, Δt, param_set)
+    TC.compute_precipitation_sink_tendencies(precip_model, grid, state, param_set, Δt)
+    TC.compute_precipitation_advection_tendencies(precip_model, edmf, grid, state, param_set)
+
     TC.compute_turbconv_tendencies!(edmf, grid, state, param_set, surf, Δt)
     compute_gm_tendencies!(edmf, grid, state, surf, radiation, force, param_set)
 

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -36,15 +36,6 @@ function compute_turbconv_tendencies!(
     surf::SurfaceBase,
     Δt::Real,
 )
-    en_thermo = edmf.en_thermo
-    precip_model = edmf.precip_model
-
-    # compute tendencies
-    # causes division error in dry bubble first time step
-    compute_precipitation_formation_tendencies(grid, state, edmf, precip_model, Δt, param_set)
-    microphysics(en_thermo, grid, state, precip_model, Δt, param_set)
-    compute_precipitation_sink_tendencies(precip_model, grid, state, param_set, Δt)
-    compute_precipitation_advection_tendencies(precip_model, edmf, grid, state, param_set)
     compute_up_tendencies!(edmf, grid, state, param_set, surf)
     compute_en_tendencies!(edmf, grid, state, param_set, Val(:tke), Val(:ρatke))
     compute_en_tendencies!(edmf, grid, state, param_set, Val(:Hvar), Val(:ρaHvar))


### PR DESCRIPTION
I accidentally moved some of these functions into `compute_turbconv_tendencies!`, when they are generally something the dycore should call, not edmf.