### PR TITLE
Group pipeline steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,11 @@ env:
   BUILDKITE_BRANCH: "${BUILDKITE_BRANCH}"
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/cpu"
 
+agents:
+  config: cpu
+  queue: central
+  slurm_ntasks: 1
+
 steps:
   - label: "init environment :computer:"
     key: "init_cpu_env"
@@ -22,294 +27,117 @@ steps:
       - "julia --project=perf -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=perf -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=perf -e 'using Pkg; Pkg.status()'"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
 
   - wait
 
-  - label: ":partly_sunny: Bomex"
-    key: "cpu_bomex"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case Bomex"
-    artifact_paths:
-      - "Output.Bomex.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+  - group: "Vanilla Experiments"
+    steps:
 
-  - label: ":partly_sunny: life_cycle_Tan2018"
-    key: "cpu_life_cycle_tan2018"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case life_cycle_Tan2018"
-    artifact_paths:
-      - "Output.life_cycle_Tan2018.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: Bomex"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case Bomex"
+        artifact_paths: "Output.Bomex.01/stats/comparison/*"
 
-  - label: ":partly_sunny: Soares"
-    key: "cpu_soares"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case Soares"
-    artifact_paths:
-      - "Output.Soares.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: life_cycle_Tan2018"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case life_cycle_Tan2018"
+        artifact_paths: "Output.life_cycle_Tan2018.01/stats/comparison/*"
 
-  - label: ":partly_sunny: Rico"
-    key: "cpu_rico"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case Rico"
-    artifact_paths:
-      - "Output.Rico.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: Soares"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case Soares"
+        artifact_paths: "Output.Soares.01/stats/comparison/*"
 
-  - label: ":partly_sunny: Nieuwstadt"
-    key: "cpu_nieuwstadt"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case Nieuwstadt"
-    artifact_paths:
-      - "Output.Nieuwstadt.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: Rico"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case Rico"
+        artifact_paths: "Output.Rico.01/stats/comparison/*"
 
-  - label: ":scissors: TRMM_LBA"
-    key: "cpu_trmm_lba"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case TRMM_LBA"
-    artifact_paths:
-      - "Output.TRMM_LBA.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: Nieuwstadt"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case Nieuwstadt"
+        artifact_paths: "Output.Nieuwstadt.01/stats/comparison/*"
 
-  - label: ":partly_sunny: ARM_SGP"
-    key: "cpu_arm_sgp"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case ARM_SGP"
-    artifact_paths:
-      - "Output.ARM_SGP.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":scissors: TRMM_LBA"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case TRMM_LBA"
+        artifact_paths: "Output.TRMM_LBA.01/stats/comparison/*"
 
-  # Takes a bit too long...
-  # - label: ":partly_sunny: GATE_III"
-  #   key: "cpu_gate_iii"
-  #   command:
-  #     - "julia --color=yes --project=test integration_tests/driver.jl --case GATE_III"
-  #   artifact_paths:
-  #     - "Output.GATE_III.01/stats/comparison/*"
-  #   agents:
-  #     config: cpu
-  #     queue: central
-  #     slurm_ntasks: 1
+      - label: ":partly_sunny: ARM_SGP"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case ARM_SGP"
+        artifact_paths: "Output.ARM_SGP.01/stats/comparison/*"
 
-  - label: ":partly_sunny: DYCOMS_RF01"
-    key: "cpu_dycoms_rf01"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case DYCOMS_RF01"
-    artifact_paths:
-      - "Output.DYCOMS_RF01.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      # Takes a bit too long...
+      # - label: ":partly_sunny: GATE_III"
+      #   command: "julia --color=yes --project=test integration_tests/driver.jl --case GATE_III"
+      #   artifact_paths: "Output.GATE_III.01/stats/comparison/*"
 
-  - label: ":partly_sunny: DYCOMS_RF02"
-    key: "cpu_dycoms_rf02"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case DYCOMS_RF02"
-    artifact_paths:
-      - "Output.DYCOMS_RF02.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: DYCOMS_RF01"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case DYCOMS_RF01"
+        artifact_paths: "Output.DYCOMS_RF01.01/stats/comparison/*"
 
-  - label: ":partly_sunny: GABLS"
-    key: "cpu_gabls"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case GABLS"
-    artifact_paths:
-      - "Output.GABLS.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: DYCOMS_RF02"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case DYCOMS_RF02"
+        artifact_paths: "Output.DYCOMS_RF02.01/stats/comparison/*"
 
-  - label: ":thought_balloon: DryBubble"
-    key: "cpu_drybubble"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case DryBubble"
-    artifact_paths:
-      - "Output.DryBubble.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: GABLS"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case GABLS"
+        artifact_paths: "Output.GABLS.01/stats/comparison/*"
 
-  - label: ":partly_sunny: LES_driven_SCM"
-    key: "cpu_lesdrivenscm"
-    command:
-      - "julia --color=yes --project=test integration_tests/driver.jl --case LES_driven_SCM"
-    artifact_paths:
-      - "Output.LES_driven_SCM.01/stats/comparison/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":thought_balloon: DryBubble"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case DryBubble"
+        artifact_paths: "Output.DryBubble.01/stats/comparison/*"
 
-  - label: ":package: 3D Bomex"
-    key: "cpu_3dBomex"
-    command:
-      - "julia --color=yes --project=test integration_tests/3dBomex.jl"
-    artifact_paths:
-      - "integration_tests/output/3dBomex/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":partly_sunny: LES_driven_SCM"
+        command: "julia --color=yes --project=test integration_tests/driver.jl --case LES_driven_SCM"
+        artifact_paths: "Output.LES_driven_SCM.01/stats/comparison/*"
 
-  - label: ":earth_americas: 3D sphere bariclinic wave"
-    key: "cpu_3dsphere_baroclinic_wave"
-    command:
-      - "julia --color=yes --project=test integration_tests/baroclinic_wave.jl"
-    artifact_paths:
-      - "integration_tests/output/baroclinic_wave/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+  - group: "3D Experiments"
+    steps:
 
-  - label: ":rocket: Allocations analysis"
-    key: "cpu_allocations"
-    command:
-      - "julia --color=yes --project=perf perf/allocs.jl"
-    artifact_paths:
-      - "perf/allocations_output/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":package: 3D Bomex"
+        command: "julia --color=yes --project=test integration_tests/3dBomex.jl"
+        artifact_paths: "integration_tests/output/3dBomex/*"
 
-  - label: ":rocket: Allocations analysis (exhaustive)"
-    key: "cpu_allocations_exhaustive"
-    command:
-      - "julia --color=yes --project=perf perf/allocs.jl exhaustive=true"
-    artifact_paths:
-      - "perf/allocations_output_exhaustive/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":earth_americas: 3D sphere bariclinic wave"
+        command: "julia --color=yes --project=test integration_tests/baroclinic_wave.jl"
+        artifact_paths: "integration_tests/output/baroclinic_wave/*"
 
-  - label: ":rocket: Benchmark tendencies"
-    key: "cpu_bm_tendencies"
-    command:
-      - "julia --color=yes --project=perf perf/benchmark.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+  - group: "Performance monitoring"
+    steps:
 
-  - label: ":rocket: Benchmark step!"
-    key: "cpu_bm_step"
-    command:
-      - "julia --color=yes --project=perf perf/benchmark_step.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":rocket: Allocations analysis"
+        command: "julia --color=yes --project=perf perf/allocs.jl"
 
-  - label: ":scales: Measure precompilation speedup (all)"
-    key: "cpu_precompilable"
-    command:
-      - "julia --color=yes --project=perf perf/precompilable.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":rocket: Allocations analysis (exhaustive)"
+        command: "julia --color=yes --project=perf perf/allocs.jl exhaustive=true"
 
-  - label: ":scales: Measure precompilation speedup (no init)"
-    key: "cpu_precompilable_no_init"
-    command:
-      - "julia --color=yes --project=perf perf/precompilable_no_init.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":rocket: Benchmark tendencies"
+        command: "julia --color=yes --project=perf perf/benchmark.jl"
 
-  - label: ":scales: Measure precompilation speedup (no io)"
-    key: "cpu_precompilable_no_io"
-    command:
-      - "julia --color=yes --project=perf perf/precompilable_no_io.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":rocket: Benchmark step!"
+        command: "julia --color=yes --project=perf perf/benchmark_step.jl"
 
-  - label: ":scales: Measure precompilation speedup (no init, no io)"
-    key: "cpu_precompilable_no_init_io"
-    command:
-      - "julia --color=yes --project=perf perf/precompilable_no_init_io.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":scales: Measure precompilation speedup (all)"
+        command: "julia --color=yes --project=perf perf/precompilable.jl"
 
-  - label: ":mag: Invalidations"
-    key: "cpu_invalidations"
-    command:
-      - "julia --color=yes --project=perf perf/invalidations.jl"
-    artifact_paths:
-      - "perf/invalidations_output/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":scales: Measure precompilation speedup (no init)"
+        command: "julia --color=yes --project=perf perf/precompilable_no_init.jl"
 
-  - label: ":mag: Inference triggers"
-    key: "cpu_inf_trigs"
-    command:
-      - "julia --color=yes --project=perf perf/inference_triggers.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+      - label: ":scales: Measure precompilation speedup (no io)"
+        command: "julia --color=yes --project=perf perf/precompilable_no_io.jl"
+
+      - label: ":scales: Measure precompilation speedup (no init, no io)"
+        command: "julia --color=yes --project=perf perf/precompilable_no_init_io.jl"
+
+      - label: ":mag: Invalidations"
+        command: "julia --color=yes --project=perf perf/invalidations.jl"
+        artifact_paths: "perf/invalidations_output/*"
+
+      - label: ":mag: Inference triggers"
+        command: "julia --color=yes --project=perf perf/inference_triggers.jl"
 
   - wait: ~
     continue_on_failure: true
 
   - label: ":robot_face: Print new mse tables"
-    key: "cpu_print_new_mse"
-    command:
-      - "julia --color=yes --project=test utils/print_new_mse.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+    command: "julia --color=yes --project=test utils/print_new_mse.jl"
 
   - wait
 
   - label: ":robot_face: Move main results"
-    key: "cpu_mv_main_res"
-    command:
-      - "julia --color=yes --project=test utils/move_output.jl"
-    agents:
-      config: cpu
-      queue: central
-      slurm_ntasks: 1
+    command: "julia --color=yes --project=test utils/move_output.jl"


### PR DESCRIPTION
This PR adjusts our buildkite pipeline to be a bit more compact, and apply buildkite groups, so that we can more easily navigate from the top of the buildkite UI. I've removed the keys because it seems like they're only needed when applying dependencies. Our dependencies are mostly in only a few chunks (init, run tests, print mse, move results).