### PR TITLE
Remove Pkg.develop in build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,12 +18,10 @@ steps:
     key: "init_cpu_env"
     command:
       - "echo $$JULIA_DEPOT_PATH"
-      - "julia --project=integration_tests -e 'using Pkg; Pkg.develop(path = \".\")'"
       - "julia --project=integration_tests -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=integration_tests -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=integration_tests -e 'using Pkg; Pkg.status()'"
 
-      - "julia --project=perf -e 'using Pkg; Pkg.develop(path = \".\")'"
       - "julia --project=perf -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=perf -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=perf -e 'using Pkg; Pkg.status()'"


### PR DESCRIPTION
This PR removes the develop step. We shouldn't need this since we're checking in the Manifest.

@yairchn, this should fix the issues you're having.