### PR TITLE
read grid specs from LES when LES driving is used

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -1123,7 +1123,8 @@ function surface_ref_state(::LES_driven_SCM, param_set::APS, namelist)
     les_filename = namelist["meta"]["lesfile"]
 
     Pg, Tg, qtg = NC.Dataset(les_filename, "r") do data
-        Pg = data.group["reference"]["p0_full"][1] #Pressure at ground
+        pg_str = haskey(data.group["reference"], "p0_full") ? "p0_full" : "p0"
+        Pg = data.group["reference"][pg_str][1] #Pressure at ground
         Tg = data.group["reference"]["temperature0"][1] #Temperature at ground
         ql_ground = data.group["reference"]["ql0"][1]
         qv_ground = data.group["reference"]["qv0"][1]

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -75,7 +75,15 @@ function Simulation1d(namelist)
     truncated_gcm_mesh = TC.parse_namelist(namelist, "grid", "stretch", "flag"; default = false)
 
     Δz = FT(namelist["grid"]["dz"])
-    nz = namelist["grid"]["nz"]
+    nz = if Cases.get_case(namelist) == Cases.LES_driven_SCM()
+        les_filename = namelist["meta"]["lesfile"]
+        NC.Dataset(les_filename, "r") do data
+            zmax = Array(TC.get_nc_data(data, "zc"))[end]
+            Int(zmax ÷ Δz)
+        end
+    else
+        namelist["grid"]["nz"]
+    end
     z₀, z₁ = FT(0), FT(nz * Δz)
     if truncated_gcm_mesh
         nzₛ = namelist["grid"]["stretch"]["nz"]


### PR DESCRIPTION
I would like to make the LES driven SCM case read grid specs from the LES file so that we can switch from shallow to deep convection cfsites easily in calibration. The main issue is that we need to read the LES grid before most of the LES data is read which makes it a bit messy -- happy to solicitude ideas for to make it better.