### PR TITLE
Fix LES domain height fetch

### DIFF
--- a/driver/main.jl
+++ b/driver/main.jl
@@ -254,7 +254,7 @@ function construct_grid(namelist; FT = Float64)
 
         les_filename = namelist["meta"]["lesfile"]
         zmax = NC.Dataset(les_filename, "r") do data
-            Array(TC.get_nc_data(data, "zc"))[end]
+            Array(TC.get_nc_data(data, "zf"))[end]
         end
         nz = isnothing(nz) ? Int(zmax ÷ Δz) : Int(nz)
         Δz = isnothing(Δz) ? FT(zmax ÷ nz) : FT(Δz)

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -179,7 +179,7 @@ all_best_mse["LES_driven_SCM"]["qt_mean"] = 3.6585461446222651e+00
 all_best_mse["LES_driven_SCM"]["v_mean"] = 1.4035659850002822e+00
 all_best_mse["LES_driven_SCM"]["u_mean"] = 4.8680732482495243e-01
 all_best_mse["LES_driven_SCM"]["temperature_mean"] = 1.3216614383634651e-03
-all_best_mse["LES_driven_SCM"]["ql_mean"] = 51870.092217716905
+all_best_mse["LES_driven_SCM"]["ql_mean"] = 5.1929489010189645e+04
 all_best_mse["LES_driven_SCM"]["thetal_mean"] = 1.5647910243269554e-03
 #
 #################################


### PR DESCRIPTION
Fixes the LES domain height fetch. In PyCLES, the centers precede the faces:

z_half = [Δz/2, Δz + Δz/2, ..., z_max - Δz/2]
z = [Δz, 2Δz, ..., z_max]

Therefore, to get the domain height, we need to fetch the last element of z, not of z_half.