### PR TITLE
Add multiple updraft buildkite job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,6 +123,10 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stoch_entr prognostic_noisy_relaxation_process --skip_tests true --suffix _prognostic_noisy_relaxation_process"
         artifact_paths: "Output.Bomex.01_prognostic_noisy_relaxation_process/stats/comparison/*"
 
+      - label: ":partly_sunny: Bomex with multiple updrafts"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --n_up 2 --suffix _n_up_2 --skip_tests true"
+        artifact_paths: "Output.Bomex.01_n_up_2/stats/comparison/*"
+
       - label: ":partly_sunny: Bomex with calibrate_io_true"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true --skip_post_proc true --suffix _calibrate_io_true"
         artifact_paths: "Output.Bomex.01_calibrate_io_true/stats/comparison/*"

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -33,6 +33,9 @@ function parse_commandline()
         "--suffix"         # A suffix for the artifact folder
         arg_type = String
         default = ""
+        "--n_up"           # Number of updrafts
+        arg_type = Int
+        default = 1
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -21,13 +21,14 @@ namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01$suffix"
 
 #! format: off
-isnothing(parsed_args["micro"]) && (parsed_args["micro"] = namelist["thermodynamics"]["quadrature_type"])
-isnothing(parsed_args["entr"]) && (parsed_args["entr"] = namelist["turbulence"]["EDMF_PrognosticTKE"]["entrainment"])
-isnothing(parsed_args["stoch_entr"]) && (parsed_args["stoch_entr"] = namelist["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"])
-isnothing(parsed_args["t_max"]) && (parsed_args["t_max"] = namelist["time_stepping"]["t_max"])
-isnothing(parsed_args["calibrate_io"]) && (parsed_args["calibrate_io"] = namelist["stats_io"]["calibrate_io"])
-isnothing(parsed_args["stretch_grid"]) && (parsed_args["stretch_grid"] = namelist["grid"]["stretch"]["flag"])
-isnothing(parsed_args["skip_io"]) && (parsed_args["skip_io"] = namelist["stats_io"]["skip"])
+!isnothing(parsed_args["micro"]) && (namelist["thermodynamics"]["quadrature_type"] = parsed_args["micro"])
+!isnothing(parsed_args["entr"]) && (namelist["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = parsed_args["entr"])
+!isnothing(parsed_args["stoch_entr"]) && (namelist["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = parsed_args["stoch_entr"])
+!isnothing(parsed_args["t_max"]) && (namelist["time_stepping"]["t_max"] = parsed_args["t_max"])
+!isnothing(parsed_args["calibrate_io"]) && (namelist["stats_io"]["calibrate_io"] = parsed_args["calibrate_io"])
+!isnothing(parsed_args["stretch_grid"]) && (namelist["grid"]["stretch"]["flag"] = parsed_args["stretch_grid"])
+!isnothing(parsed_args["skip_io"]) && (namelist["stats_io"]["skip"] = parsed_args["skip_io"])
+!isnothing(parsed_args["n_up"]) && (namelist["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = parsed_args["n_up"])
 #! format: on
 
 ds_tc_filename, return_code = main(namelist)


### PR DESCRIPTION
I'm impressed that this is working out of the box! Are there other things we could add to visualization? I'm curious (and suspect) what the distribution is of different variables between updrafts.

This PR adds a `n_up` cli option, and fixes a pretty big bug introduced in #932 (parsed args were set to cli options, and not the other way around) 😬.