### PR TITLE
Refactor IO

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -59,7 +59,7 @@ function io(surf::TC.SurfaceBase, surf_params, grid, state, Stats::NetCDFIO_Stat
 end
 function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
     for var in keys(io_dict)
-        write_field(Stats, var, io_dict[var].field(state); group = io_dict[var].group)
+        write_field(Stats, var, vec(io_dict[var].field(state)), io_dict[var].group)
     end
 end
 
@@ -77,7 +77,7 @@ function initialize_io(Stats::NetCDFIO_Stats, io_dicts::Dict...)
     NC.Dataset(Stats.nc_filename, "a") do ds
         for io_dict in io_dicts
             for var_name in keys(io_dict)
-                add_field(ds, var_name; dims = io_dict[var_name].dims, group = io_dict[var_name].group)
+                add_field(ds, var_name, io_dict[var_name].dims, io_dict[var_name].group)
             end
         end
     end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -3,29 +3,14 @@
 #####
 
 #=
-    io_dictionary_ref_state()
     io_dictionary_aux()
 
 These functions return a dictionary whose
  - `keys` are the nc variable names
  - `values` are NamedTuples corresponding to
     - `dims` (`("z")`  or `("z", "t")`) and
-    - `group` (`"reference"` or `"profiles"`)
+    - `group` (`"reference"` or, e.g., `"profiles"`)
 =#
-
-function io_dictionary_ref_state()
-    DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String}, String, Any}}
-    cent_ref_state = center_ref_state # so that things nicely align :)
-    io_dict = Dict{String, DT}(
-        "ρ0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).ρ0),
-        "ρ0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).ρ0),
-        "p0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).p0),
-        "p0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).p0),
-        "α0_f" => (; dims = ("zf",), group = "reference", field = state -> face_ref_state(state).α0),
-        "α0_c" => (; dims = ("zc",), group = "reference", field = state -> cent_ref_state(state).α0),
-    )
-    return io_dict
-end
 
 #! format: off
 # TODO: use a better name, this exports fields from the prognostic state, and the aux state.


### PR DESCRIPTION
This PR makes reference profiles not rely on `write_field`, as a small step towards removing our dependence on `NetCDFIO_Stats`.