### PR TITLE
change default NN to 2-layer network, generalize NN construction

### DIFF
--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -105,27 +105,24 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     # entrainment
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment_factor"] = 0.13
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["detrainment_factor"] = 0.51
-    # 1-layer nn parameters
+    # nn parameters
     #! format: off
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["general_ent_params"] =
-        SA.SVector(0.3038, 0.719,-0.910,-0.483,
-                   0.739, 0.0755, 0.178, 0.521,
-                   0.0, 0.0, 0.843,-0.340,
-                   0.655, 0.113, 0.0, 0.0)
+        SA.SVector{69}(rand(69))
     # For FNO add here
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["fno_ent_params"] =
         SA.SVector{74}(rand(74))
 
-    # m=100 random features, d=4 input Pi groups
+    # m=100 random features, d=6 input Pi groups
     # RF: parameters to optimize, 2 x (m + 1 + d)
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["rf_opt_ent_params"] =
-        vec(cat(sqrt(100) * randn(2,100),
-                    ones(2,5), dims=2))
+        vec(cat(sqrt(100) * randn(2,100), # vec(cat(sqrt(m) * randn(2, m),
+                    ones(2,7), dims=2)) # ones(2, d + 1), dims=2))
 
     # RF: fixed realizations of random variables, 2 x m x (1 + d)
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["rf_fix_ent_params"] =
-        vec(cat(2*pi*rand(2,100,1),
-                    randn(2,100,4), dims=3))
+        vec(cat(2*pi*rand(2,100,1), # vec(cat(2*pi*rand(2, m, 1),
+                    randn(2,100,6), dims=3)) # randn(2, m, d), dims=3))
 
     # General stochastic entrainment/detrainment parameters
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["general_stochastic_ent_params"] =
@@ -175,6 +172,8 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "NN_nonlocal", "Linear", "FNO", "RF"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = "buoy_vel" # {"buoy_vel", "inv_z"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_pi_subset"] = ntuple(i -> i, 6) # or, e.g., (1, 3, 6)
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pi_norm_consts"] = [478.298, 1.0, 1.0, 1.0, 1.0, 1.0] # normalization constants for Pi groups
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = "deterministic"  # {"deterministic", "noisy_relaxation_process", "lognormal_scaling", "prognostic_noisy_relaxation_process"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["use_local_micro"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -292,6 +292,7 @@ function main1d(namelist; time_run = true)
         "fno_ent_params",
         "rf_opt_ent_params",
         "rf_fix_ent_params",
+        "pi_norm_consts",
     ]
         if haskey(namelist["turbulence"]["EDMF_PrognosticTKE"], param_name)
             _p = namelist["turbulence"]["EDMF_PrognosticTKE"][param_name]

--- a/src/ClimaParams.jl
+++ b/src/ClimaParams.jl
@@ -23,6 +23,7 @@ static_stab_coeff(ps::APS) = ps.nt.c_b
 l_max(ps::APS) = ps.nt.l_max
 
 """Additional entrainment/detrainment parameters."""
+Π_norm(ps::APS) = ps.nt.Π_norm
 c_gen(ps::APS) = ps.nt.c_gen
 c_fno(ps::APS) = ps.nt.c_fno
 c_rf_fix(ps::APS) = ps.nt.c_rf_fix

--- a/src/closures/nondimensional_exchange_functions.jl
+++ b/src/closures/nondimensional_exchange_functions.jl
@@ -8,15 +8,21 @@ function max_area_limiter(param_set, max_area, a_up)
 end
 
 function non_dimensional_groups(param_set, εδ_model_vars)
+    FT = eltype(εδ_model_vars.tke_en)
     Δw = get_Δw(param_set, εδ_model_vars.w_up, εδ_model_vars.w_en)
     Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
-    FT = eltype(εδ_model_vars.tke_en)
-    Π_1 = (εδ_model_vars.zc_i * Δb) / (Δw^2 + εδ_model_vars.wstar^2)
-    Π_1 = Π_1 / FT(478.298) # Normalize by max(abs(Π_1)) found in {Bomex, DYCOMS, TRMM}
-    Π_2 = (εδ_model_vars.tke_gm - εδ_model_vars.a_en * εδ_model_vars.tke_en) / (εδ_model_vars.tke_gm + eps(FT))
-    Π_3 = √(εδ_model_vars.a_up)
-    Π_4 = εδ_model_vars.RH_up - εδ_model_vars.RH_en
-    return SA.SVector(Π_1, Π_2, Π_3, Π_4)
+    Π_norm = ICP.Π_norm(param_set)
+    Π₁ = (εδ_model_vars.zc_i * Δb) / (Δw^2 + εδ_model_vars.wstar^2) / Π_norm[1]
+    Π₂ =
+        (εδ_model_vars.tke_gm - εδ_model_vars.a_en * εδ_model_vars.tke_en) / (εδ_model_vars.tke_gm + eps(FT)) /
+        Π_norm[2]
+    Π₃ = √(εδ_model_vars.a_up) / Π_norm[3]
+    Π₄ = (εδ_model_vars.RH_up - εδ_model_vars.RH_en) / Π_norm[4]
+    Π₅ = εδ_model_vars.zc_i / εδ_model_vars.H_up / Π_norm[5]
+    Π₆ = εδ_model_vars.zc_i / εδ_model_vars.ref_H / Π_norm[6]
+    Π_groups = (Π₁, Π₂, Π₃, Π₄, Π₅, Π₆)
+
+    return map(i -> Π_groups[i], εδ_model_vars.entr_Π_subset)
 end
 
 """
@@ -29,7 +35,7 @@ functions following Cohen et al. (JAMES, 2020), given:
  - `εδ_model_type`  :: MDEntr - Moisture deficit entrainment closure
 """
 function non_dimensional_function(param_set, εδ_model_vars, ::MDEntr)
-    FT = eltype(εδ_model_vars)
+    FT = eltype(εδ_model_vars.q_cond_up)
     Δw = get_Δw(param_set, εδ_model_vars.w_up, εδ_model_vars.w_en)
     c_ε = FT(CPEDMF.c_ε(param_set))
     μ_0 = FT(CPEDMF.μ_0(param_set))
@@ -56,32 +62,30 @@ function non_dimensional_function(param_set, εδ_model_vars, ::MDEntr)
 end
 
 """
-    non_dimensional_function!(nondim_ε ,nondim_δ ,param_set ,Π₁ ,Π₂ ,Π₃ ,Π₄, εδ_model::FNOEntr)
+    non_dimensional_function!(nondim_ε, nondim_δ, param_set, Π_groups, εδ_model::FNOEntr)
 
 Uses a non local (Fourier) neural network to predict the fields of
     non-dimensional components of dynamical entrainment/detrainment.
  - `nondim_ε`   :: output - non dimensional entr from FNO, as column fields
  - `nondim_δ`   :: output - non dimensional detr from FNO, as column fields
  - `param_set`  :: input - parameter set
- - `Π₁,₂,₃,₄`   :: input - non dimensional groups, as column fields
+ - `Π_groups`   :: input - non dimensional groups, as column fields
  - `::FNOEntr ` a non-local entrainment-detrainment model type
 """
 function non_dimensional_function!(
     nondim_ε::AbstractArray{FT}, # output
     nondim_δ::AbstractArray{FT}, # output
     param_set::APS,
-    Π₁::AbstractArray{FT}, # input
-    Π₂::AbstractArray{FT}, # input
-    Π₃::AbstractArray{FT}, # input
-    Π₄::AbstractArray{FT}, # input
+    Π_groups::AbstractArray{FT}, # input
     εδ_model::FNOEntr,
 ) where {FT <: Real}
 
+    n_input_vars = size(Π_groups)[2]
     # define the model
-    Π = hcat(Π₁, Π₂, Π₃, Π₄)'
+    Π = Π_groups'
     Π = reshape(Π, (size(Π)..., 1))
     trafo = OF.FourierTransform(modes = (2,))
-    model = OF.Chain(OF.SpectralKernelOperator(trafo, 4 => 2, Flux.relu),)
+    model = OF.Chain(OF.SpectralKernelOperator(trafo, n_input_vars => 2, Flux.relu),)
 
     # set the parameters
     c_fno = ICP.c_fno(param_set)
@@ -110,39 +114,85 @@ function non_dimensional_function!(
 end
 
 """
-    non_dimensional_function!(nondim_ε ,nondim_δ ,param_set ,Π₁ ,Π₂ ,Π₃ ,Π₄, εδ_model::NNEntr)
+    Count number of parameters in fully-connected NN model given tuple specifying architecture following
+         the pattern: (#inputs, #neurons in L1, #neurons in L2, ...., #outputs)
+"""
+num_params_from_arc(nn_arc::NTuple) = sum(i -> (nn_arc[i] * nn_arc[i + 1] + nn_arc[i + 1]), 1:(length(nn_arc) - 1))
+
+"""
+    construct_fully_connected_nn(
+        nn_arc::NTuple,
+        parameters::AbstractArray{FT};
+        activation_function::Flux.Function = Flux.sigmoid,
+        output_layer_activation_function::Flux.Function = Flux.relu,)
+
+    Given network architecture and parameter vector, construct NN model and unpack parameters as weights and biases.
+    - `nn_arc` :: tuple specifying network architecture
+    - `nn_params` :: parameter vector containing weights and biases
+    - `activation_function` :: activation function for hidden layers
+    - `output_layer_activation_function` :: activation function for output layer
+"""
+function construct_fully_connected_nn(
+    nn_arc::NTuple,
+    parameters::AbstractArray{FT};
+    activation_function::Flux.Function = Flux.sigmoid,
+    output_layer_activation_function::Flux.Function = Flux.relu,
+) where {FT <: Real}
+
+    n_params_nn = num_params_from_arc(nn_arc)
+    n_params_vect = length(parameters)
+    if n_params_vect != n_params_nn
+        error("Incorrect number of parameters ($n_params_vect) for requested NN architecture ($n_params_nn)!")
+    end
+
+    layers = []
+    parameters_i = 1
+    # unpack parameters in parameter vector into network
+    for layer_i in 1:(length(nn_arc) - 1)
+        if layer_i == length(nn_arc) - 1
+            activation_function = output_layer_activation_function
+        end
+        layer_num_weights = nn_arc[layer_i] * nn_arc[layer_i + 1]
+        layer = Flux.Dense(
+            reshape(
+                parameters[parameters_i:(parameters_i + layer_num_weights - 1)],
+                nn_arc[layer_i + 1],
+                nn_arc[layer_i],
+            ),
+            parameters[(parameters_i + layer_num_weights):(parameters_i + layer_num_weights + nn_arc[layer_i + 1] - 1)],
+            activation_function,
+        )
+        parameters_i += layer_num_weights + nn_arc[layer_i + 1]
+        push!(layers, layer)
+    end
+
+    return Flux.Chain(layers...)
+end
+
+"""
+    non_dimensional_function!(nondim_ε, nondim_δ, param_set, Π_groups, εδ_model::NNEntrNonlocal)
 
 Uses a fully connected neural network to predict the non-dimensional components of dynamical entrainment/detrainment.
     non-dimensional components of dynamical entrainment/detrainment.
  - `nondim_ε`   :: output - non dimensional entr from FNO, as column fields
  - `nondim_δ`   :: output - non dimensional detr from FNO, as column fields
  - `param_set`  :: input - parameter set
- - `Π₁,₂,₃,₄`   :: input - non dimensional groups, as column fields
+ - `Π_groups`   :: input - non dimensional groups, as column fields
  - `::NNEntrNonlocal ` a non-local entrainment-detrainment model type
 """
 function non_dimensional_function!(
     nondim_ε::AbstractArray{FT}, # output
     nondim_δ::AbstractArray{FT}, # output
     param_set::APS,
-    Π₁::AbstractArray{FT}, # input
-    Π₂::AbstractArray{FT}, # input
-    Π₃::AbstractArray{FT}, # input
-    Π₄::AbstractArray{FT}, # input)
+    Π_groups::AbstractArray{FT}, # input
     εδ_model::NNEntrNonlocal,
 ) where {FT <: Real}
-
+    # neural network architecture
+    n_input_vars = size(Π_groups)[2]
+    nn_arc = (n_input_vars, 5, 4, 2) # (#inputs, #neurons in L1, #neurons in L2, ...., #outputs)
     c_gen = ICP.c_gen(param_set)
-    Π = hcat(Π₁, Π₂, Π₃, Π₄)'
-
-    # Neural network closure
-    nn_arc = (4, 2, 2)  # (#inputs, #neurons, #outputs)
-    nn_model = Flux.Chain(
-        Flux.Dense(reshape(c_gen[1:8], nn_arc[2], nn_arc[1]), c_gen[9:10], Flux.sigmoid),
-        Flux.Dense(reshape(c_gen[11:14], nn_arc[3], nn_arc[2]), c_gen[15:16], Flux.relu),
-    )
-
-    output = nn_model(Π)
-
+    nn_model = construct_fully_connected_nn(nn_arc, c_gen)
+    output = nn_model(Π_groups')
     nondim_ε .= output[1, :]
     nondim_δ .= output[2, :]
 
@@ -160,14 +210,11 @@ Uses a fully connected neural network to predict the non-dimensional components 
 function non_dimensional_function(param_set, εδ_model_vars, ::NNEntr)
     c_gen = ICP.c_gen(param_set)
 
-    # Neural network closure
-    nn_arc = (4, 2, 2)  # (#inputs, #neurons, #outputs)
-    nn_model = Flux.Chain(
-        Flux.Dense(reshape(c_gen[1:8], nn_arc[2], nn_arc[1]), c_gen[9:10], Flux.sigmoid),
-        Flux.Dense(reshape(c_gen[11:14], nn_arc[3], nn_arc[2]), c_gen[15:16], Flux.relu),
-    )
+    nondim_groups = collect(non_dimensional_groups(param_set, εδ_model_vars))
+    # neural network architecture
+    nn_arc = (length(nondim_groups), 5, 4, 2) # (#inputs, #neurons in L1, #neurons in L2, ...., #outputs)
+    nn_model = construct_fully_connected_nn(nn_arc, c_gen)
 
-    nondim_groups = non_dimensional_groups(param_set, εδ_model_vars)
     nondim_ε, nondim_δ = nn_model(nondim_groups)
     return nondim_ε, nondim_δ
 end
@@ -183,12 +230,12 @@ Uses a simple linear model to predict the non-dimensional components of dynamica
 function non_dimensional_function(param_set, εδ_model_vars, ::LinearEntr)
     c_gen = ICP.c_gen(param_set)
 
+    nondim_groups = collect(non_dimensional_groups(param_set, εδ_model_vars))
     # Linear closure
-    lin_arc = (4, 1)  # (#weights, #outputs)
+    lin_arc = (length(nondim_groups), 1)  # (#inputs, #outputs)
     lin_model_ε = Flux.Dense(reshape(c_gen[1:4], lin_arc[2], lin_arc[1]), [c_gen[5]], Flux.relu)
     lin_model_δ = Flux.Dense(reshape(c_gen[6:9], lin_arc[2], lin_arc[1]), [c_gen[10]], Flux.relu)
 
-    nondim_groups = non_dimensional_groups(param_set, εδ_model_vars)
     nondim_ε = lin_model_ε(nondim_groups)[1]
     nondim_δ = lin_model_δ(nondim_groups)[1]
     return nondim_ε, nondim_δ
@@ -205,7 +252,7 @@ Uses a Random Feature model to predict the non-dimensional components of dynamic
 """
 function non_dimensional_function(param_set, εδ_model_vars, ::RFEntr)
     # d=4 inputs, p=2 outputs, m random features
-    nondim_groups = non_dimensional_groups(param_set, εδ_model_vars)
+    nondim_groups = collect(non_dimensional_groups(param_set, εδ_model_vars))
     d = size(nondim_groups)[1]
 
     # Learnable and fixed parameters
@@ -239,7 +286,7 @@ Arguments:
  - `εδ_model_type`  :: LogNormalScalingProcess - Stochastic lognormal scaling
 """
 function non_dimensional_function(param_set, εδ_model_vars, εδ_model_type::LogNormalScalingProcess)
-    FT = eltype(εδ_model_vars)
+    FT = eltype(εδ_model_vars.q_cond_up)
     # model parameters
     mean_model = εδ_model_type.mean_model
     c_gen_stoch = ICP.c_gen_stoch(param_set)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -15,7 +15,7 @@ cent_aux_vars_en_2m(FT) = (;
     interdomain = FT(0),
     rain_src = FT(0),
 )
-cent_aux_vars_up(FT) = (;
+cent_aux_vars_up(FT, edmf) = (;
     q_liq = FT(0),
     q_ice = FT(0),
     T = FT(0),
@@ -35,10 +35,7 @@ cent_aux_vars_up(FT) = (;
     entr_turb_dyn = FT(0),
     detr_turb_dyn = FT(0),
     asp_ratio = FT(0),
-    Π₁ = FT(0),
-    Π₂ = FT(0),
-    Π₃ = FT(0),
-    Π₄ = FT(0),
+    Π_groups = ntuple(i -> FT(0), n_Π_groups(edmf)),
 )
 cent_aux_vars_edmf(FT, edmf) = (;
     turbconv = (;
@@ -57,7 +54,7 @@ cent_aux_vars_edmf(FT, edmf) = (;
             θ_liq_ice_tendency_precip_formation = FT(0),
             qt_tendency_precip_formation = FT(0),
         ),
-        up = ntuple(i -> cent_aux_vars_up(FT), n_updrafts(edmf)),
+        up = ntuple(i -> cent_aux_vars_up(FT, edmf), n_updrafts(edmf)),
         en = (;
             w = FT(0),
             area = FT(0),


### PR DESCRIPTION
This Pr:
          1.) Generalizes NN construction for arbitrary fully-connected architectures. 
          2.) Changes default local NN to have 2 hidden layers. 
          3.) Adds a namelist option for flexibly specifying Pi groups. 
          4.) Adds 2 new pi groups -> `z/(updraft top)` & `z/(scale height of reference state)`