### PR TITLE
Fix git ignore, add up_deps script to dev folder

### DIFF
--- a/.dev/up_deps.jl
+++ b/.dev/up_deps.jl
@@ -1,0 +1,20 @@
+#=
+A simple script for updating the manifest
+files in all of our environments.
+=#
+
+root = dirname(@__DIR__)
+dirs =
+    (root, joinpath(root, "test"), joinpath(root, "perf"), joinpath(root, "docs"), joinpath(root, "integration_tests"))
+
+for dir in dirs
+    cmd = `$(Base.julia_cmd()) --project=$dir 'import Pkg; Pkg.up()'`
+    run(cmd)
+end
+
+# https://github.com/JuliaLang/Pkg.jl/issues/3014
+for dir in dirs
+    cd(dir) do
+        rm("LocalPreferences.toml"; force = true)
+    end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,4 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
-
-# Ensure tests and performance analysis are reproduceable
-!integration_tests/Manifest.toml
-!perf/Manifest.toml
-!docs/Manifest.toml
-
-integration_tests/utils/Artifacts.toml
+test/Manifest.toml


### PR DESCRIPTION
This PR adds a `.dev/up_deps.jl`, which we can use for upgrading the manifest files according to their compat entries. To keep compat entries synchronized, I created a development package which I plan to register, [CompatDevTools.jl](https://github.com/charleskawczynski/CompatDevTools.jl), which has a function `synchronize_compats(pkg_dir::String)` that we can use. This way, we can monitor / update compat entries in the `integration_tests/` environment, and then use `CompatDevTools.synchronize_compats` to synchronize the other environments.

This PR also adds `test/Manifest.toml` to the git ignore and removes some other entries (I missed that the original manifest entry only applies to the pkgdir, and not using a `*` pattern).