### PR TITLE
Optional non-equilibrium moisture model

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,10 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --n_up 2 --suffix _n_up_2 --skip_tests true"
         artifact_paths: "Output.Bomex.01_n_up_2/stats/comparison/*"
 
+      - label: ":scissors: TRMM_LBA with non-equilibrium moisture"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --moisture_model nonequilibrium --skip_tests true --suffix _nonequilibrium_moisture"
+        artifact_paths: "Output.TRMM_LBA.01_nonequilibrium_moisture/stats/comparison/*"
+
       - label: ":partly_sunny: Bomex with calibrate_io_true"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true --skip_post_proc true --suffix _calibrate_io_true"
         artifact_paths: "Output.Bomex.01_calibrate_io_true/stats/comparison/*"

--- a/driver/Surface.jl
+++ b/driver/Surface.jl
@@ -73,6 +73,8 @@ function get_surface(
         ρθ_liq_ice_flux = shf / TD.cp_m(param_set, ts_in),
         ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
         wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
     )
 end
 
@@ -131,6 +133,8 @@ function get_surface(
         ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
         bflux = result.buoy_flux,
         wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
     )
 end
 
@@ -189,6 +193,8 @@ function get_surface(
         ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
         bflux = result.buoy_flux,
         wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
     )
 end
 
@@ -249,5 +255,7 @@ function get_surface(
         ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
         bflux = result.buoy_flux,
         wstar = convective_vel,
+        ρq_liq_flux = FT(0),
+        ρq_ice_flux = FT(0),
     )
 end

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -160,6 +160,7 @@ function default_namelist(
 
     namelist_defaults["thermodynamics"] = Dict()
     namelist_defaults["thermodynamics"]["thermal_variable"] = "thetal"
+    namelist_defaults["thermodynamics"]["moisture_model"] = "equilibrium" #"nonequilibrium"
     namelist_defaults["thermodynamics"]["sgs"] = "quadrature"
     namelist_defaults["thermodynamics"]["quadrature_order"] = 3
     namelist_defaults["thermodynamics"]["quadrature_type"] = "log-normal" #"gaussian" or "log-normal"

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -39,10 +39,8 @@ function parse_commandline()
         default = ""
         "--n_up"           # Number of updrafts
         arg_type = Int
-        # TODO in 928
-        #"--moisture_model" # Moisture model (equilibrium or non-equilibrium)
-        #arg_type = String
-        #default = "equilibrium"
+        "--moisture_model" # Moisture model (equilibrium or non-equilibrium)
+        arg_type = String
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -1,4 +1,44 @@
 """
+Computes tendencies to q_liq and q_ice due to
+condensation, evaporation, deposition and sublimation
+"""
+function compute_nonequilibrium_moisture_tendencies!(
+    grid::Grid,
+    state::State,
+    edmf::EDMFModel,
+    Δt::Real,
+    param_set::APS,
+)
+    N_up = n_updrafts(edmf)
+    p0_c = center_ref_state(state).p0
+    ρ0_c = center_ref_state(state).ρ0
+    aux_up = center_aux_updrafts(state)
+    aux_bulk = center_aux_bulk(state)
+
+    @inbounds for i in 1:N_up
+        @inbounds for k in real_center_indices(grid)
+            T_up = aux_up[i].T[k]
+            q_up = TD.PhasePartition(aux_up[i].q_tot[k], aux_up[i].q_liq[k], aux_up[i].q_ice[k])
+            ts_up = TD.PhaseNonEquil_pTq(param_set, p0_c[k], T_up, q_up)
+
+            # condensation/evaporation, deposition/sublimation
+            mph = noneq_moisture_sources(param_set, aux_up[i].area[k], ρ0_c[k], Δt, ts_up)
+            aux_up[i].ql_tendency_noneq[k] = mph.ql_tendency * aux_up[i].area[k]
+            aux_up[i].qi_tendency_noneq[k] = mph.qi_tendency * aux_up[i].area[k]
+        end
+    end
+    @inbounds for k in real_center_indices(grid)
+        aux_bulk.ql_tendency_noneq[k] = 0
+        aux_bulk.qi_tendency_noneq[k] = 0
+        @inbounds for i in 1:N_up
+            aux_bulk.ql_tendency_noneq[k] += aux_up[i].ql_tendency_noneq[k]
+            aux_bulk.qi_tendency_noneq[k] += aux_up[i].qi_tendency_noneq[k]
+        end
+    end
+    return nothing
+end
+
+"""
 Computes tendencies to qt and θ_liq_ice due to precipitation formation
 """
 function compute_precipitation_formation_tendencies(
@@ -21,7 +61,16 @@ function compute_precipitation_formation_tendencies(
         @inbounds for k in real_center_indices(grid)
             T_up = aux_up[i].T[k]
             q_tot_up = aux_up[i].q_tot[k]
-            ts_up = TD.PhaseEquil_pTq(param_set, p0_c[k], T_up, q_tot_up)
+            if edmf.moisture_model isa EquilibriumMoisture
+                ts_up = TD.PhaseEquil_pTq(param_set, p0_c[k], T_up, q_tot_up)
+            elseif edmf.moisture_model isa NonEquilibriumMoisture
+                q_liq_up = aux_up[i].q_liq[k]
+                q_ice_up = aux_up[i].q_ice[k]
+                q = TD.PhasePartition(q_tot_up, q_liq_up, q_ice_up)
+                ts_up = TD.PhaseNonEquil_pTq(param_set, p0_c[k], T_up, q)
+            else
+                error("Something went wrong in EDMF_Updrafts. The expected moisture model is Equilibrium or NonEquilibrium")
+            end
 
             # autoconversion and accretion
             mph = precipitation_formation(
@@ -36,7 +85,10 @@ function compute_precipitation_formation_tendencies(
             )
             aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
             aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]
-
+            if edmf.moisture_model isa NonEquilibriumMoisture
+                aux_up[i].ql_tendency_precip_formation[k] = mph.ql_tendency * aux_up[i].area[k]
+                aux_up[i].qi_tendency_precip_formation[k] = mph.qi_tendency * aux_up[i].area[k]
+            end
             tendencies_pr.q_rai[k] += mph.qr_tendency * aux_up[i].area[k]
             tendencies_pr.q_sno[k] += mph.qs_tendency * aux_up[i].area[k]
         end
@@ -48,6 +100,14 @@ function compute_precipitation_formation_tendencies(
         @inbounds for i in 1:N_up
             aux_bulk.θ_liq_ice_tendency_precip_formation[k] += aux_up[i].θ_liq_ice_tendency_precip_formation[k]
             aux_bulk.qt_tendency_precip_formation[k] += aux_up[i].qt_tendency_precip_formation[k]
+        end
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            aux_bulk.ql_tendency_precip_formation[k] = 0
+            aux_bulk.qi_tendency_precip_formation[k] = 0
+            @inbounds for i in 1:N_up
+                aux_bulk.ql_tendency_precip_formation[k] += aux_up[i].ql_tendency_precip_formation[k]
+                aux_bulk.qi_tendency_precip_formation[k] += aux_up[i].qi_tendency_precip_formation[k]
+            end
         end
     end
     return nothing

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -99,6 +99,23 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
         @. massflux_h += massflux * (If(θ_liq_ice_up) - If(θ_liq_ice_en))
         @. massflux_qt += massflux * (If(q_tot_up) - If(q_tot_en))
     end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        massflux_ql = aux_tc_f.massflux_ql
+        massflux_qi = aux_tc_f.massflux_qi
+        parent(massflux_ql) .= 0
+        parent(massflux_qi) .= 0
+        q_liq_en = aux_en.q_liq
+        q_ice_en = aux_en.q_ice
+        @inbounds for i in 1:N_up
+            aux_up_f_i = aux_up_f[i]
+            aux_up_i = aux_up[i]
+            q_liq_up = aux_up_i.q_liq
+            q_ice_up = aux_up_i.q_ice
+            massflux = aux_up_f[i].massflux
+            @. massflux_ql += massflux * (If(q_liq_up) - If(q_liq_en))
+            @. massflux_qi += massflux * (If(q_ice_up) - If(q_ice_en))
+        end
+    end
 
     massflux_tendency_h = aux_tc.massflux_tendency_h
     massflux_tendency_qt = aux_tc.massflux_tendency_qt
@@ -122,6 +139,23 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     @. sgs_flux_q_tot = diffusive_flux_qt + massflux_qt
     @. sgs_flux_u = diffusive_flux_u # + massflux_u
     @. sgs_flux_v = diffusive_flux_v # + massflux_v
+
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        massflux_tendency_ql = aux_tc.massflux_tendency_ql
+        massflux_tendency_qi = aux_tc.massflux_tendency_qi
+
+        @. massflux_tendency_ql = -∇c(wvec(massflux_ql)) * α0_c
+        @. massflux_tendency_qi = -∇c(wvec(massflux_qi)) * α0_c
+
+        diffusive_flux_ql = aux_tc_f.diffusive_flux_ql
+        diffusive_flux_qi = aux_tc_f.diffusive_flux_qi
+
+        sgs_flux_q_liq = aux_gm_f.sgs_flux_q_liq
+        sgs_flux_q_ice = aux_gm_f.sgs_flux_q_ice
+
+        @. sgs_flux_q_liq = diffusive_flux_ql + massflux_ql
+        @. sgs_flux_q_ice = diffusive_flux_qi + massflux_qi
+    end
 
     return nothing
 end
@@ -165,6 +199,17 @@ function compute_diffusive_fluxes(edmf::EDMFModel, grid::Grid, state::State, sur
     @. aux_tc_f.diffusive_flux_u = -aux_tc_f.ρ_ae_KM * ∇u_gm(wvec(prog_gm.u))
     @. aux_tc_f.diffusive_flux_v = -aux_tc_f.ρ_ae_KM * ∇v_gm(wvec(prog_gm.v))
 
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        aeKHq_liq_bc = FT(0)
+        aeKHq_ice_bc = FT(0)
+
+        ∇q_liq_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHq_liq_bc), top = CCO.SetDivergence(FT(0)))
+        ∇q_ice_en = CCO.DivergenceC2F(; bottom = CCO.SetDivergence(aeKHq_ice_bc), top = CCO.SetDivergence(FT(0)))
+
+        @. aux_tc_f.diffusive_flux_ql = -aux_tc_f.ρ_ae_KH * ∇q_liq_en(wvec(aux_en.q_liq))
+        @. aux_tc_f.diffusive_flux_qi = -aux_tc_f.ρ_ae_KH * ∇q_ice_en(wvec(aux_en.q_ice))
+    end
+
     return nothing
 end
 
@@ -199,6 +244,7 @@ function affect_filter!(
 end
 
 function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    FT = eltype(grid)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
@@ -215,6 +261,12 @@ function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::Su
         prog_up[i].ρarea[kc_surf] = ρ0_c[kc_surf] * a_surf
         prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
         prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
+        if edmf.moisture_model isa NonEquilibriumMoisture
+            q_liq_surf = FT(0)
+            q_ice_surf = FT(0)
+            prog_up[i].ρaq_liq[kc_surf] = prog_up[i].ρarea[kc_surf] * q_liq_surf
+            prog_up[i].ρaq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * q_ice_surf
+        end
         prog_up_f[i].ρaw[kf_surf] = ρ0_f[kf_surf] * w_surface_bc(surf)
     end
 
@@ -293,6 +345,12 @@ function q_surface_bc(surf::SurfaceBase{FT}, grid::Grid, state::State, edmf::EDM
     qt_var = get_surface_variance(ρq_tot_flux * α0LL, ρq_tot_flux * α0LL, ustar, zLL, oblength)
     surface_scalar_coeff = percentile_bounds_mean_norm(1 - a_total + (i - 1) * a_, 1 - a_total + i * a_, 1000)
     return prog_gm.q_tot[kc_surf] + surface_scalar_coeff * sqrt(qt_var)
+end
+function ql_surface_bc(surf::SurfaceBase{FT})::FT where {FT}
+    return FT(0)
+end
+function qi_surface_bc(surf::SurfaceBase{FT})::FT where {FT}
+    return FT(0)
 end
 
 function get_GMV_CoVar(
@@ -430,6 +488,36 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
             -∇c(wvec(LBF(Ic(w_up) * ρ0_c * a_up * q_tot_up))) + (ρ0_c * a_up * Ic(w_up) * entr_turb_dyn * q_tot_en) -
             (ρ0_c * a_up * Ic(w_up) * detr_turb_dyn * q_tot_up) + (ρ0_c * qt_tendency_precip_formation)
 
+        if edmf.moisture_model isa NonEquilibriumMoisture
+
+            q_liq_up = aux_up_i.q_liq
+            q_ice_up = aux_up_i.q_ice
+            q_liq_en = aux_en.q_liq
+            q_ice_en = aux_en.q_ice
+
+            ql_tendency_noneq = aux_up_i.ql_tendency_noneq
+            qi_tendency_noneq = aux_up_i.qi_tendency_noneq
+            ql_tendency_precip_formation = aux_up_i.ql_tendency_precip_formation
+            qi_tendency_precip_formation = aux_up_i.qi_tendency_precip_formation
+
+            tends_ρaq_liq = tendencies_up[i].ρaq_liq
+            tends_ρaq_ice = tendencies_up[i].ρaq_ice
+
+            @. tends_ρaq_liq =
+                -∇c(wvec(LBF(Ic(w_up) * ρ0_c * a_up * q_liq_up))) +
+                (ρ0_c * a_up * Ic(w_up) * entr_turb_dyn * q_liq_en) -
+                (ρ0_c * a_up * Ic(w_up) * detr_turb_dyn * q_liq_up) +
+                (ρ0_c * (ql_tendency_precip_formation + ql_tendency_noneq))
+
+            @. tends_ρaq_ice =
+                -∇c(wvec(LBF(Ic(w_up) * ρ0_c * a_up * q_ice_up))) +
+                (ρ0_c * a_up * Ic(w_up) * entr_turb_dyn * q_ice_en) -
+                (ρ0_c * a_up * Ic(w_up) * detr_turb_dyn * q_ice_up) +
+                (ρ0_c * (qi_tendency_precip_formation + qi_tendency_noneq))
+
+            tends_ρaq_liq[kc_surf] = 0
+            tends_ρaq_ice[kc_surf] = 0
+        end
 
         # prognostic entr/detr
         if edmf.entr_closure isa PrognosticNoisyRelaxationProcess
@@ -513,6 +601,12 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
             prog_up[i].ρarea[k] = min(prog_up[i].ρarea[k], ρ0_c[k] * a_max)
         end
     end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for i in 1:N_up
+            prog_up[i].ρaq_liq .= max.(prog_up[i].ρaq_liq, 0)
+            prog_up[i].ρaq_ice .= max.(prog_up[i].ρaq_ice, 0)
+        end
+    end
 
     @inbounds for i in 1:N_up
         @. prog_up_f[i].ρaw = max.(prog_up_f[i].ρaw, 0)
@@ -533,6 +627,22 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
             end
         end
     end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for k in real_center_indices(grid)
+            @inbounds for i in 1:N_up
+                is_surface_center(grid, k) && continue
+                prog_up[i].ρaq_tot[k] = max(prog_up[i].ρaq_tot[k], 0)
+                # this is needed to make sure Rico is unchanged.
+                # TODO : look into it further to see why
+                # a similar filtering of ρaθ_liq_ice breaks the simulation
+                if prog_up[i].ρarea[k] / ρ0_c[k] < a_min
+                    prog_up[i].ρaq_liq[k] = 0
+                    prog_up[i].ρaq_ice[k] = 0
+                end
+            end
+        end
+    end
+
 
     Ic = CCO.InterpolateF2C()
     @inbounds for i in 1:N_up
@@ -545,6 +655,16 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
         prog_up[i].ρarea[kc_surf] = ρ0_c[kc_surf] * a_surf
         prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
         prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
+    end
+    if edmf.moisture_model isa NonEquilibriumMoisture
+        @inbounds for i in 1:N_up
+            @. prog_up[i].ρaq_liq = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_liq)
+            @. prog_up[i].ρaq_ice = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_ice)
+            ql_surf = ql_surface_bc(surf)
+            qi_surf = qi_surface_bc(surf)
+            prog_up[i].ρaq_liq[kc_surf] = prog_up[i].ρarea[kc_surf] * ql_surf
+            prog_up[i].ρaq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * qi_surf
+        end
     end
     return nothing
 end

--- a/src/thermodynamics.jl
+++ b/src/thermodynamics.jl
@@ -4,3 +4,8 @@ function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT) whe
     config = ()
     return TD.PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
 end
+function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
+    config = ()
+    q = TD.PhasePartition(q_tot, q_liq, q_ice)
+    return TD.PhaseNonEquil_pθq(param_set, p, θ_liq_ice, q, config...)
+end


### PR DESCRIPTION
This is a draft PR with the non-equilibrium moisture model. The general description of what we are trying to do is here: https://www.overleaf.com/read/hgzwbvbfkqzw

This PR implements the first step from the above document. It (only) adds the non-equilibrium moisture to the updraft equations (equation (7) from the above document). It doesn't do anything about the second order terms related to the cloud liquid and cloud ice variables. This means we are limiting ourselves to not using the quadratures for the buoyancy gradients and the sgs source terms in the environment.

I made sure to code it as an option for `TC.jl`. I don't expect to use it in "operational" `TC.jl` simulations soon. But it is a very interesting research project led by @jbphyswx . 

It would be great if @yairchn and @ilopezgp could take a look and check if I'm updating all the necessary equations and if @charleskawczynski could take a look and check if there is anything that can be optimised at this stage. And that @jbphyswx could double check that the proposed changes are in line with what we have drafted before. 

A couple of additional notes:
- I did not change how the buoyancy gradients are calculated. In theory the moist gas constants should be computed based on the non-equilibrium thermodynamic state. But for the sake of simplicity I did not want to add additional options there. I don't think it should matter.
- The `src/update_aux.jl` file needs some additional cleaning. For this PR my main goal was to introduce minimal changes to the code structure. As a result, for the non-equilibrium option we are updating the `q_liq` and `q_ice` values twice. - Once during the "prognostic update" of the auxiliary variables, and another time in the "diagnostic update" of the auxiliary variables. This should not matter because for the case of non-equilibrium moisture, the thermodynamic state is constructed by passing a full phase partition tuple which is already populated based on the prognostic variables. So in short, the values are being overwritten with the same values. In the future it would be good to improve the `src/update_aux.jl` file. 
- I have assumed that the boundary condition fluxes for `q_liq` and `q_ice` are zero.
- I have added the `ql_tendency` and `qi_tendency` to the `PrecipFormation` struct. We don't need them for the equilibrium moisture model. But I thought that the code readability is better this way than duplicating the code only to once populate the `qt_tendency` and other time to also populate the `ql_tendency` and `qi_tendency`.
- In the `driver/dycore.jl` I am extending the list of prognostic variables based on the `edmf.moisture_model` choice. I know that in principle the driver fields should not depend on the edmf model fields. But to me this seemed like a smaller change than introducing some hypothetical option for the hypothetical driver model. 

Those are the namelist fields that have to be changed from defaults to make the Bomex simulation run:

```
    # TODO - move to one of the "Vanilla + Deviations" tests                    
    namelist["thermodynamics"]["moisture_model"] = "nonequilibrium"             
    namelist["thermodynamics"]["sgs"] = "mean"                                  
    namelist["turbulence"]["EDMF_PrognosticTKE"]["env_buoy_grad"] = "mean"      
    namelist["time_stepping"]["adapt_dt"] = false  
```
