### PR TITLE
Add and update some docs and doc stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,3 @@ Upon running a particular experiment (described above), comparison plots (agains
 | `q_tot′q_tot′`| [x]           |  [✓]            |  [-]         |
 | `θ′q_tot′`    | [x]           |  [✓]            |  [-]         |
 
-

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,9 +10,12 @@ bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"))
 #! format: off
 pages = Any[
     "Home" => "index.md",
+    "Formulation" => "Formulation.md",
     "Reference states" => "ReferenceStates.md",
-    "References" => "References.md",
     "EDMF equations" => "EDMFEquations.md",
+    "API" => "API.md",
+    "Developer docs" => "dev.md",
+    "References" => "References.md",
 ]
 
 mathengine = MathJax(Dict(

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,0 +1,9 @@
+# TurbulenceConvection.jl's API
+
+```@meta
+CurrentModule = TurbulenceConvection
+```
+
+```@docs
+TurbulenceConvection.ClimaParams
+```

--- a/docs/src/Formulation.md
+++ b/docs/src/Formulation.md
@@ -1,0 +1,3 @@
+# TurbulenceConvection.jl mathematical formulation
+
+<!-- TODO: Add introduction to EDMF, including figures & equations -->

--- a/docs/src/PlotReferenceStates.jl
+++ b/docs/src/PlotReferenceStates.jl
@@ -2,6 +2,7 @@ import TurbulenceConvection
 const TC = TurbulenceConvection
 import Plots
 import NCDatasets
+import Logging
 import CLIMAParameters
 import ClimaCore
 const CC = ClimaCore
@@ -68,18 +69,21 @@ function export_ref_profile(case_name::String)
     Plots.savefig("$case_name.svg")
 
 end
-for case_name in (
-    "Bomex",
-    "life_cycle_Tan2018",
-    "Soares",
-    "Rico",
-    "ARM_SGP",
-    "DYCOMS_RF01",
-    "GABLS",
-    "SP",
-    "DryBubble",
-    "TRMM_LBA",
-    "GATE_III",
-)
-    export_ref_profile(case_name)
-end;
+
+Logging.with_logger(Logging.NullLogger()) do # silence output
+    for case_name in (
+        "Bomex",
+        "life_cycle_Tan2018",
+        "Soares",
+        "Rico",
+        "ARM_SGP",
+        "DYCOMS_RF01",
+        "GABLS",
+        "SP",
+        "DryBubble",
+        "TRMM_LBA",
+        "GATE_III",
+    )
+        export_ref_profile(case_name)
+    end
+end

--- a/docs/src/ReferenceStates.md
+++ b/docs/src/ReferenceStates.md
@@ -1,5 +1,7 @@
 # Reference States
 
+Below are plots of reference profiles vs altitude for all of the vanilla experiments that are routinely run in TurbulenceConvection.jl's integration tests.
+
 ```@example
 include("PlotReferenceStates.jl")
 ```

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -1,0 +1,4 @@
+# Developer docs
+
+This page provides miscellaneous developer documentation
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,2 @@
 # TurbulenceConvection.jl
 
-```@meta
-CurrentModule = TurbulenceConvection
-```
-
-```@docs
-TurbulenceConvection.ClimaParams
-```


### PR DESCRIPTION
This PR:
 - Moves the README table to the developer docs (I wrote this when trying to understand the equations)
 - Moves the index.md contents to a newly added API.md, where we can have/add doc string links
 - Adds Formulation.md, where we can add (perhaps some from the EDMFEquations.md) a story of the EDMF formulation including figures and equations
 - Silences the printed statements in ReferenceStates.md