### PR TITLE
Further refactor io

### DIFF
--- a/docs/src/PlotReferenceStates.jl
+++ b/docs/src/PlotReferenceStates.jl
@@ -36,10 +36,10 @@ function export_ref_profile(case_name::String)
     compute_ref_state!(state, grid, param_set; ts_g = surf_ref_state)
 
     io_nt = TC.io_dictionary_ref_state()
-    initialize_io(io_nt, Stats)
+    initialize_io(Stats, io_nt)
     io(io_nt, Stats, state)
 
-    NCDatasets.Dataset(joinpath(Stats.path_plus_file), "r") do ds
+    NCDatasets.Dataset(joinpath(Stats.nc_filename), "r") do ds
         zc = ds.group["profiles"]["zc"][:]
         zf = ds.group["profiles"]["zf"][:]
         ρ0_c = ds.group["reference"]["ρ0_c"][:]

--- a/driver/NetCDFIO.jl
+++ b/driver/NetCDFIO.jl
@@ -6,95 +6,82 @@ const TC = TurbulenceConvection
 
 # TODO: remove `vars` hack that avoids https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
 
+function nc_fileinfo(namelist)
+
+    uuid = string(namelist["meta"]["uuid"])
+    simname = namelist["meta"]["simname"]
+    outpath = joinpath(namelist["output"]["output_root"], "Output.$simname.$uuid")
+    mkpath(outpath)
+
+    nc_filename = joinpath(outpath, namelist["stats_io"]["stats_dir"])
+    mkpath(nc_filename)
+
+    nc_filename = joinpath(nc_filename, "Stats.$simname.nc")
+    return nc_filename, outpath
+end
+
 mutable struct NetCDFIO_Stats
     root_grp::NC.NCDataset{Nothing}
     profiles_grp::NC.NCDataset{NC.NCDataset{Nothing}}
     ts_grp::NC.NCDataset{NC.NCDataset{Nothing}}
-    last_output_time::Float64
-    uuid::String
     frequency::Float64
-    stats_path::String
-    path_plus_file::String
+    nc_filename::String
     vars::Dict{String, Any} # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
-    function NetCDFIO_Stats(namelist, grid::TC.Grid)
+end
 
-        # Initialize properties with valid type:
-        tmp = tempname()
-        root_grp = NC.Dataset(tmp, "c")
-        NC.defGroup(root_grp, "profiles")
-        NC.defGroup(root_grp, "timeseries")
-        profiles_grp = root_grp.group["profiles"]
-        ts_grp = root_grp.group["timeseries"]
-        close(root_grp)
-
-        last_output_time = 0.0
-        uuid = string(namelist["meta"]["uuid"])
-
-        frequency = namelist["stats_io"]["frequency"]
-
-        # Setup the statistics output path
-        simname = namelist["meta"]["simname"]
-        casename = namelist["meta"]["casename"]
-        outpath = joinpath(namelist["output"]["output_root"], "Output.$simname.$uuid")
-        mkpath(outpath)
-
-        stats_path = joinpath(outpath, namelist["stats_io"]["stats_dir"])
-        mkpath(stats_path)
-
-        path_plus_file = joinpath(stats_path, "Stats.$simname.nc")
-
-        # TODO: uncomment restart
-        # if isfile(path_plus_file)
-        #   @inbounds for i in 1:100
-        #         res_name = "Restart_$i"
-        #         if isfile(path_plus_file)
-        #             path_plus_file = stats_path * "Stats.$simname.$res_name.nc"
-        #         else
-        #             break
-        #         end
-        #     end
-        # end
-
-        # Write namelist file to output directory
-        open(joinpath(outpath, "namelist_$casename.in"), "w") do io
-            JSON.print(io, namelist, 4)
-        end
-
-        # Remove the NC file if it exists, in case it accidentally wasn't closed
-        isfile(path_plus_file) && rm(path_plus_file; force = true)
-
-        NC.Dataset(path_plus_file, "c") do root_grp
-
-            zf = vec(grid.zf)
-            zc = vec(grid.zc)
-
-            # Set profile dimensions
-            profile_grp = NC.defGroup(root_grp, "profiles")
-            NC.defDim(profile_grp, "zf", TC.n_cells(grid) + 1)
-            NC.defDim(profile_grp, "zc", TC.n_cells(grid))
-            NC.defDim(profile_grp, "t", Inf)
-            NC.defVar(profile_grp, "zf", zf, ("zf",))
-            NC.defVar(profile_grp, "zc", zc, ("zc",))
-            NC.defVar(profile_grp, "t", Float64, ("t",))
-
-            reference_grp = NC.defGroup(root_grp, "reference")
-            NC.defDim(reference_grp, "zf", TC.n_cells(grid) + 1)
-            NC.defDim(reference_grp, "zc", TC.n_cells(grid))
-            NC.defVar(reference_grp, "zf", zf, ("zf",))
-            NC.defVar(reference_grp, "zc", zc, ("zc",))
-
-            ts_grp = NC.defGroup(root_grp, "timeseries")
-            NC.defDim(ts_grp, "t", Inf)
-            NC.defVar(ts_grp, "t", Float64, ("t",))
-        end
-        vars = Dict{String, Any}()
-        return new(root_grp, profiles_grp, ts_grp, last_output_time, uuid, frequency, stats_path, path_plus_file, vars)
+# Convenience backward compatible outer constructor
+function NetCDFIO_Stats(namelist, grid::TC.Grid)
+    frequency = namelist["stats_io"]["frequency"]
+    # Setup the statistics output path
+    casename = namelist["meta"]["casename"]
+    nc_filename, outpath = nc_fileinfo(namelist)
+    # Write namelist file to output directory
+    open(joinpath(outpath, "namelist_$casename.in"), "w") do io
+        JSON.print(io, namelist, 4)
     end
+    NetCDFIO_Stats(; nc_filename, frequency, z_faces = vec(grid.zf), z_centers = vec(grid.zc))
+end
+
+function NetCDFIO_Stats(; nc_filename, frequency, z_faces, z_centers)
+    # Initialize properties with valid type:
+    tmp = tempname()
+    root_grp = NC.Dataset(tmp, "c")
+    NC.defGroup(root_grp, "profiles")
+    NC.defGroup(root_grp, "timeseries")
+    profiles_grp = root_grp.group["profiles"]
+    ts_grp = root_grp.group["timeseries"]
+    close(root_grp)
+
+    # Remove the NC file if it exists, in case it accidentally wasn't closed
+    isfile(nc_filename) && rm(nc_filename; force = true)
+
+    NC.Dataset(nc_filename, "c") do root_grp
+        # Set profile dimensions
+        profile_grp = NC.defGroup(root_grp, "profiles")
+        NC.defDim(profile_grp, "zf", length(z_faces))
+        NC.defDim(profile_grp, "zc", length(z_centers))
+        NC.defDim(profile_grp, "t", Inf)
+        NC.defVar(profile_grp, "zf", z_faces, ("zf",))
+        NC.defVar(profile_grp, "zc", z_centers, ("zc",))
+        NC.defVar(profile_grp, "t", Float64, ("t",))
+
+        reference_grp = NC.defGroup(root_grp, "reference")
+        NC.defDim(reference_grp, "zf", length(z_faces))
+        NC.defDim(reference_grp, "zc", length(z_centers))
+        NC.defVar(reference_grp, "zf", z_faces, ("zf",))
+        NC.defVar(reference_grp, "zc", z_centers, ("zc",))
+
+        ts_grp = NC.defGroup(root_grp, "timeseries")
+        NC.defDim(ts_grp, "t", Inf)
+        NC.defVar(ts_grp, "t", Float64, ("t",))
+    end
+    vars = Dict{String, Any}()
+    return NetCDFIO_Stats(root_grp, profiles_grp, ts_grp, frequency, nc_filename, vars)
 end
 
 
 function open_files(self::NetCDFIO_Stats)
-    self.root_grp = NC.Dataset(self.path_plus_file, "a")
+    self.root_grp = NC.Dataset(self.nc_filename, "a")
     self.profiles_grp = self.root_grp.group["profiles"]
     self.ts_grp = self.root_grp.group["timeseries"]
     vars = self.vars
@@ -118,22 +105,20 @@ end
 ##### Generic field
 #####
 
-function add_field(self::NetCDFIO_Stats, var_name::String; dims, group)
-    NC.Dataset(self.path_plus_file, "a") do root_grp
-        profile_grp = root_grp.group[group]
-        new_var = NC.defVar(profile_grp, var_name, Float64, dims)
-    end
+function add_field(ds, var_name::String; dims, group)
+    profile_grp = ds.group[group]
+    new_var = NC.defVar(profile_grp, var_name, Float64, dims)
+    return nothing
 end
 
 #####
 ##### Time-series data
 #####
 
-function add_ts(self::NetCDFIO_Stats, var_name::String)
-    NC.Dataset(self.path_plus_file, "a") do root_grp
-        ts_grp = root_grp.group["timeseries"]
-        new_var = NC.defVar(ts_grp, var_name, Float64, ("t",))
-    end
+function add_ts(ds, var_name::String)
+    ts_grp = ds.group["timeseries"]
+    new_var = NC.defVar(ts_grp, var_name, Float64, ("t",))
+    return nothing
 end
 
 #####
@@ -152,7 +137,7 @@ function write_field(self::NetCDFIO_Stats, var_name::String, data::T; group) whe
         # Not sure why `end` instead of `end+1`, but `end+1` produces garbage output
         # @inbounds var[end, :] = data :: T
     elseif group == "reference"
-        NC.Dataset(self.path_plus_file, "a") do root_grp
+        NC.Dataset(self.nc_filename, "a") do root_grp
             reference_grp = root_grp.group[group]
             var = reference_grp[var_name]
             var .= data::T

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -64,42 +64,22 @@ function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
 end
 
 
-function initialize_io(Stats::NetCDFIO_Stats)
-    add_ts(Stats, "Tsurface")
-    add_ts(Stats, "shf")
-    add_ts(Stats, "lhf")
-    add_ts(Stats, "ustar")
-    add_ts(Stats, "wstar")
-    add_ts(Stats, "lwp_mean")
-    add_ts(Stats, "iwp_mean")
-    add_ts(Stats, "cloud_base_mean")
-    add_ts(Stats, "cloud_top_mean")
-    add_ts(Stats, "cloud_cover_mean")
+function initialize_io(Stats::NetCDFIO_Stats, ts_list)
+    NC.Dataset(Stats.nc_filename, "a") do ds
+        for var_name in ts_list
+            add_ts(ds, var_name)
+        end
+    end
     return nothing
 end
 
-# Initialize the IO pertaining to this class
-function initialize_io(edmf::TC.EDMFModel, Stats::NetCDFIO_Stats)
-    add_ts(Stats, "env_cloud_base")
-    add_ts(Stats, "env_cloud_top")
-    add_ts(Stats, "env_cloud_cover")
-    add_ts(Stats, "env_lwp")
-    add_ts(Stats, "env_iwp")
-    add_ts(Stats, "updraft_cloud_cover")
-    add_ts(Stats, "updraft_cloud_base")
-    add_ts(Stats, "updraft_cloud_top")
-    add_ts(Stats, "updraft_lwp")
-    add_ts(Stats, "updraft_iwp")
-    add_ts(Stats, "rwp_mean")
-    add_ts(Stats, "swp_mean")
-    add_ts(Stats, "cutoff_precipitation_rate")
-    add_ts(Stats, "Hd")
-    return nothing
-end
-
-function initialize_io(io_dict::Dict, Stats::NetCDFIO_Stats)
-    for var_name in keys(io_dict)
-        add_field(Stats, var_name; dims = io_dict[var_name].dims, group = io_dict[var_name].group)
+function initialize_io(Stats::NetCDFIO_Stats, io_dicts::Dict...)
+    NC.Dataset(Stats.nc_filename, "a") do ds
+        for io_dict in io_dicts
+            for var_name in keys(io_dict)
+                add_field(ds, var_name; dims = io_dict[var_name].dims, group = io_dict[var_name].group)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This PR:
 - Renames `path_plus_file` to `nc_filename`
 - Makes the inner constructor for `NetCDFIO_Stats` an outer constructor, because I'd like to decouple this data structure from the namelist so that we can later improve io management
 - Deletes some `NetCDFIO_Stats` properties that seem to be unused:
   - `last_output_time`
   - `uuid`
   - `stats_path`
 - opens and closes files fewer times
