### PR TITLE
Refactor cli options

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,43 +92,43 @@ steps:
     steps:
 
       - label: ":partly_sunny: Bomex with gaussian"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --micro gaussian"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --micro gaussian --skip_tests true --suffix _gaussian"
         artifact_paths: "Output.Bomex.01_gaussian/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with stretched grid"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stretch_grid true"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stretch_grid true --suffix _stretch_grid_true"
         artifact_paths: "Output.Bomex.01_stretch_grid_true/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with NN_nonlocal"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal --skip_tests true --suffix _NN_nonlocal"
         artifact_paths: "Output.Bomex.01_NN_nonlocal/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with NN"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN --skip_tests true --suffix _NN"
         artifact_paths: "Output.Bomex.01_NN/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with FNO"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr FNO"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr FNO --skip_tests true --suffix _FNO"
         artifact_paths: "Output.Bomex.01_FNO/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with RF"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr RF"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr RF --skip_tests true --suffix _RF"
         artifact_paths: "Output.Bomex.01_RF/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with noisy_relaxation_process"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stoch_entr noisy_relaxation_process"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stoch_entr noisy_relaxation_process --skip_tests true --suffix _noisy_relaxation_process"
         artifact_paths: "Output.Bomex.01_noisy_relaxation_process/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with prognostic_noisy_relaxation_process"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stoch_entr prognostic_noisy_relaxation_process"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stoch_entr prognostic_noisy_relaxation_process --skip_tests true --suffix _prognostic_noisy_relaxation_process"
         artifact_paths: "Output.Bomex.01_prognostic_noisy_relaxation_process/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with calibrate_io_true"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true --skip_post_proc true --suffix _calibrate_io_true"
         artifact_paths: "Output.Bomex.01_calibrate_io_true/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with skip_io_true"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --skip_io true"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --skip_io true --skip_post_proc true --suffix _skip_io_true"
         artifact_paths: "Output.Bomex.01_skip_io_true/stats/comparison/*"
 
 

--- a/driver/NetCDFIO.jl
+++ b/driver/NetCDFIO.jl
@@ -11,12 +11,15 @@ function nc_fileinfo(namelist)
     uuid = string(namelist["meta"]["uuid"])
     simname = namelist["meta"]["simname"]
     outpath = joinpath(namelist["output"]["output_root"], "Output.$simname.$uuid")
+    @info "Output folder: `$outpath`"
     mkpath(outpath)
 
     nc_filename = joinpath(outpath, namelist["stats_io"]["stats_dir"])
     mkpath(nc_filename)
+    @info "NC filename path: `$nc_filename`"
 
     nc_filename = joinpath(nc_filename, "Stats.$simname.nc")
+    @info "NC filename: `$nc_filename`"
     return nc_filename, outpath
 end
 

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -1,0 +1,39 @@
+import ArgParse
+
+function parse_commandline()
+    s = ArgParse.ArgParseSettings()
+    ArgParse.@add_arg_table s begin
+        "--case"
+        help = "Case to run"
+        default = "Bomex"
+        "--micro"          # Try other microphysics quadrature
+        default = "log-normal"
+        "--entr"           # Try other entr-detr models
+        arg_type = String
+        default = "moisture_deficit"
+        "--stoch_entr"     # Choose type of stochastic entr-detr model
+        arg_type = String
+        "--t_max"          # Simulation time to run to
+        arg_type = Float64
+        "--calibrate_io"   # Test that calibration IO passes regression tests
+        arg_type = Bool
+        default = false
+        "--stretch_grid"   # Test stretched grid option
+        arg_type = Bool
+        default = false
+        "--skip_io"        # Test that skipping IO passes regression tests
+        arg_type = Bool
+        default = false
+        "--skip_post_proc" # Skip post processing
+        arg_type = Bool
+        default = false
+        "--skip_tests"     # Skip regression tests
+        arg_type = Bool
+        default = false
+        "--suffix"         # A suffix for the artifact folder
+        arg_type = String
+        default = ""
+    end
+    parsed_args = ArgParse.parse_args(ARGS, s)
+    return (s, parsed_args)
+end


### PR DESCRIPTION
This PR refactors the CLI options by:

 - Adding explicit flags for skipping post-processing and tests
 - Using ArgParse.jl's parsing

@trontrytel, I've removed the `run_from_command_line` flag, but I think we can use `@isdefined parsed_args` to make REPL development easier. Once we create a `parsed_args`, we can reset any of the args to whatever we'd like:

```julia
parsed_args["entr"] = "FNO"
```

This should make #929 much easier to get working without piling on more hacks.