### PR TITLE
Separate large scale advective from radiative tendencies

### DIFF
--- a/driver/Radiation.jl
+++ b/driver/Radiation.jl
@@ -1,10 +1,10 @@
-update_radiation(self::TC.RadiationBase, grid, state, param_set) = nothing
+update_radiation(self::TC.RadiationBase, grid, state, t::Real, param_set) = nothing
 initialize(self::TC.RadiationBase{TC.RadiationNone}, grid, state) = nothing
 
 """
 see eq. 3 in Stevens et. al. 2005 DYCOMS paper
 """
-function update_radiation(self::TC.RadiationBase{TC.RadiationDYCOMS_RF01}, grid, state, param_set)
+function update_radiation(self::TC.RadiationBase{TC.RadiationDYCOMS_RF01}, grid, state, t::Real, param_set)
     cp_d = CPP.cp_d(param_set)
     ρ0_f = TC.face_ref_state(state).ρ0
     ρ0_c = TC.center_ref_state(state).ρ0
@@ -82,4 +82,23 @@ function initialize(self::TC.RadiationBase{TC.RadiationLES}, grid, state, LESDat
         aux_gm.dTdt_rad[k] = dTdt[k]
     end
     return
+end
+
+
+function initialize(self::TC.RadiationBase{TC.RadiationTRMM_LBA}, grid, state)
+    aux_gm = TC.center_aux_grid_mean(state)
+    rad = APL.TRMM_LBA_radiation(eltype(grid))
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.dTdt_rad[k] = rad(0, grid.zc[k].z)
+    end
+    return nothing
+end
+
+function update_radiation(self::TC.RadiationBase{TC.RadiationTRMM_LBA}, grid, state, t::Real, param_set)
+    aux_gm = TC.center_aux_grid_mean(state)
+    rad = APL.TRMM_LBA_radiation(eltype(grid))
+    @inbounds for k in real_center_indices(grid)
+        aux_gm.dTdt_rad[k] = rad(t, grid.zc[k].z)
+    end
+    return nothing
 end

--- a/integration_tests/3dBomex.jl
+++ b/integration_tests/3dBomex.jl
@@ -230,7 +230,7 @@ function ∑tendencies_3d_bomex!(tendencies, prog, cache, t)
         radiation = case.Rad
         TC.affect_filter!(edmf, grid, state, param_set, surf, case.casename, t)
         Cases.update_forcing(case, grid, state, t, param_set)
-        Cases.update_radiation(case.Rad, grid, state, param_set)
+        Cases.update_radiation(case.Rad, grid, state, t, param_set)
         TC.update_aux!(edmf, grid, state, surf, param_set, t, Δt)
         # compute tendencies
         TC.compute_turbconv_tendencies!(edmf, grid, state, param_set, surf, Δt)

--- a/integration_tests/baroclinic_wave.jl
+++ b/integration_tests/baroclinic_wave.jl
@@ -236,7 +236,7 @@ function ∑tendencies_bw!(tendencies::FV, prog::FV, cache, t::Real) where {FV <
     # Some of these methods should probably live in `compute_tendencies`, when written, but we'll
     # treat them as auxiliary variables for now, until we disentangle the tendency computations.
     Cases.update_forcing(case, grid, state, t, param_set)
-    Cases.update_radiation(case.Rad, grid, state, param_set)
+    Cases.update_radiation(case.Rad, grid, state, t, param_set)
 
     TC.update_aux!(edmf, grid, state, surf, param_set, t, Δt)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -367,6 +367,7 @@ struct ForcingLES end
 struct RadiationNone end
 struct RadiationDYCOMS_RF01 end
 struct RadiationLES end
+struct RadiationTRMM_LBA end
 
 Base.@kwdef struct LESData
     "Start time index of LES"
@@ -391,8 +392,6 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct ForcingBase{T, R}
     "Boolean specifying whether Coriolis forcing is applied"
     apply_coriolis::Bool = false
-    "Boolean specifying whether subsidence forcing is applied"
-    apply_subsidence::Bool = false
     "Coriolis parameter"
     coriolis_param::Float64 = 0
     "Momentum relaxation timescale"


### PR DESCRIPTION
The motivation for this PR is organizing and making a clear distinction between the various large scale tendencies in the various cases. Currently, several cases mix the application of advective and radiative tendencies. This has no effect when `θ_liq_ice` is the prognostic variable and both tendencies are applied in the same way. When `e_tot` is the prognostic variable however these two tendencies need to be applied differently, i.e. acting on total enthalpy (with `c_pm`) or on total energy (with `c_vm`).
* I removed `dTdt` and `dqtdt` in `aux_gm` as it is ambiguous and resorted to use `dTdt_hadv` and `dqtdt_hadv` instead. 
* The flag `apply subsidence` is not needed anymore as in cases where subsidence should not be applied the subsidence velocity is simply zero anyways. 