### PR TITLE
Make benchmark more precise, remove update_n

### DIFF
--- a/perf/alloc_per_case.jl
+++ b/perf/alloc_per_case.jl
@@ -5,7 +5,9 @@ import Profile
 case_name = ENV["ALLOCATION_CASE_NAME"]
 @info "Recording allocations for $case_name"
 sim = init_sim(case_name)
-tendencies = copy(sim.state.prog)
-update_n(sim, tendencies, 1) # compile first
+(prob, alg, kwargs) = solve_args(sim)
+integrator = ODE.init(prob, alg; kwargs...)
+
+ODE.step!(integrator) # compile first
 Profile.clear_malloc_data()
-update_n(sim, tendencies, 1)
+ODE.step!(integrator)

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -2,22 +2,22 @@ include(joinpath(@__DIR__, "common.jl"))
 import BenchmarkTools
 
 sim = init_sim("Bomex")
-tendencies = copy(sim.state.prog)
-update_n(sim, tendencies, 1) # compile first
-trial = BenchmarkTools.@benchmark update_n($sim, $tendencies, 1)
+(; tendencies, prog, params, TS) = unpack_params(sim)
+∑tendencies!(tendencies, prog, params, TS.t) # compile first
+trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
 show(stdout, MIME("text/plain"), trial)
 println()
 
 sim = init_sim("TRMM_LBA")
-tendencies = copy(sim.state.prog)
-update_n(sim, tendencies, 1) # compile first
-trial = BenchmarkTools.@benchmark update_n($sim, $tendencies, 1)
+(; tendencies, prog, params, TS) = unpack_params(sim)
+∑tendencies!(tendencies, prog, params, TS.t) # compile first
+trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
 show(stdout, MIME("text/plain"), trial)
 println()
 
 sim = init_sim("Rico")
-tendencies = copy(sim.state.prog)
-update_n(sim, tendencies, 1) # compile first
-trial = BenchmarkTools.@benchmark update_n($sim, $tendencies, 1)
+(; tendencies, prog, params, TS) = unpack_params(sim)
+∑tendencies!(tendencies, prog, params, TS.t) # compile first
+trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
 show(stdout, MIME("text/plain"), trial)
 println()

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -10,9 +10,8 @@ include(joinpath(tc_dir, "driver", "generate_namelist.jl"))
 include(joinpath(tc_dir, "driver", "main.jl"))
 import .NameList
 
-update_n(sim, tendencies, N::Int) = update_n(sim, tendencies, Val(N))
-
-function update_n(sim, tendencies, ::Val{N}) where {N}
+function unpack_params(sim)
+    tendencies = copy(sim.state.prog)
     grid = sim.grid
     TS = sim.TS
     prog = sim.state.prog
@@ -26,10 +25,7 @@ function update_n(sim, tendencies, ::Val{N}) where {N}
         TS = TS,
         aux = aux,
     )
-    for i in 1:N
-        ∑tendencies!(tendencies, prog, params, TS.t)
-    end
-    return nothing
+    return (; tendencies, prog, params, TS)
 end
 
 function init_sim(case_name; skip_io = true, single_timestep = true, prefix = "")
@@ -42,7 +38,6 @@ function init_sim(case_name; skip_io = true, single_timestep = true, prefix = ""
     else
         @info "Initializing $case_name with IO."
     end
-    @info "call update_n(sim, tendencies, n) to run update n-times"
     namelist = NameList.default_namelist(case_name)
     if single_timestep
         namelist["time_stepping"]["t_max"] = namelist["time_stepping"]["dt_max"]

--- a/perf/profile.jl
+++ b/perf/profile.jl
@@ -3,11 +3,17 @@ import ProfileView
 import Profile
 
 sim = init_sim("Bomex")
-tendencies = copy(sim.state.prog)
+(; tendencies, prog, params, TS) = unpack_params(sim)
 
-Profile.@profile update_n(sim, tendencies, 100)
-Profile.print()
-# Profile.print(; format = :flat, sortedby = :count)
-ProfileView.@profview update_n(sim, tendencies, 1000) # compile first
-ProfileView.@profview update_n(sim, tendencies, 1000)
+ProfileView.@profview begin # compile first
+    for i in 1:100
+        ∑tendencies!(tendencies, prog, params, TS.t)
+    end
+end
+
 Profile.clear_malloc_data()
+ProfileView.@profview begin
+    for i in 1:1000
+        ∑tendencies!(tendencies, prog, params, TS.t)
+    end
+end


### PR DESCRIPTION
Creating the `params` tuple inside `update_n` may account for some allocations in the benchmark. This PR should
 - make our benchmarks a bit more precise.
 - widens our allocation monitoring from `∑tendencies!` to `step!` (for which codecov doesn't seem to find any new entries)