### PR TITLE
Add flame graph script for io

### DIFF
--- a/perf/flame_io.jl
+++ b/perf/flame_io.jl
@@ -1,0 +1,34 @@
+include(joinpath(@__DIR__, "common.jl"))
+import Profile
+
+case_name = "Bomex"
+namelist = NameList.default_namelist(case_name)
+namelist["time_stepping"]["t_max"] = 15 * namelist["time_stepping"]["dt_max"]
+namelist["stats_io"]["frequency"] = 0 # io at every step
+namelist["meta"]["uuid"] = "01_flame_io"
+sim = Simulation1d(namelist)
+initialize(sim)
+open_files(sim.Stats) # force compilation
+close_files(sim.Stats) # force compilation
+open_files(sim.Stats)
+(prob, alg, kwargs) = solve_args(sim)
+integrator = ODE.init(prob, alg; kwargs...)
+
+ODE.step!(integrator) # force compilation
+# callbacks not called after first `step!`
+# call, so need to call `step!` again:
+ODE.step!(integrator) # force compilation
+
+Profile.clear_malloc_data()
+prof = Profile.@profile begin
+    for _ in 1:10
+        ODE.step!(integrator)
+    end
+end
+close_files(sim.Stats)
+∑tendencies!
+import PProf
+PProf.pprof()
+# http://localhost:57599/ui/flamegraph?tf
+# import ProfileView
+# ProfileView.view()


### PR DESCRIPTION
This PR adds a flame graph script to analyze io performance. Here's what we're starting how it currently looks:

<img width="1998" alt="Screen Shot 2022-03-10 at 9 16 26 AM" src="https://user-images.githubusercontent.com/1880641/157721484-67804406-819c-4235-8037-ca7a18709594.png">

@Alexander-Barth, why is `size(::NCDataset)` so expensive? This is happening in the call [here](https://github.com/CliMA/TurbulenceConvection.jl/blob/0b7af151696b717bd5c82c81b68a02400704e3d1/driver/NetCDFIO.jl#L149)