### PR TITLE
Add to the cli options, unify env_buoy_grad and sgs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,7 +92,7 @@ steps:
     steps:
 
       - label: ":partly_sunny: Bomex with gaussian"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --micro gaussian --skip_tests true --suffix _gaussian"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --quad_type gaussian --skip_tests true --suffix _gaussian"
         artifact_paths: "Output.Bomex.01_gaussian/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with stretched grid"

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -185,7 +185,6 @@ function default_namelist(
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["constant_area"] = false
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["calculate_tke"] = true
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["mixing_length"] = "sbtd_eq"
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["env_buoy_grad"] = "quadratures"
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_buoy"] = "normalmode"
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["pressure_closure_drag"] = "normalmode"

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -6,21 +6,25 @@ function parse_commandline()
         "--case"
         help = "Case to run"
         default = "Bomex"
-        "--micro"          # Try other microphysics quadrature
-        default = "log-normal"
+        "--sgs"            # SGS environmental teratment (mean or quadratures)
+        arg_type = String
+        "--quad_type"      # SGS quadrature type (lognormal or Gaussian)
+        arg_type = String
         "--entr"           # Try other entr-detr models
         arg_type = String
-        default = "moisture_deficit"
         "--stoch_entr"     # Choose type of stochastic entr-detr model
         arg_type = String
         "--t_max"          # Simulation time to run to
+        arg_type = Float64
+        "--adapt_dt"       # use adaptive timestepping
+        arg_type = Bool
+        "--dt"             # Specify model time step (when not using adaptive dt)
         arg_type = Float64
         "--calibrate_io"   # Test that calibration IO passes regression tests
         arg_type = Bool
         default = false
         "--stretch_grid"   # Test stretched grid option
         arg_type = Bool
-        default = false
         "--skip_io"        # Test that skipping IO passes regression tests
         arg_type = Bool
         default = false
@@ -35,7 +39,10 @@ function parse_commandline()
         default = ""
         "--n_up"           # Number of updrafts
         arg_type = Int
-        default = 1
+        # TODO in 928
+        #"--moisture_model" # Moisture model (equilibrium or non-equilibrium)
+        #arg_type = String
+        #default = "equilibrium"
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -23,10 +23,13 @@ namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01$suffix"
 
 #! format: off
-!isnothing(parsed_args["micro"]) && (namelist["thermodynamics"]["quadrature_type"] = parsed_args["micro"])
+!isnothing(parsed_args["sgs"]) && (namelist["thermodynamics"]["sgs"] = parsed_args["sgs"])
+!isnothing(parsed_args["quad_type"]) && (namelist["thermodynamics"]["quadrature_type"] = parsed_args["quad_type"])
 !isnothing(parsed_args["entr"]) && (namelist["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = parsed_args["entr"])
 !isnothing(parsed_args["stoch_entr"]) && (namelist["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = parsed_args["stoch_entr"])
 !isnothing(parsed_args["t_max"]) && (namelist["time_stepping"]["t_max"] = parsed_args["t_max"])
+!isnothing(parsed_args["adapt_dt"]) && (namelist["time_stepping"]["adapt_dt"] = parsed_args["adapt_dt"])
+!isnothing(parsed_args["dt"]) && (namelist["time_stepping"]["dt_min"] = parsed_args["dt"])
 !isnothing(parsed_args["calibrate_io"]) && (namelist["stats_io"]["calibrate_io"] = parsed_args["calibrate_io"])
 !isnothing(parsed_args["stretch_grid"]) && (namelist["grid"]["stretch"]["flag"] = parsed_args["stretch_grid"])
 !isnothing(parsed_args["skip_io"]) && (namelist["stats_io"]["skip"] = parsed_args["skip_io"])

--- a/src/types.jl
+++ b/src/types.jl
@@ -459,28 +459,22 @@ struct EDMFModel{N_up, FT, PM, ENT, EBGC, EC, EDS, EPG}
         precip_model = precip_model
         # Create the environment variable class (major diagnostic and prognostic variables)
 
-        # Create the class for environment thermodynamics
-        en_thermo_name = parse_namelist(namelist, "thermodynamics", "sgs"; default = "mean")
-        en_thermo = if en_thermo_name == "mean"
+        # Create the class for environment thermodynamics and buoyancy gradient computation
+        en_sgs_name =
+            parse_namelist(namelist, "thermodynamics", "sgs"; default = "mean", valid_options = ["mean", "quadrature"])
+        en_thermo = if en_sgs_name == "mean"
             SGSMean()
-        elseif en_thermo_name == "quadrature"
+        elseif en_sgs_name == "quadrature"
             SGSQuadrature(namelist)
+        else
+            error("Something went wrong. Invalid environmental sgs type '$en_sgs_name'")
         end
-
-        bg_type = parse_namelist(
-            namelist,
-            "turbulence",
-            "EDMF_PrognosticTKE",
-            "env_buoy_grad";
-            default = "mean",
-            valid_options = ["mean", "quadratures"],
-        )
-        bg_closure = if bg_type == "mean"
+        bg_closure = if en_sgs_name == "mean"
             BuoyGradMean()
-        elseif bg_type == "quadratures"
+        elseif en_sgs_name == "quadrature"
             BuoyGradQuadratures()
         else
-            error("Something went wrong. Invalid environmental buoyancy gradient closure type '$bg_type'")
+            error("Something went wrong. Invalid environmental buoyancy gradient closure type '$en_sgs_name'")
         end
 
         # entr closure


### PR DESCRIPTION
This PR:
- adds more command line options (I need them for adding the upcoming #928 to the CI)
- unifies the `["turbulence"]["EDMF_PrognosticTKE"]["env_buoy_grad"]` and the `["thermodynamics"]["sgs"]` namelist flags. This ensures that the buoyancy gradients and environmental sources are computed consistently either on the mean or the quadrature points. 