### PR TITLE
Add (1/m) scaling to entrainment closure.

### DIFF
--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -171,7 +171,7 @@ function default_namelist(case_name::String; root::String = ".", write::Bool = t
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = 1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = "moisture_deficit"  # {"moisture_deficit", "NN", "NN_nonlocal", "Linear", "FNO", "RF"}
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = "buoy_vel" # {"buoy_vel", "inv_z"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = "buoy_vel" # {"buoy_vel", "inv_z", "none"}
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["entr_pi_subset"] = ntuple(i -> i, 6) # or, e.g., (1, 3, 6)
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pi_norm_consts"] = [478.298, 1.0, 1.0, 1.0, 1.0, 1.0] # normalization constants for Pi groups
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = "deterministic"  # {"deterministic", "noisy_relaxation_process", "lognormal_scaling", "prognostic_noisy_relaxation_process"}

--- a/src/closures/entr_detr.jl
+++ b/src/closures/entr_detr.jl
@@ -35,7 +35,7 @@ function get_MdMdz(M::FT, dMdz::FT) where {FT}
     return MdMdz_ε, MdMdz_δ
 end
 
-function entrainment_length_scale(
+function entrainment_inv_length_scale(
     param_set,
     b_up::FT,
     b_en::FT,
@@ -50,7 +50,7 @@ function entrainment_length_scale(
     return (λ / Δw)
 end
 
-function entrainment_length_scale(
+function entrainment_inv_length_scale(
     param_set,
     b_up::FT,
     b_en::FT,
@@ -61,6 +61,19 @@ function entrainment_length_scale(
     ::InvZEntrDimScale,
 ) where {FT}
     return (1 / zc_i)
+end
+
+function entrainment_inv_length_scale(
+    param_set,
+    b_up::FT,
+    b_en::FT,
+    w_up::FT,
+    w_en::FT,
+    tke::FT,
+    zc_i::FT,
+    ::InvMeterEntrDimScale,
+) where {FT}
+    return FT(1)
 end
 
 """
@@ -77,7 +90,7 @@ Parameters:
 """
 function εδ_dyn(param_set::APS, εδ_vars, entr_dim_scale, ε_nondim, δ_nondim)
     FT = eltype(εδ_vars.q_cond_up)
-    dim_scale = entrainment_length_scale(
+    dim_scale = entrainment_inv_length_scale(
         param_set,
         εδ_vars.b_up,
         εδ_vars.b_en,
@@ -336,7 +349,7 @@ function compute_entr_detr!(
                 aux_en.tke[k],
                 plume_scale_height[i],
             )
-            dim_scale = entrainment_length_scale(
+            dim_scale = entrainment_inv_length_scale(
                 param_set,
                 aux_up[i].buoy[k],
                 aux_en.buoy[k],

--- a/src/types.jl
+++ b/src/types.jl
@@ -53,6 +53,7 @@ end
 abstract type EntrDimScale end
 struct BuoyVelEntrDimScale <: EntrDimScale end
 struct InvZEntrDimScale <: EntrDimScale end
+struct InvMeterEntrDimScale <: EntrDimScale end
 
 """
     GradBuoy
@@ -541,6 +542,8 @@ struct EDMFModel{N_up, FT, PM, ENT, EBGC, EC, EDS, EPG}
             BuoyVelEntrDimScale()
         elseif entr_dim_scale == "inv_z"
             InvZEntrDimScale()
+        elseif entr_dim_scale == "none"
+            InvMeterEntrDimScale()
         else
             error("Something went wrong. Invalid entrainment dimension scale '$entr_dim_scale'")
         end


### PR DESCRIPTION
- Adds the 1/m (i.e., identity) dimensional scaling option for entrainment/detrainment non dimensional outputs.
- Fixes function name.