### PR TITLE
Fix gitignore for integration test manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ docs/site/
 Manifest.toml
 
 # Ensure tests and performance analysis are reproduceable
-!test/Manifest.toml
+!integration_tests/Manifest.toml
 !perf/Manifest.toml
 !docs/Manifest.toml
 


### PR DESCRIPTION
This PR fixes the .gitignore to ensure the `integration_tests` manifest stays checked into the repo.