### PR TITLE
Move mse code loading to after solve, add prefixes for each job

### DIFF
--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -43,11 +43,7 @@ using Test
 const tc_dir = pkgdir(TurbulenceConvection)
 include(joinpath(tc_dir, "driver", "main.jl"))
 include(joinpath(tc_dir, "driver", "generate_namelist.jl"))
-include(joinpath(tc_dir, "post_processing", "compute_mse.jl"))
-include(joinpath(tc_dir, "post_processing", "mse_tables.jl"))
 import .NameList
-
-best_mse = all_best_mse[case_name]
 
 namelist = NameList.default_namelist(case_name)
 
@@ -73,6 +69,9 @@ ds_tc_filename, return_code = main(namelist)
 
 # Post-processing case kwargs
 include(joinpath(tc_dir, "post_processing", "case_kwargs.jl"))
+include(joinpath(tc_dir, "post_processing", "compute_mse.jl"))
+include(joinpath(tc_dir, "post_processing", "mse_tables.jl"))
+best_mse = all_best_mse[case_name]
 
 # TODO: Remove this and compare only the prognostic state
 #       we may need a more generic / flexible version of

--- a/perf/alloc_per_case.jl
+++ b/perf/alloc_per_case.jl
@@ -4,7 +4,7 @@ import Profile
 
 case_name = ENV["ALLOCATION_CASE_NAME"]
 @info "Recording allocations for $case_name"
-sim = init_sim(case_name)
+sim = init_sim(case_name; prefix = "alloc_$case_name")
 (prob, alg, kwargs) = solve_args(sim)
 integrator = ODE.init(prob, alg; kwargs...)
 

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -1,21 +1,21 @@
 include(joinpath(@__DIR__, "common.jl"))
 import BenchmarkTools
 
-sim = init_sim("Bomex")
+sim = init_sim("Bomex"; prefix = "bm_Bomex")
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
 trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
 show(stdout, MIME("text/plain"), trial)
 println()
 
-sim = init_sim("TRMM_LBA")
+sim = init_sim("TRMM_LBA"; prefix = "bm_TRMM_LBA")
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
 trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
 show(stdout, MIME("text/plain"), trial)
 println()
 
-sim = init_sim("Rico")
+sim = init_sim("Rico"; prefix = "bm_Rico")
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
 trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))

--- a/perf/benchmark_step.jl
+++ b/perf/benchmark_step.jl
@@ -3,21 +3,21 @@ import BenchmarkTools
 # Use a NullLogger to avoid highly excessive progress bar printing
 Logging.with_logger(Logging.NullLogger()) do
 
-    sim = init_sim("Bomex")
+    sim = init_sim("Bomex"; prefix = "bm_step_Bomex")
     (prob, alg, kwargs) = solve_args(sim)
     integrator = ODE.init(prob, alg; kwargs...)
     trial = BenchmarkTools.@benchmark ODE.step!($integrator)
     show(stdout, MIME("text/plain"), trial)
     println()
 
-    sim = init_sim("TRMM_LBA")
+    sim = init_sim("TRMM_LBA"; prefix = "bm_step_TRMM_LBA")
     (prob, alg, kwargs) = solve_args(sim)
     integrator = ODE.init(prob, alg; kwargs...)
     trial = BenchmarkTools.@benchmark ODE.step!($integrator)
     show(stdout, MIME("text/plain"), trial)
     println()
 
-    sim = init_sim("Rico")
+    sim = init_sim("Rico"; prefix = "bm_step_Rico")
     (prob, alg, kwargs) = solve_args(sim)
     integrator = ODE.init(prob, alg; kwargs...)
     trial = BenchmarkTools.@benchmark ODE.step!($integrator)

--- a/perf/inference_triggers.jl
+++ b/perf/inference_triggers.jl
@@ -4,7 +4,7 @@ import SnoopCompileCore
 
 case_name = "Bomex"
 println("Running $case_name...")
-sim = init_sim(case_name)
+sim = init_sim(case_name; prefix = "inf_trig_$case_name")
 sim.skip_io || open_files(sim.Stats) # #removeVarsHack
 (prob, alg, kwargs) = solve_args(sim)
 

--- a/perf/invalidations.jl
+++ b/perf/invalidations.jl
@@ -13,7 +13,7 @@ invalidations = @snoopr begin
     case_name = "Bomex"
     println("Running $case_name...")
     namelist = NameList.default_namelist(case_name)
-    namelist["meta"]["uuid"] = "01"
+    namelist["meta"]["uuid"] = "01_invalidations"
     ds_tc_filename, return_code = main(namelist)
 end;
 import SnoopCompile

--- a/post_processing/case_kwargs.jl
+++ b/post_processing/case_kwargs.jl
@@ -1,3 +1,4 @@
+import OrderedCollections
 case_kwargs = OrderedCollections.OrderedDict()
 
 #! format: off


### PR DESCRIPTION
This PR moves the MSE code loading to after the call to `main`. Interesting, this resulted in exposing a race condition which presents itself as a netCDF error:

```
ERROR: LoadError: NetCDF error: NetCDF: String match to name in use (NetCDF error code: -42)
--
  | Stacktrace:
  | [1] check
  | @ /central/scratch/esm/slurm-buildkite/turbulenceconvection-ci/depot/cpu/packages/NCDatasets/c8XyT/src/errorhandling.jl:27 [inlined]
  | [2] nc_def_var(ncid::Int32, name::String, xtype::Int64, dimids::Vector{Int32})
  | @ NCDatasets /central/scratch/esm/slurm-buildkite/turbulenceconvection-ci/depot/cpu/packages/NCDatasets/c8XyT/src/netcdf_c.jl:1389
  | [3] defVar(ds::NCDatasets.NCDataset{NCDatasets.NCDataset{Nothing}}, name::String, vtype::DataType, dimnames::Tuple{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ NCDatasets /central/scratch/esm/slurm-buildkite/turbulenceconvection-ci/depot/cpu/packages/NCDatasets/c8XyT/src/cfvariable.jl:110
  | [4] defVar
  | @ /central/scratch/esm/slurm-buildkite/turbulenceconvection-ci/depot/cpu/packages/NCDatasets/c8XyT/src/cfvariable.jl:96 [inlined]
  | [5] #6
```

Why did this expose the race condition? Interesting note here. Our artifacts are currently downloaded on every push, and those downloads either
 - Take sufficiently different amounts of time per agent or
 - Requests are handled serially and all agents must wait in line to download (or end up failing due to waiting too long)

The way this was fixed was by adding prefixes to the NC files that we're working with per job. That is, every buildkite job should be reading and writing to different NC files (for their own simulation). It's kind of amazing that this hasn't been more of an issue, but I think it's resolved with this PR, and we should be able to continue and fix the issues with the artifact downloads next.
