### PR TITLE
Make artifacts download lazily

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,8 @@ steps:
       - "julia --project=perf -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=perf -e 'using Pkg; Pkg.status()'"
 
+      - "julia --project=integration_tests integration_tests/download_artifacts.jl"
+
   - wait
 
   - group: "Vanilla Experiments"

--- a/integration_tests/artifact_funcs.jl
+++ b/integration_tests/artifact_funcs.jl
@@ -3,10 +3,10 @@
 import ArtifactWrappers
 const AW = ArtifactWrappers
 
-function pycles_output_dataset_folder(lazy_download = false)
+function pycles_output_dataset_folder(lazy_download = true)
     PyCLES_output_dataset = AW.ArtifactWrapper(
         @__DIR__,
-        isempty(get(ENV, "CI", "")),
+        lazy_download,
         "PyCLES_output",
         AW.ArtifactFile[
         AW.ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
@@ -23,10 +23,10 @@ function pycles_output_dataset_folder(lazy_download = false)
     return AW.get_data_folder(PyCLES_output_dataset)
 end
 
-function scampy_output_dataset_folder(lazy_download = false)
+function scampy_output_dataset_folder(lazy_download = true)
     SCAMPy_output_dataset = AW.ArtifactWrapper(
         @__DIR__,
-        isempty(get(ENV, "CI", "")),
+        lazy_download,
         "SCAMPy_output",
         AW.ArtifactFile[
         AW.ArtifactFile(url = "https://caltech.box.com/shared/static/1dzpydqiagjvzfpyv9lbic3atvca93hl.nc", filename = "Rico.nc",),
@@ -45,10 +45,10 @@ function scampy_output_dataset_folder(lazy_download = false)
     return AW.get_data_folder(SCAMPy_output_dataset)
 end
 
-function les_driven_scm_data_folder(lazy_download = false)
+function les_driven_scm_data_folder(lazy_download = true)
     LESDrivenSCM_output_dataset = AW.ArtifactWrapper(
         @__DIR__,
-        isempty(get(ENV, "CI", "")),
+        lazy_download,
         "LESDrivenSCM_output_dataset",
         AW.ArtifactFile[
             AW.ArtifactFile(url = "https://caltech.box.com/shared/static/0hnf7nkttueraaqf9tpkqsx38gjqx41p.nc", filename = "Stats.cfsite23_HadGEM2-A_amip_2004-2008.07.nc",),

--- a/integration_tests/download_artifacts.jl
+++ b/integration_tests/download_artifacts.jl
@@ -1,0 +1,10 @@
+include(joinpath(@__DIR__, "..", "integration_tests", "artifact_funcs.jl"))
+
+# Trigger download if data doesn't exist locally
+function trigger_download(lazy_download = true)
+    @info "pycles Artifact folder : $(pycles_output_dataset_folder(lazy_download))"
+    @info "scampy Artifact folder : $(scampy_output_dataset_folder(lazy_download))"
+    @info "LES_driven_SCM Artifact folder : $(les_driven_scm_data_folder(lazy_download))"
+    return nothing
+end
+trigger_download()


### PR DESCRIPTION
A long time ago, we decided to add a flag in ArtifactWrappers, `local_run`, which allows users to make a temporary download folder to avoid race conditions (downloading Artifacts is not safe to race conditions). The problem is that this basically completely side-steps the utility of lazily downloading the artifacts on remote machines. So, right now, users leverage the utility of Artifacts because the `local_run` flag we have set to `isempty(get(ENV, "CI", ""))`, which is true on buildkite and GHA CI, but all of CI infra is downloading these artifacts on every build.

This PR changes this by doing a proper lazy download during the initial `steps` in the buildkite pipeline (which happens in serial, but avoids the race condition). The advantage of this is that the very first time we do this, we'll pay the cost, but subsequent PRs should now be doing a lazy download.

We should probably just remove this flag in ArtifactWrappers, since it kind of defeats the purpose of Artifacts to begin with, the logic of always downloading can be done by users.

With this PR, we should basically no longer run into these failures:

```
ERROR: LoadError: HTTP/2 302 (Operation too slow. Less than 1 bytes/sec transferred the last 20 seconds) while requesting https://caltech.box.com/shared/static/7upt639siyc2umon8gs6qsjiqavof5cq.nc
--
  | Stacktrace:
  | [1] (::Downloads.var"#9#18"{IOStream, Base.DevNull, Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Bool, String, Int64, Bool, Bool})(easy::Downloads.Curl.Easy)
  | @ Downloads /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Downloads/src/Downloads.jl:369
  | [2] with_handle(f::Downloads.var"#9#18"{IOStream, Base.DevNull, Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Bool, String, I
```

Also, we should probably apply this fix to other repos that have used this pattern.