### PR TITLE
Fix scope of calibrate_io, add more fields

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -20,9 +20,7 @@ function affect_io!(integrator)
     state = TC.State(integrator.u, aux, ODE.get_du(integrator))
 
     # TODO: is this the best location to call diagnostics?
-    if !calibrate_io
-        compute_diagnostics!(edmf, precip_model, param_set, grid, state, diagnostics, Stats, case, t)
-    end
+    compute_diagnostics!(edmf, precip_model, param_set, grid, state, diagnostics, Stats, case, t, calibrate_io)
 
     # TODO: remove `vars` hack that avoids
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -122,6 +122,7 @@ function compute_diagnostics!(
     Stats::NetCDFIO_Stats,
     case::TC.CasesBase,
     t::Real,
+    calibrate_io::Bool,
 ) where {D <: CC.Fields.FieldVector}
     FT = eltype(grid)
     N_up = TC.n_updrafts(edmf)
@@ -168,6 +169,9 @@ function compute_diagnostics!(
     @inbounds for i in 1:N_up
         @. massflux_s += aux_up_f[i].massflux * (If(aux_up[i].s) - If(aux_en.s))
     end
+
+    # We only need computations above here for calibration io.
+    calibrate_io && return nothing
 
     #####
     ##### Cloud base, top and cover

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -131,7 +131,7 @@ function Simulation1d(namelist)
     case = Cases.CasesBase(case_type; inversion_type, surf_params, Fo, Rad, spk...)
 
     calibrate_io = namelist["stats_io"]["calibrate_io"]
-    ref_state_dict = calibrate_io ? Dict() : TC.io_dictionary_ref_state()
+    ref_state_dict = TC.io_dictionary_ref_state()
     aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate() : TC.io_dictionary_aux()
     diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics()
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -151,6 +151,12 @@ function io_dictionary_aux_calibrate()
         "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
         "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).θ_liq_ice),
         "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
+        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
+        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
+        "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
+        "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
+        "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
     )
     return io_dict
 end


### PR DESCRIPTION
@costachris pointed out that we actually need some computations in `compute_diagnostics!`. Arguably, the variables in those aux fields should be moved into a diagnostics array instead, so that we can make better guarantees about not having simulation results depend on diagnostics. For now, I think this is a quick fix to enable using `calibrate_io`.