### PR TITLE
Further refactor IO

### DIFF
--- a/driver/NetCDFIO.jl
+++ b/driver/NetCDFIO.jl
@@ -107,7 +107,7 @@ end
 
 function add_field(ds, var_name::String, dims, group)
     profile_grp = ds.group[group]
-    new_var = NC.defVar(profile_grp, var_name, Float64, dims)
+    NC.defVar(profile_grp, var_name, Float64, dims)
     return nothing
 end
 
@@ -117,7 +117,7 @@ end
 
 function add_ts(ds, var_name::String)
     ts_grp = ds.group["timeseries"]
-    new_var = NC.defVar(ts_grp, var_name, Float64, ("t",))
+    NC.defVar(ts_grp, var_name, Float64, ("t",))
     return nothing
 end
 
@@ -125,37 +125,26 @@ end
 ##### Performance critical IO
 #####
 
-function write_field(self::NetCDFIO_Stats, var_name::String, data::T, group) where {T <: AbstractArray{Float64, 1}}
-    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
-    @inbounds self.vars[group][var_name][:, end] = data
-    # Ideally, we remove self.vars and use:
-    # var = self.profiles_grp[var_name]
+function write_field(group, var_name::String, data::T) where {T <: AbstractArray{Float64, 1}}
+    # @inbounds self.vars[group][var_name][:, end] = data
+    @inbounds group[var_name][:, end] = data
     # Not sure why `end` instead of `end+1`, but `end+1` produces garbage output
     # @inbounds var[end, :] = data :: T
 end
 
-function add_write_field(ds, var_name::String, data::T, group, dims) where {T <: AbstractArray{Float64, 1}}
-    grp = ds.group[group]
-    NC.defVar(grp, var_name, Float64, dims)
-    var = grp[var_name]
+function add_write_field(group, var_name::String, data::T, dims) where {T <: AbstractArray{Float64, 1}}
+    NC.defVar(group, var_name, Float64, dims)
+    var = group[var_name]
     var .= data::T
     return nothing
 end
 
-function write_ts(self::NetCDFIO_Stats, var_name::String, data::Float64)
-    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
-    @inbounds self.vars["timeseries"][var_name][end] = data::Float64
-    # Ideally, we remove self.vars and use:
-    # var = self.ts_grp[var_name]
-    # @inbounds var[end+1] = data :: Float64
+function write_ts(group, var_name::String, data::Float64)
+    # TODO: end vs. end+1 ?
+    @inbounds group[var_name][end] = data::Float64
 end
 
-function write_simulation_time(self::NetCDFIO_Stats, t::Float64)
-    # # Write to profiles group
-    profile_t = self.profiles_grp["t"]
-    @inbounds profile_t[end + 1] = t::Float64
-
-    # # Write to timeseries group
-    ts_t = self.ts_grp["t"]
-    @inbounds ts_t[end + 1] = t::Float64
+function write_simulation_time(group, t::Float64)
+    # Write to profiles group
+    @inbounds group[end + 1] = t::Float64
 end

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -26,7 +26,8 @@ function affect_io!(integrator)
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
     # opening/closing files every step should be okay. #removeVarsHack
     # TurbulenceConvection.io(sim) # #removeVarsHack
-    write_simulation_time(Stats, t) # #removeVarsHack
+    write_simulation_time(Stats.profiles_grp["t"], t)
+    write_simulation_time(Stats.ts_grp["t"], t)
 
     io(io_nt.aux, Stats, state)
     io(io_nt.diagnostics, Stats, diagnostics)

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -54,15 +54,17 @@ end
 #! format: on
 
 function io(surf::TC.SurfaceBase, surf_params, grid, state, Stats::NetCDFIO_Stats, t::Real)
-    write_ts(Stats, "Tsurface", TC.surface_temperature(surf_params, t))
-    write_ts(Stats, "shf", surf.shf)
-    write_ts(Stats, "lhf", surf.lhf)
-    write_ts(Stats, "ustar", surf.ustar)
-    write_ts(Stats, "wstar", surf.wstar)
+    group = Stats.vars["timeseries"]
+    write_ts(group, "Tsurface", TC.surface_temperature(surf_params, t))
+    write_ts(group, "shf", surf.shf)
+    write_ts(group, "lhf", surf.lhf)
+    write_ts(group, "ustar", surf.ustar)
+    write_ts(group, "wstar", surf.wstar)
 end
 function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
+    group = Stats.vars["profiles"]
     for var in keys(io_dict)
-        write_field(Stats, var, vec(io_dict[var].field(state)), io_dict[var].group)
+        write_field(group, var, vec(io_dict[var].field(state)))
     end
 end
 
@@ -326,26 +328,27 @@ function compute_diagnostics!(
     # Demonstration of how we can move all of the `write_ts` calls
     # outside of `compute_diagnostics!`, which currently computes
     # _and_ exports (some) diagnostics.
-    write_ts(Stats, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
-    write_ts(Stats, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])
-    write_ts(Stats, "updraft_cloud_top", diag_tc_svpc.updraft_cloud_top[cent])
-    write_ts(Stats, "env_cloud_cover", diag_tc_svpc.env_cloud_cover[cent])
-    write_ts(Stats, "env_cloud_base", diag_tc_svpc.env_cloud_base[cent])
-    write_ts(Stats, "env_cloud_top", diag_tc_svpc.env_cloud_top[cent])
-    write_ts(Stats, "env_lwp", diag_tc_svpc.env_lwp[cent])
-    write_ts(Stats, "env_iwp", diag_tc_svpc.env_iwp[cent])
-    write_ts(Stats, "Hd", diag_tc_svpc.Hd[cent])
-    write_ts(Stats, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
-    write_ts(Stats, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
+    group = Stats.vars["timeseries"]
+    write_ts(group, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
+    write_ts(group, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])
+    write_ts(group, "updraft_cloud_top", diag_tc_svpc.updraft_cloud_top[cent])
+    write_ts(group, "env_cloud_cover", diag_tc_svpc.env_cloud_cover[cent])
+    write_ts(group, "env_cloud_base", diag_tc_svpc.env_cloud_base[cent])
+    write_ts(group, "env_cloud_top", diag_tc_svpc.env_cloud_top[cent])
+    write_ts(group, "env_lwp", diag_tc_svpc.env_lwp[cent])
+    write_ts(group, "env_iwp", diag_tc_svpc.env_iwp[cent])
+    write_ts(group, "Hd", diag_tc_svpc.Hd[cent])
+    write_ts(group, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
+    write_ts(group, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
 
-    write_ts(Stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
-    write_ts(Stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
-    write_ts(Stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
-    write_ts(Stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
-    write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
-    write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
-    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
-    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
+    write_ts(group, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
+    write_ts(group, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
+    write_ts(group, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
+    write_ts(group, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
+    write_ts(group, "lwp_mean", diag_svpc.lwp_mean[cent])
+    write_ts(group, "iwp_mean", diag_svpc.iwp_mean[cent])
+    write_ts(group, "rwp_mean", diag_svpc.rwp_mean[cent])
+    write_ts(group, "swp_mean", diag_svpc.swp_mean[cent])
 
     return
 end

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -134,13 +134,13 @@ function Simulation1d(namelist)
 
     if !skip_io
         NC.Dataset(Stats.nc_filename, "a") do ds
-            group = "reference"
-            add_write_field(ds, "ρ0_f", vec(TC.face_ref_state(state).ρ0), group, ("zf",))
-            add_write_field(ds, "ρ0_c", vec(TC.center_ref_state(state).ρ0), group, ("zc",))
-            add_write_field(ds, "p0_f", vec(TC.face_ref_state(state).p0), group, ("zf",))
-            add_write_field(ds, "p0_c", vec(TC.center_ref_state(state).p0), group, ("zc",))
-            add_write_field(ds, "α0_f", vec(TC.face_ref_state(state).α0), group, ("zf",))
-            add_write_field(ds, "α0_c", vec(TC.center_ref_state(state).α0), group, ("zc",))
+            group = ds.group["reference"]
+            add_write_field(group, "ρ0_f", vec(TC.face_ref_state(state).ρ0), ("zf",))
+            add_write_field(group, "ρ0_c", vec(TC.center_ref_state(state).ρ0), ("zc",))
+            add_write_field(group, "p0_f", vec(TC.face_ref_state(state).p0), ("zf",))
+            add_write_field(group, "p0_c", vec(TC.center_ref_state(state).p0), ("zc",))
+            add_write_field(group, "α0_f", vec(TC.face_ref_state(state).α0), ("zf",))
+            add_write_field(group, "α0_c", vec(TC.center_ref_state(state).α0), ("zc",))
         end
     end
 
@@ -219,7 +219,8 @@ function initialize(sim::Simulation1d)
 
     open_files(sim.Stats)
     try
-        write_simulation_time(sim.Stats, t)
+        write_simulation_time(sim.Stats.profiles_grp["t"], t)
+        write_simulation_time(sim.Stats.ts_grp["t"], t)
 
         io(sim.io_nt.aux, sim.Stats, state)
         io(sim.io_nt.diagnostics, sim.Stats, sim.diagnostics)


### PR DESCRIPTION
This PR makes some of the IO functions, e.g., `write_field` and `add_write_field` etc. accept `group`, instead of a `NetCDFIO_Stats`, and the group is now extracted outside. This makes these io function more low-level and alleviates our dependence on `NetCDFIO_Stats`. I think that we can apply this to other functions, but I'd like to do this incrementally.