### PR TITLE
Skip some computations / io for calibrate_io

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -12,14 +12,17 @@ end
 condition_every_iter(u, t, integrator) = true
 
 function affect_io!(integrator)
-    UnPack.@unpack edmf, precip_model, aux, grid, io_nt, diagnostics, case, param_set, Stats, skip_io = integrator.p
+    UnPack.@unpack edmf, calibrate_io, precip_model, aux, grid, io_nt, diagnostics, case, param_set, Stats, skip_io =
+        integrator.p
     skip_io && return nothing
     t = integrator.t
 
     state = TC.State(integrator.u, aux, ODE.get_du(integrator))
 
     # TODO: is this the best location to call diagnostics?
-    compute_diagnostics!(edmf, precip_model, param_set, grid, state, diagnostics, Stats, case, t)
+    if !calibrate_io
+        compute_diagnostics!(edmf, precip_model, param_set, grid, state, diagnostics, Stats, case, t)
+    end
 
     # TODO: remove `vars` hack that avoids
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
@@ -30,8 +33,10 @@ function affect_io!(integrator)
     io(io_nt.aux, Stats, state)
     io(io_nt.diagnostics, Stats, diagnostics)
 
-    surf = get_surface(case.surf_params, grid, state, t, param_set)
-    io(surf, case.surf_params, grid, state, Stats, t)
+    if !calibrate_io
+        surf = get_surface(case.surf_params, grid, state, t, param_set)
+        io(surf, case.surf_params, grid, state, Stats, t)
+    end
 
     ODE.u_modified!(integrator, false) # We're legitamately not mutating `u` (the state vector)
 end

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -15,8 +15,10 @@ function unpack_params(sim)
     grid = sim.grid
     TS = sim.TS
     prog = sim.state.prog
+    calibrate_io = sim.calibrate_io
     aux = sim.state.aux
     params = (;
+        calibrate_io,
         edmf = sim.edmf,
         precip_model = sim.precip_model,
         grid = grid,


### PR DESCRIPTION
I made a flame graph from CalibrateEDMF's julia parallel (pmap) integration test, and it seem that we're somehow paying a pretty steep price for some of the diagnostics. This PR adds `calibrate_io` bool to `Simulation1d` to conditionally skip some of the computations and IO that are not needed for calibration.

<img width="2156" alt="Screen Shot 2022-02-25 at 9 48 15 PM" src="https://user-images.githubusercontent.com/1880641/155831101-1a7a5e9e-f75e-47fc-a07e-ee9cae1da40b.png">
