### PR TITLE
Add ODE+SDE back into alloc monitor

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -42,7 +42,7 @@ deps_to_monitor = [
     LinearAlgebra,
     NCDatasets,
     OrderedCollections,
-    # OrdinaryDiffEq, # TODO: add back in!
+    OrdinaryDiffEq,
     PoissonRandom,
     Random,
     RootSolvers,
@@ -50,7 +50,7 @@ deps_to_monitor = [
     StaticArrays,
     Statistics,
     StatsBase,
-    # StochasticDiffEq, # TODO: add back in!
+    StochasticDiffEq,
     SurfaceFluxes,
     TerminalLoggers,
     Thermodynamics,


### PR DESCRIPTION
I'm not sure why, but after buildkite directories have changed, our depot isn't working for the perf environment with `OrdinaryDiffEq` and `StochasticDiffEq`. Perhaps, notably, we're not saving a manifest there like we do with our test env. Perhaps we should add it (not just to fix, but maybe it's a good idea regardless).