### PR TITLE
Check in artifacts toml

### DIFF
--- a/integration_tests/Artifacts.toml
+++ b/integration_tests/Artifacts.toml
@@ -1,0 +1,8 @@
+[LESDrivenSCM_output_dataset]
+git-tree-sha1 = "8824d54d209da7dcd530b1b5d7e4fb5d340c14a9"
+
+[PyCLES_output]
+git-tree-sha1 = "ffe50b647306a7e6f7094c7f70c0c4bf50ff2f4c"
+
+[SCAMPy_output]
+git-tree-sha1 = "135c12b25f26fd5957ce7ef5825921506eec254a"


### PR DESCRIPTION
I think we missed this in #876, this PR adds the artifacts toml to `integration_tests/`. So, I think we're now still technically downloading on every push, but only once in the `download_artifacts` job. This should fix that and avoid downloads from now on. We should probably clean up any artifact `toml` files that are not used.

(I realized this from running an example locally)

Hmm, actually, the download portion of the job is still taking ~2 min, I may need to play around with this to make sure, or we'll see if the init ever fails due to long download times.