### PR TITLE
Update artifacts toml, add cleanup to driver

### DIFF
--- a/integration_tests/Artifacts.toml
+++ b/integration_tests/Artifacts.toml
@@ -1,8 +1,8 @@
 [LESDrivenSCM_output_dataset]
-git-tree-sha1 = "8824d54d209da7dcd530b1b5d7e4fb5d340c14a9"
+git-tree-sha1 = "3d6bb62d803fb01908ffe85469a89933f28ced45"
 
 [PyCLES_output]
-git-tree-sha1 = "ffe50b647306a7e6f7094c7f70c0c4bf50ff2f4c"
+git-tree-sha1 = "c2d323fb412d1250182be3aeadf9d94e816550a0"
 
 [SCAMPy_output]
-git-tree-sha1 = "135c12b25f26fd5957ce7ef5825921506eec254a"
+git-tree-sha1 = "6b82611f969d3cf99102baa7d898e3c759cf014c"

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -127,3 +127,7 @@ end
     end
     nothing
 end
+
+# Cleanup
+# https://github.com/JuliaLang/Pkg.jl/issues/3014
+rm("LocalPreferences.toml"; force = true)


### PR DESCRIPTION
Lately I've been seeing that the artifact toml file needs to be updated. This PR updates the artifacts toml and adds a cleanup after the driver, since running TC tends to create this file