### PR TITLE
Add calibrate_io namelist bool

### DIFF
--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -191,6 +191,7 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
     namelist_defaults["stats_io"]["stats_dir"] = "stats"
     namelist_defaults["stats_io"]["frequency"] = 60.0
     namelist_defaults["stats_io"]["skip"] = false
+    namelist_defaults["stats_io"]["calibrate_io"] = false # limit io for calibration when `true`
 
     if case_name == "Soares"
         namelist = Soares(namelist_defaults)

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -128,11 +128,12 @@ function Simulation1d(namelist)
     inversion_type = Cases.inversion_type(case_type)
     case = Cases.CasesBase(case_type; inversion_type, surf_params, Fo, Rad, spk...)
 
-    io_nt = (;
-        ref_state = TC.io_dictionary_ref_state(),
-        aux = TC.io_dictionary_aux(),
-        diagnostics = io_dictionary_diagnostics(),
-    )
+    calibrate_io = namelist["stats_io"]["calibrate_io"]
+    ref_state_dict = calibrate_io ? Dict() : TC.io_dictionary_ref_state()
+    aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate() : TC.io_dictionary_aux()
+    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics()
+
+    io_nt = (; ref_state = ref_state_dict, aux = aux_dict, diagnostics = diagnostics_dict)
 
     return Simulation1d(
         io_nt,

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -137,4 +137,21 @@ function io_dictionary_aux()
     )
     return io_dict
 end
+
+function io_dictionary_aux_calibrate()
+    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
+    io_dict = Dict{String, DT}(
+        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).u),
+        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).v),
+        "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
+        "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).q_tot),
+        "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),
+        "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
+        "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
+        "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
+        "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).θ_liq_ice),
+        "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
+    )
+    return io_dict
+end
 #! format: on


### PR DESCRIPTION
This flag may give us pretty significant performance improvements in calibration since it will effectively skip out on exporting ~90 fields at the io frequency.

I forget if this is the complete set of needed fields or not, maybe someone can confirm?