### PR TITLE
Add error checking to CL overwrites

### DIFF
--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -26,17 +26,18 @@ namelist["meta"]["uuid"] = "01$suffix"
 
 #! format: off
 overwrite_namelist_map = Dict(
-"sgs"          => (nl, pa, key) -> (nl["thermodynamics"]["sgs"] = pa[key]),
-"quad_type"    => (nl, pa, key) -> (nl["thermodynamics"]["quadrature_type"] = pa[key]),
-"entr"         => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = pa[key]),
-"stoch_entr"   => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = pa[key]),
-"t_max"        => (nl, pa, key) -> (nl["time_stepping"]["t_max"] = pa[key]),
-"adapt_dt"     => (nl, pa, key) -> (nl["time_stepping"]["adapt_dt"] = pa[key]),
-"dt"           => (nl, pa, key) -> (nl["time_stepping"]["dt_min"] = pa[key]),
-"calibrate_io" => (nl, pa, key) -> (nl["stats_io"]["calibrate_io"] = pa[key]),
-"stretch_grid" => (nl, pa, key) -> (nl["grid"]["stretch"]["flag"] = pa[key]),
-"skip_io"      => (nl, pa, key) -> (nl["stats_io"]["skip"] = pa[key]),
-"n_up"         => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
+"sgs"            => (nl, pa, key) -> (nl["thermodynamics"]["sgs"] = pa[key]),
+"quad_type"      => (nl, pa, key) -> (nl["thermodynamics"]["quadrature_type"] = pa[key]),
+"entr"           => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = pa[key]),
+"stoch_entr"     => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = pa[key]),
+"t_max"          => (nl, pa, key) -> (nl["time_stepping"]["t_max"] = pa[key]),
+"adapt_dt"       => (nl, pa, key) -> (nl["time_stepping"]["adapt_dt"] = pa[key]),
+"dt"             => (nl, pa, key) -> (nl["time_stepping"]["dt_min"] = pa[key]),
+"calibrate_io"   => (nl, pa, key) -> (nl["stats_io"]["calibrate_io"] = pa[key]),
+"stretch_grid"   => (nl, pa, key) -> (nl["grid"]["stretch"]["flag"] = pa[key]),
+"skip_io"        => (nl, pa, key) -> (nl["stats_io"]["skip"] = pa[key]),
+"n_up"           => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
+"moisture_model" => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
 )
 no_overwrites = (
     "case", # default_namelist already overwrites namelist["meta"]["casename"]

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -105,13 +105,14 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     massflux_h[kf_surf] = 0
 
     if edmf.moisture_model isa NonEquilibriumMoisture
+        massflux_en = aux_tc_f.massflux_en
         massflux_ql = aux_tc_f.massflux_ql
         massflux_qi = aux_tc_f.massflux_qi
         q_liq_en = aux_en.q_liq
         q_ice_en = aux_en.q_ice
         q_liq_gm = prog_gm.q_liq
         q_ice_gm = prog_gm.q_ice
-        massflux_en = ρ0_f * Ifae(a_en) * (w_en - w_gm)
+        @. massflux_en = ρ0_f * Ifae(a_en) * (w_en - w_gm)
         @. massflux_ql = massflux_en * (If(q_liq_en) - If(q_liq_gm))
         @. massflux_qi = massflux_en * (If(q_ice_en) - If(q_ice_gm))
         @inbounds for i in 1:N_up

--- a/src/types.jl
+++ b/src/types.jl
@@ -507,7 +507,7 @@ struct EDMFModel{N_up, FT, MM, PM, ENT, EBGC, EC, EDS, EPG}
         else
             error("Something went wrong. Invalid environmental buoyancy gradient closure type '$en_sgs_name'")
         end
-        if moisture_model_name == "nonequilibrium" && en_thermo_name == "quadrature"
+        if moisture_model_name == "nonequilibrium" && en_thermo == "quadrature"
             error("SGS quadratures are not yet implemented for non-equilibrium moisture. Please use the option: mean.")
         end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -4,7 +4,7 @@
 
 # Helpers for adding empty thermodynamic state fields:
 thermo_state(FT, ::EquilibriumMoisture) = TD.PhaseEquil{FT}(0, 0, 0, 0, 0)
-thermo_state(FT, ::NonEquilibriumMoisture) = TD.PhaseEquil{FT}(0, 0, TD.PhasePartition{FT}(0, 0, 0))
+thermo_state(FT, ::NonEquilibriumMoisture) = TD.PhaseNonEquil{FT}(0, 0, TD.PhasePartition(FT(0), FT(0), FT(0)))
 
 ##### Auxiliary fields
 
@@ -173,8 +173,13 @@ face_aux_vars_up(FT) = (;
     nh_pressure_drag = FT(0),
     massflux = FT(0),
 )
-face_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) =
-    (; massflux_ql = FT(0), massflux_qi = FT(0), diffusive_flux_ql = FT(0), diffusive_flux_qi = FT(0))
+face_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
+    massflux_en = FT(0), # TODO: is this the right place for this?
+    massflux_ql = FT(0),
+    massflux_qi = FT(0),
+    diffusive_flux_ql = FT(0),
+    diffusive_flux_qi = FT(0),
+)
 face_aux_vars_edmf_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
 face_aux_vars_edmf(FT, edmf) = (;
     turbconv = (;


### PR DESCRIPTION
This PR adds error checking to the CL arguments to prevent silently running unexpected configurations. This requires that we keep two lists up to date: `overwrite_namelist_map` (which we already had) and `no_overwrites` (now added). Before running, we now check that we've overwritten the correctly prescribed number of CL arguments.

This PR also attempts to fix the case that uses the nonequilibrium model, which we forgot to add to the `overwrite_namelist_map`.

~It seems like it's not yet working, but I made some changes that I'm not sure about.~ Looks like it's working!