### PR TITLE
Draft of non-eqilibrium moisture

### DIFF
--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -437,9 +437,9 @@ function compute_gm_tendencies!(
     ∇v_sgs = CCO.DivergenceF2C()
 
     @. tends_θ_liq_ice += -α0_c * ∇θ_liq_ice_sgs(wvec(sgs_flux_θ_liq_ice))
-    @. tends_q_tot += -α0_c * ∇q_tot_sgs(wvec(sgs_flux_q_tot))
-    @. tends_q_liq += -α0_c * ∇q_liq_sgs(wvec(sgs_flux_q_liq))
-    @. tends_q_ice += -α0_c * ∇q_ice_sgs(wvec(sgs_flux_q_ice))
+    @. tends_q_tot += -α0_c * ∇q_sgs(wvec(sgs_flux_q_tot))
+    @. tends_q_liq += -α0_c * ∇q_sgs(wvec(sgs_flux_q_liq))
+    @. tends_q_ice += -α0_c * ∇q_sgs(wvec(sgs_flux_q_ice))
     @. tends_u += -α0_c * ∇u_sgs(wvec(sgs_flux_u))
     @. tends_v += -α0_c * ∇v_sgs(wvec(sgs_flux_v))
     return nothing

--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -432,9 +432,7 @@ function compute_gm_tendencies!(
     tends_v = tendencies_gm.v
 
     ∇θ_liq_ice_sgs = CCO.DivergenceF2C()
-    ∇q_tot_sgs = CCO.DivergenceF2C()
-    ∇q_liq_sgs = CCO.DivergenceF2C()
-    ∇q_ice_sgs = CCO.DivergenceF2C()
+    ∇q_sgs = CCO.DivergenceF2C()
     ∇u_sgs = CCO.DivergenceF2C()
     ∇v_sgs = CCO.DivergenceF2C()
 

--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -15,6 +15,10 @@ function microphysics(
     aux_en_sat = aux_en.sat
     aux_en_unsat = aux_en.unsat
 
+    # TO-DO tie in environment tendencies from liq/ice? I think that has to happen here... to we need a to use tendencies_en?
+    # maybe see center_tendencies_environment(state) = tendencies_turbconv(state, CentField()).en in dycore_api.jl
+
+
     @inbounds for k in real_center_indices(grid)
         # condensation
         q_tot_en = aux_en.q_tot[k]

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -14,40 +14,32 @@ function compute_nonequilibrium_moisture_tendencies(
     ρ0_c = center_ref_state(state).ρ0
     aux_up = center_aux_updrafts(state)
     aux_bulk = center_aux_bulk(state)
-    prog_pr = center_prog_precipitation(state)
-    tendencies_pr = center_tendencies_precipitation(state)
 
     @inbounds for i in 1:N_up
         @inbounds for k in real_center_indices(grid)
             T_up = aux_up[i].T[k]
-            q_tot_up = aux_up[i].q_tot[k]
-            ts_up = TD.PhaseEquil_pTq(param_set, p0_c[k], T_up, q_tot_up)
+            q_up = TD.PhasePartition(aux_up[i].q_tot[k], aux_up[i].q_liq[k], aux_up[i].q_ice[k])
+            ts_up = TD.PhaseNonEquil_pTq(param_set, p0_c[k], T_up, q_up)
 
             # autoconversion and accretion
-            mph = precipitation_formation(
+            mph = cloud_formation(
                 param_set,
-                precip_model,
-                prog_pr.q_rai[k],
-                prog_pr.q_sno[k],
                 aux_up[i].area[k],
                 ρ0_c[k],
                 Δt,
                 ts_up,
             )
-            aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
-            aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]
-
-            tendencies_pr.q_rai[k] += mph.qr_tendency * aux_up[i].area[k]
-            tendencies_pr.q_sno[k] += mph.qs_tendency * aux_up[i].area[k]
+            aux_up[i].ql_tendency_cloud_formation[k] = mph.ql_tendency * aux_up[i].area[k]
+            aux_up[i].qi_tendency_cloud_formation[k] = mph.qi_tendency * aux_up[i].area[k]
         end
     end
     # TODO - to be deleted once we sum all tendencies elsewhere
     @inbounds for k in real_center_indices(grid)
-        aux_bulk.θ_liq_ice_tendency_precip_formation[k] = 0
-        aux_bulk.qt_tendency_precip_formation[k] = 0
+        aux_bulk.ql_tendency_cloud_formation[k] = 0
+        aux_bulk.qi_tendency_cloud_formation[k] = 0
         @inbounds for i in 1:N_up
-            aux_bulk.θ_liq_ice_tendency_precip_formation[k] += aux_up[i].θ_liq_ice_tendency_precip_formation[k]
-            aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
+            aux_bulk.ql_tendency_cloud_formation[k] += aux_up[i].qt_cloud_formation[k]
+            aux_bulk.qi_tendency_cloud_formation[k] += aux_up[i].qt_cloud_formation[k]
         end
     end
     return nothing

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -1,4 +1,60 @@
 """
+Computes tendencies to q_liq and q_ice due to
+condensation, evaporation, deposition and sublimation
+"""
+function compute_nonequilibrium_moisture_tendencies(
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    Δt::Real,
+    param_set::APS,
+)
+    N_up = n_updrafts(edmf)
+    p0_c = center_ref_state(state).p0
+    ρ0_c = center_ref_state(state).ρ0
+    aux_up = center_aux_updrafts(state)
+    aux_bulk = center_aux_bulk(state)
+    prog_pr = center_prog_precipitation(state)
+    tendencies_pr = center_tendencies_precipitation(state)
+
+    @inbounds for i in 1:N_up
+        @inbounds for k in real_center_indices(grid)
+            T_up = aux_up[i].T[k]
+            q_tot_up = aux_up[i].q_tot[k]
+            ts_up = TD.PhaseEquil_pTq(param_set, p0_c[k], T_up, q_tot_up)
+
+            # autoconversion and accretion
+            mph = precipitation_formation(
+                param_set,
+                precip_model,
+                prog_pr.q_rai[k],
+                prog_pr.q_sno[k],
+                aux_up[i].area[k],
+                ρ0_c[k],
+                Δt,
+                ts_up,
+            )
+            aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
+            aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]
+
+            tendencies_pr.q_rai[k] += mph.qr_tendency * aux_up[i].area[k]
+            tendencies_pr.q_sno[k] += mph.qs_tendency * aux_up[i].area[k]
+        end
+    end
+    # TODO - to be deleted once we sum all tendencies elsewhere
+    @inbounds for k in real_center_indices(grid)
+        aux_bulk.θ_liq_ice_tendency_precip_formation[k] = 0
+        aux_bulk.qt_tendency_precip_formation[k] = 0
+        @inbounds for i in 1:N_up
+            aux_bulk.θ_liq_ice_tendency_precip_formation[k] += aux_up[i].θ_liq_ice_tendency_precip_formation[k]
+            aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
+        end
+    end
+    return nothing
+end
+
+
+"""
 Computes tendencies to qt and θ_liq_ice due to precipitation formation
 """
 function compute_precipitation_formation_tendencies(

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -29,17 +29,21 @@ function compute_nonequilibrium_moisture_tendencies(
                 Δt,
                 ts_up,
             )
+
+            # aux_up[i].qt_tendency_noneq_moisture[k] = mph.qt_tendency * aux_up[i].area[k] (why no qt here? or at least anna didn't add it)
             aux_up[i].ql_tendency_noneq_moisture[k] = mph.ql_tendency * aux_up[i].area[k]
             aux_up[i].qi_tendency_noneq_moisture[k] = mph.qi_tendency * aux_up[i].area[k]
         end
     end
-    # TODO - to be deleted once we sum all tendencies elsewhere
+    # TODO - to be deleted once we sum all tendencies elsewhere (what does this mean?)
     @inbounds for k in real_center_indices(grid)
+        aux_bulk.qt_tendency_noneq_moisture[k] = 0
         aux_bulk.ql_tendency_noneq_moisture[k] = 0
         aux_bulk.qi_tendency_noneq_moisture[k] = 0
         @inbounds for i in 1:N_up
-            aux_bulk.ql_tendency_noneq_moisture[k] += aux_up[i].qt_noneq_moisture[k]
-            aux_bulk.qi_tendency_noneq_moisture[k] += aux_up[i].qt_noneq_moisture[k]
+            aux_bulk.qt_tendency_noneq_moisture[k] += aux_up[i].qt_noneq_moisture[k]
+            aux_bulk.ql_tendency_noneq_moisture[k] += aux_up[i].ql_noneq_moisture[k]
+            aux_bulk.qi_tendency_noneq_moisture[k] += aux_up[i].qi_noneq_moisture[k]
         end
     end
     return nothing
@@ -82,6 +86,9 @@ function compute_precipitation_formation_tendencies(
                 ts_up,
             )
             aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
+            aux_up[i].ql_tendency_precip_formation[k] = mph.ql_tendency * aux_up[i].area[k] # added liq and ice
+            aux_up[i].qi_tendency_precip_formation[k] = mph.qi_tendency * aux_up[i].area[k]
+
             aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]
 
             tendencies_pr.q_rai[k] += mph.qr_tendency * aux_up[i].area[k]
@@ -92,6 +99,9 @@ function compute_precipitation_formation_tendencies(
     @inbounds for k in real_center_indices(grid)
         aux_bulk.θ_liq_ice_tendency_precip_formation[k] = 0
         aux_bulk.qt_tendency_precip_formation[k] = 0
+        aux_bulk.ql_tendency_precip_formation[k] = 0 # added liq and ice
+        aux_bulk.qi_tendency_precip_formation[k] = 0
+
         @inbounds for i in 1:N_up
             aux_bulk.θ_liq_ice_tendency_precip_formation[k] += aux_up[i].θ_liq_ice_tendency_precip_formation[k]
             aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -22,29 +22,28 @@ function compute_nonequilibrium_moisture_tendencies(
             ts_up = TD.PhaseNonEquil_pTq(param_set, p0_c[k], T_up, q_up)
 
             # autoconversion and accretion
-            mph = cloud_formation(
+            mph = noneq_moisture_sources(
                 param_set,
                 aux_up[i].area[k],
                 ρ0_c[k],
                 Δt,
                 ts_up,
             )
-            aux_up[i].ql_tendency_cloud_formation[k] = mph.ql_tendency * aux_up[i].area[k]
-            aux_up[i].qi_tendency_cloud_formation[k] = mph.qi_tendency * aux_up[i].area[k]
+            aux_up[i].ql_tendency_noneq_moisture[k] = mph.ql_tendency * aux_up[i].area[k]
+            aux_up[i].qi_tendency_noneq_moisture[k] = mph.qi_tendency * aux_up[i].area[k]
         end
     end
     # TODO - to be deleted once we sum all tendencies elsewhere
     @inbounds for k in real_center_indices(grid)
-        aux_bulk.ql_tendency_cloud_formation[k] = 0
-        aux_bulk.qi_tendency_cloud_formation[k] = 0
+        aux_bulk.ql_tendency_noneq_moisture[k] = 0
+        aux_bulk.qi_tendency_noneq_moisture[k] = 0
         @inbounds for i in 1:N_up
-            aux_bulk.ql_tendency_cloud_formation[k] += aux_up[i].qt_cloud_formation[k]
-            aux_bulk.qi_tendency_cloud_formation[k] += aux_up[i].qt_cloud_formation[k]
+            aux_bulk.ql_tendency_noneq_moisture[k] += aux_up[i].qt_noneq_moisture[k]
+            aux_bulk.qi_tendency_noneq_moisture[k] += aux_up[i].qt_noneq_moisture[k]
         end
     end
     return nothing
 end
-
 
 """
 Computes tendencies to qt and θ_liq_ice due to precipitation formation

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -226,6 +226,7 @@ function affect_filter!(
 end
 
 function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    FT = eltype(grid)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
@@ -452,7 +453,6 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
         qt_tendency_precip_formation = aux_up_i.qt_tendency_precip_formation
         ql_tendency_precip_formation = aux_up_i.ql_tendency_precip_formation
         qi_tendency_precip_formation = aux_up_i.qi_tendency_precip_formation
-
 
         tends_ρarea = tendencies_up[i].ρarea
         tends_ρaθ_liq_ice = tendencies_up[i].ρaθ_liq_ice

--- a/src/types.jl
+++ b/src/types.jl
@@ -327,6 +327,8 @@ Base.@kwdef struct SurfaceBase{FT}
     bflux::FT = 0
     ustar::FT = 0
     ρq_tot_flux::FT = 0
+    ρq_liq_flux::FT = 0
+    ρq_ice_flux::FT = 0
     ρθ_liq_ice_flux::FT = 0
     ρu_flux::FT = 0
     ρv_flux::FT = 0

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -194,6 +194,7 @@ single_value_per_col_diagnostic_vars_edmf(FT, edmf) = (;
 
 # Center only
 cent_prognostic_vars_up(FT, _) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0))
+cent_prognostic_vars_up(FT, ::NonequilibriumMoisture) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ρaq_liq = FT(0), ρaq_ice = FT(0))
 cent_prognostic_vars_up(FT, ::PrognosticNoisyRelaxationProcess) =
     (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ε_nondim = FT(0), δ_nondim = FT(0))
 cent_prognostic_vars_en(FT) = (; ρatke = FT(0), ρaHvar = FT(0), ρaQTvar = FT(0), ρaHQTcov = FT(0))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -27,6 +27,10 @@ cent_aux_vars_up(FT, edmf) = (;
     θ_liq_ice = FT(0),
     θ_liq_ice_tendency_precip_formation = FT(0),
     qt_tendency_precip_formation = FT(0),
+    ql_tendency_precip_formation = FT(0),
+    qi_tendency_precip_formation = FT(0),
+    ql_tendency_noneq_moisture = FT(0),
+    qi_tendency_noneq_moisture = FT(0),
     entr_sc = FT(0),
     detr_sc = FT(0),
     ε_nondim = FT(0),  # nondimensional entrainment
@@ -53,6 +57,10 @@ cent_aux_vars_edmf(FT, edmf) = (;
             cloud_fraction = FT(0),
             θ_liq_ice_tendency_precip_formation = FT(0),
             qt_tendency_precip_formation = FT(0),
+            ql_tendency_precip_formation = FT(0),
+            qi_tendency_precip_formation = FT(0),
+            ql_tendency_noneq_moisture = FT(0),
+            qi_tendency_noneq_moisture = FT(0),
         ),
         up = ntuple(i -> cent_aux_vars_up(FT, edmf), n_updrafts(edmf)),
         en = (;
@@ -74,7 +82,11 @@ cent_aux_vars_edmf(FT, edmf) = (;
             QTvar = FT(0),
             HQTcov = FT(0),
             qt_tendency_precip_formation = FT(0),
+            ql_tendency_precip_formation = FT(0),
+            qi_tendency_precip_formation = FT(0),
             θ_liq_ice_tendency_precip_formation = FT(0),
+            ql_tendency_noneq_moisture = FT(0),
+            qi_tendency_noneq_moisture = FT(0),
             unsat = (; q_tot = FT(0), θ_dry = FT(0), θ_virt = FT(0)),
             sat = (; T = FT(0), q_vap = FT(0), q_tot = FT(0), θ_dry = FT(0), θ_liq_ice = FT(0)),
             Hvar_rain_dt = FT(0),
@@ -101,8 +113,12 @@ cent_aux_vars_edmf(FT, edmf) = (;
         mixing_length = FT(0),
         massflux_tendency_h = FT(0),
         massflux_tendency_qt = FT(0),
+        massflux_tendency_ql = FT(0),
+        massflux_tendency_qi = FT(0),
         diffusive_tendency_h = FT(0),
         diffusive_tendency_qt = FT(0),
+        diffusive_tendency_ql = FT(0),
+        diffusive_tendency_qi = FT(0),
         prandtl_nvec = FT(0),
         # Added by Ignacio : Length scheme in use (mls), and smooth min effect (ml_ratio)
         # Variable Prandtl number initialized as neutral value.
@@ -146,9 +162,13 @@ face_aux_vars_edmf(FT, edmf) = (;
         up = ntuple(i -> face_aux_vars_up(FT), n_updrafts(edmf)),
         massflux_h = FT(0),
         massflux_qt = FT(0),
+        massflux_ql = FT(0),
+        massflux_qi = FT(0),
         ϕ_temporary = FT(0),
         diffusive_flux_h = FT(0),
         diffusive_flux_qt = FT(0),
+        diffusive_flux_ql = FT(0),
+        diffusive_flux_qi = FT(0),
         diffusive_flux_u = FT(0),
         diffusive_flux_v = FT(0),
     ),
@@ -193,8 +213,8 @@ single_value_per_col_diagnostic_vars_edmf(FT, edmf) = (;
 ##### Prognostic fields
 
 # Center only
-cent_prognostic_vars_up(FT, _) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0))
-cent_prognostic_vars_up(FT, ::NonequilibriumMoisture) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ρaq_liq = FT(0), ρaq_ice = FT(0))
+cent_prognostic_vars_up(FT, _) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ρaq_liq = FT(0), ρaq_ice = FT(0))
+#cent_prognostic_vars_up(FT, ::NonequilibriumMoisture) = (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ρaq_liq = FT(0), ρaq_ice = FT(0))
 cent_prognostic_vars_up(FT, ::PrognosticNoisyRelaxationProcess) =
     (; ρarea = FT(0), ρaθ_liq_ice = FT(0), ρaq_tot = FT(0), ε_nondim = FT(0), δ_nondim = FT(0))
 cent_prognostic_vars_en(FT) = (; ρatke = FT(0), ρaHvar = FT(0), ρaQTvar = FT(0), ρaHQTcov = FT(0))


### PR DESCRIPTION
@jbphyswx and me were brainstorming today about how to add the non-equlibrium moisture. We are still ironing out the details of how to do it in the environment. The updrafts and the grid mean equations however are easier to start from. The things to do would be to:
- [ ] Add `q_liq` and `q_ice` related fluxes, tendencies, etc wherever necessary. With that finished we should be able to run `TC.jl` with `q_liq` and `q_ice` computed offline for the updrafts.
- [ ] Change the thermodynamic state constructors to the non-equilibrium ones.

This draft tries to tackle the first issue. Of course we want those changes to be optional based on some `namelist` argument. I wasn't sure how to do it, especially on the host model dycore side.

@charleskawczynski, it would be great if you could take a look at the extent of the damage :) Maybe in the upcoming days we could pair program with @jbphyswx to make this draft a namelist optional list of changes. 

Additionally there is a lot of repetition between `q_liq` and `q_ice`. Maybe there are some other ways where we could avoid it?