### PR TITLE
Truncate printing of ClimaCore field types

### DIFF
--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -41,6 +41,10 @@ function parse_commandline()
         arg_type = Int
         "--moisture_model" # Moisture model (equilibrium or non-equilibrium)
         arg_type = String
+        "--trunc_stack_traces"
+        help = "Set to `true` to truncate printing of ClimaCore `Field`s"
+        arg_type = Bool
+        default = true
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -7,6 +7,8 @@ if !@isdefined case_name
     case_name = parsed_args["case"]
 end
 
+parsed_args["trunc_stack_traces"] && include("truncate_stack_traces.jl")
+
 @info "Running $case_name..."
 @info "`suffix`: `$(suffix)`"
 @info "See `cli_options.jl` changing defaults"

--- a/integration_tests/truncate_stack_traces.jl
+++ b/integration_tests/truncate_stack_traces.jl
@@ -1,0 +1,33 @@
+import ClimaCore
+
+function Base.show(io::IO, ::Type{T}) where {T <: ClimaCore.Fields.Field}
+    values_type(::Type{T}) where {V, T <: ClimaCore.Fields.Field{V}} = V
+    V = values_type(T)
+
+    _apply!(f, ::T, match_list) where {T} = nothing # sometimes we need this...
+    function _apply!(f, ::Type{T}, match_list) where {T}
+        if f(T)
+            push!(match_list, T)
+        end
+        for p in T.parameters
+            _apply!(f, p, match_list)
+        end
+    end
+    #=
+        apply(::T) where {T <: Any}
+    Recursively traverse type `T` and apply
+    `f` to the types (and type parameters).
+    Returns a list of matches where `f(T)` is true.
+    =#
+    apply(f, ::T) where {T} = apply(f, T)
+    function apply(f, ::Type{T}) where {T}
+        match_list = []
+        _apply!(f, T, match_list)
+        return match_list
+    end
+
+    nts = apply(x -> x <: NamedTuple, eltype(V))
+    syms = unique(map(nt -> fieldnames(nt), nts))
+    s = join(syms, ",")
+    print(io, "Field{$s} (trunc disp)")
+end


### PR DESCRIPTION
Who wants shorter stack traces? 📒 This PR truncates printing for ClimaCore Field types (which people may know can be pretty long).