### PR TITLE
Use cached thermo state field more

### DIFF
--- a/driver/Surface.jl
+++ b/driver/Surface.jl
@@ -20,11 +20,8 @@ function get_surface(
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     p0_f_surf = TC.face_ref_state(state).p0[kf_surf]
-    p0_c_surf = TC.center_ref_state(state).p0[kc_surf]
     u_gm_surf = prog_gm.u[kc_surf]
     v_gm_surf = prog_gm.v[kc_surf]
-    q_tot_gm_surf = prog_gm.q_tot[kc_surf]
-    θ_liq_ice_gm_surf = prog_gm.θ_liq_ice[kc_surf]
     Tsurface = TC.surface_temperature(surf_params, t)
     qsurface = TC.surface_q_tot(surf_params, t)
     shf = TC.sensible_heat_flux(surf_params, t)
@@ -33,7 +30,7 @@ function get_surface(
     zrough = surf_params.zrough
 
     ts_sfc = TD.PhaseEquil_pTq(param_set, p0_f_surf, Tsurface, qsurface)
-    ts_in = TD.PhaseEquil_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, q_tot_gm_surf)
+    ts_in = aux_gm.ts[kc_surf]
     universal_func = UF.Businger()
     scheme = SF.FVScheme()
 
@@ -89,13 +86,10 @@ function get_surface(
     kc_surf = TC.kc_surface(grid)
     kf_surf = TC.kf_surface(grid)
     p0_f_surf = TC.face_ref_state(state).p0[kf_surf]
-    p0_c_surf = TC.center_ref_state(state).p0[kc_surf]
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     u_gm_surf = prog_gm.u[kc_surf]
     v_gm_surf = prog_gm.v[kc_surf]
-    q_tot_gm_surf = prog_gm.q_tot[kc_surf]
-    θ_liq_ice_gm_surf = prog_gm.θ_liq_ice[kc_surf]
     Tsurface = TC.surface_temperature(surf_params, t)
     qsurface = TC.surface_q_tot(surf_params, t)
     zrough = surf_params.zrough
@@ -108,7 +102,7 @@ function get_surface(
     z_sfc = FT(0)
     z_in = grid.zc[kc_surf].z
     ts_sfc = TD.PhaseEquil_pθq(param_set, p0_f_surf, Tsurface, qsurface)
-    ts_in = TD.PhaseEquil_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, q_tot_gm_surf)
+    ts_in = aux_gm.ts[kc_surf]
     u_sfc = SA.SVector{2, FT}(0, 0)
     u_in = SA.SVector{2, FT}(u_gm_surf, v_gm_surf)
     vals_sfc = SF.SurfaceValues(z_sfc, u_sfc, ts_sfc)

--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -353,6 +353,7 @@ function compute_gm_tendencies!(
     p0_c = TC.center_ref_state(state).p0
     α0_c = TC.center_ref_state(state).α0
     aux_tc = TC.center_aux_turbconv(state)
+    ts_gm = TC.center_aux_grid_mean(state).ts
 
     θ_liq_ice_gm_toa = prog_gm.θ_liq_ice[kc_toa]
     q_tot_gm_toa = prog_gm.q_tot[kc_toa]
@@ -376,13 +377,7 @@ function compute_gm_tendencies!(
 
     @inbounds for k in TC.real_center_indices(grid)
         # Apply large-scale horizontal advection tendencies
-        if edmf.moisture_model isa TC.EquilibriumMoisture
-            ts = TD.PhaseEquil_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], prog_gm.q_tot[k])
-        else
-            q = TD.PhasePartition(prog_gm.q_tot[k], prog_gm.q_liq[k], prog_gm.q_ice[k])
-            ts = TD.PhaseNonEquil_pθq(param_set, p0_c[k], prog_gm.θ_liq_ice[k], q)
-        end
-        Π = TD.exner(param_set, ts)
+        Π = TD.exner(param_set, ts_gm[k])
 
         if force.apply_coriolis
             tendencies_gm.u[k] -= force.coriolis_param * (aux_gm.vg[k] - prog_gm.v[k])

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -379,14 +379,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
         # buoyancy_gradients
         if edmf.bg_closure == BuoyGradMean()
             # First order approximation: Use environmental mean fields.
-            if edmf.moisture_model isa EquilibriumMoisture
-                ts_en = TD.PhaseEquil_pTq(param_set, p0_c[k], aux_en.T[k], aux_en.q_tot[k])
-            elseif edmf.moisture_model isa NonEquilibriumMoisture
-                q = TD.PhasePartition(aux_en.q_tot[k], aux_en.q_liq[k], aux_en.q_ice[k])
-                ts_en = TD.PhaseNonEquil_pTq(param_set, p0_c[k], aux_en.T[k], q)
-            else
-                error("Something went wrong in aux update. Expected moisture models are equilibrium and non-equilibrium")
-            end
+            ts_en = ts_env[k]
             bg_kwargs = (;
                 t_sat = aux_en.T[k],
                 qv_sat = TD.vapor_specific_humidity(param_set, ts_en),


### PR DESCRIPTION
A followup to #947, #946, and #945.

This PR is technically behavior changing because our thermo states constructed in Surface.jl used to not depend on the equilibrium model (and will depend on the equilibrium model in this PR). Specifically, the calls: `TD.PhaseEquil_pθq(param_set, p0_c_surf, θ_liq_ice_gm_surf, q_tot_gm_surf)`.

We may not need to update the MSE tables, however, since we don't have regression tests for non-vanilla experiments.