### PR TITLE
Add internal clima parameters

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -5,5 +5,6 @@ CurrentModule = TurbulenceConvection
 ```
 
 ```@docs
-TurbulenceConvection.ClimaParams
+TurbulenceConvection.ExperimentalClimaParams
+TurbulenceConvection.InternalClimaParams
 ```

--- a/src/EDMF_Precipitation.jl
+++ b/src/EDMF_Precipitation.jl
@@ -90,16 +90,16 @@ function compute_precipitation_sink_tendencies(
         c_pm = TD.cp_m(param_set, ts)
         c_vm = TD.cv_m(param_set, ts)
         R_m = TD.gas_constant_air(param_set, ts)
-        R_v = CPP.R_v(param_set)
-        L_v0 = CPP.LH_v0(param_set)
-        L_s0 = CPP.LH_s0(param_set)
+        R_v = ICP.R_v(param_set)
+        L_v0 = ICP.LH_v0(param_set)
+        L_s0 = ICP.LH_s0(param_set)
         L_v = TD.latent_heat_vapor(param_set, ts)
         L_s = TD.latent_heat_sublim(param_set, ts)
         L_f = TD.latent_heat_fusion(param_set, ts)
 
-        α_evp = CPMP.microph_scaling(param_set)
-        α_dep_sub = CPMP.microph_scaling_dep_sub(param_set)
-        α_melt = CPMP.microph_scaling_melt(param_set)
+        α_evp = ICP.microph_scaling(param_set)
+        α_dep_sub = ICP.microph_scaling_dep_sub(param_set)
+        α_melt = ICP.microph_scaling_melt(param_set)
 
         # TODO - move limiters elsewhere
         # TODO - when using adaptive timestepping we are limiting the source terms

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -421,7 +421,7 @@ function compute_updraft_top(grid::Grid{FT}, state::State, i::Int)::FT where {FT
 end
 
 function compute_plume_scale_height(grid::Grid{FT}, state::State, param_set::APS, i::Int)::FT where {FT}
-    H_up_min::FT = CPEDMF.H_up_min(param_set)
+    H_up_min::FT = ICP.H_up_min(param_set)
     updraft_top = compute_updraft_top(grid, state, i)
     return max(updraft_top, H_up_min)
 end
@@ -437,7 +437,7 @@ function compute_up_stoch_tendencies!(edmf::EDMFModel, grid::Grid, state::State,
         tends_ε_nondim = tendencies_up[i].ε_nondim
         tends_δ_nondim = tendencies_up[i].δ_nondim
 
-        c_gen_stoch = ICP.c_gen_stoch(param_set)
+        c_gen_stoch = ECP.c_gen_stoch(param_set)
         mean_entr = aux_up[i].ε_nondim
         mean_detr = aux_up[i].δ_nondim
         ε_σ² = c_gen_stoch[1]
@@ -545,7 +545,7 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
 
         # prognostic entr/detr
         if edmf.entr_closure isa PrognosticNoisyRelaxationProcess
-            c_gen_stoch = ICP.c_gen_stoch(param_set)
+            c_gen_stoch = ECP.c_gen_stoch(param_set)
             mean_entr = aux_up[i].ε_nondim
             mean_detr = aux_up[i].δ_nondim
             ε_λ = c_gen_stoch[3]
@@ -852,7 +852,7 @@ function compute_covariance_dissipation(
     param_set::APS,
 ) where {covar_sym}
     FT = eltype(grid)
-    c_d::FT = CPEDMF.c_d(param_set)
+    c_d::FT = ICP.c_d(param_set)
     aux_tc = center_aux_turbconv(state)
     ρ0_c = center_ref_state(state).ρ0
     prog_en = center_prog_environment(state)
@@ -892,7 +892,7 @@ function compute_en_tendencies!(
     aux_covar = getproperty(aux_en_2m, covar_sym)
     aux_up = center_aux_updrafts(state)
     w_en_f = face_aux_environment(state).w
-    c_d = CPEDMF.c_d(param_set)
+    c_d = ICP.c_d(param_set)
     is_tke = covar_sym == :tke
     FT = eltype(grid)
 
@@ -971,8 +971,8 @@ function update_diagnostic_covariances!(
     aux_covar = getproperty(aux_en_2m, covar_sym)
     aux_up = center_aux_updrafts(state)
     w_en_f = face_aux_environment(state).w
-    c_d = CPEDMF.c_d(param_set)
-    covar_lim = ICP.covar_lim(param_set)
+    c_d = ICP.c_d(param_set)
+    covar_lim = ECP.covar_lim(param_set)
 
     ρ_ae_K = face_aux_turbconv(state).ρ_ae_K
     KH = center_aux_turbconv(state).KH

--- a/src/ExperimentalClimaParams.jl
+++ b/src/ExperimentalClimaParams.jl
@@ -1,5 +1,5 @@
 """
-    ClimaParams
+    ExperimentalClimaParams
 
 This is a module for staging experimental
 clima parameters-- that we are unsure will
@@ -9,7 +9,7 @@ to CLIMAParameters.jl.
 
 TODO: move non-experimental parameters to CLIMAParameters
 """
-module ClimaParams
+module ExperimentalClimaParams
 
 import CLIMAParameters
 const CP = CLIMAParameters

--- a/src/InternalClimaParams.jl
+++ b/src/InternalClimaParams.jl
@@ -1,0 +1,61 @@
+"""
+    InternalClimaParams
+
+This is a module is an interface to CLIMAParameters.jl.
+"""
+module InternalClimaParams
+
+import CLIMAParameters
+const CP = CLIMAParameters
+const APS = CP.AbstractEarthParameterSet
+
+α_a(ps::APS) = CP.Atmos.EDMF.α_a(ps)
+α_b(ps::APS) = CP.Atmos.EDMF.α_b(ps)
+α_d(ps::APS) = CP.Atmos.EDMF.α_d(ps)
+
+β(ps::APS) = CP.Atmos.EDMF.β(ps)
+
+c_d(ps::APS) = CP.Atmos.EDMF.c_d(ps)
+c_m(ps::APS) = CP.Atmos.EDMF.c_m(ps)
+cv_l(ps::APS) = CP.Planet.cv_l(ps)
+
+c_δ(ps::APS) = CP.Atmos.EDMF.c_δ(ps)
+c_ε(ps::APS) = CP.Atmos.EDMF.c_ε(ps)
+c_λ(ps::APS) = CP.Atmos.EDMF.c_λ(ps)
+c_γ(ps::APS) = CP.Atmos.EDMF.c_γ(ps)
+
+grav(ps::APS) = CP.Planet.grav(ps)
+
+H_up_min(ps::APS) = CP.Atmos.EDMF.H_up_min(ps)
+
+χ(ps::APS) = CP.Atmos.EDMF.χ(ps)
+
+κ_star²(ps::APS) = CP.Atmos.EDMF.κ_star²(ps)
+
+LH_v0(ps::APS) = CP.Planet.LH_v0(ps)
+LH_s0(ps::APS) = CP.Planet.LH_s0(ps)
+
+microph_scaling(ps::APS) = CP.Atmos.Microphysics.microph_scaling(ps)
+microph_scaling_dep_sub(ps::APS) = CP.Atmos.Microphysics.microph_scaling_dep_sub(ps)
+microph_scaling_melt(ps::APS) = CP.Atmos.Microphysics.microph_scaling_melt(ps)
+molmass_ratio(ps::APS) = CP.Planet.molmass_ratio(ps)
+
+μ_0(ps::APS) = CP.Atmos.EDMF.μ_0(ps)
+
+Pr_n(ps::APS) = CP.Atmos.EDMF.Pr_n(ps)
+
+Ri_c(ps::APS) = CP.Atmos.EDMF.Ri_c(ps)
+R_d(ps::APS) = CP.Planet.R_d(ps)
+R_v(ps::APS) = CP.Planet.R_v(ps)
+
+smin_ub(ps::APS) = CP.Atmos.EDMF.smin_ub(ps)
+smin_rm(ps::APS) = CP.Atmos.EDMF.smin_rm(ps)
+
+T_freeze(ps::APS) = CP.Planet.T_freeze(ps)
+
+von_karman_const(ps::APS) = CP.SubgridScale.von_karman_const(ps)
+
+w_min(ps::APS) = CP.Atmos.EDMF.w_min(ps)
+ω_pr(ps::APS) = CP.Atmos.EDMF.ω_pr(ps)
+
+end

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -10,7 +10,6 @@ import LambertW
 import Thermodynamics
 import Distributions
 import FastGaussQuadrature
-import CLIMAParameters
 import CloudMicrophysics
 import UnPack
 import StochasticDiffEq
@@ -33,13 +32,9 @@ const ice_type = CM1.IceType()
 const rain_type = CM1.RainType()
 const snow_type = CM1.SnowType()
 
+import CLIMAParameters
 const CP = CLIMAParameters
-const CPP = CP.Planet
-const CPSGS = CP.SubgridScale
 const APS = CP.AbstractEarthParameterSet
-
-const CPMP = CP.Atmos.Microphysics
-const CPEDMF = CP.Atmos.EDMF
 
 up_sum(vals::AbstractArray) = reshape(sum(vals; dims = 1), size(vals, 2))
 
@@ -63,9 +58,15 @@ function parse_namelist(namelist, keys...; default = nothing, valid_options = no
     return param
 end
 
-include("ClimaParams.jl")
-import .ClimaParams
-const ICP = ClimaParams # internal clima parameters
+include("ExperimentalClimaParams.jl")
+import .ExperimentalClimaParams
+const ECP = ExperimentalClimaParams
+
+include("InternalClimaParams.jl")
+import .InternalClimaParams
+const ICP = InternalClimaParams
+
+Base.broadcastable(param_set::APS) = Ref(param_set)
 
 #=
     debug_state(state, code_location::String)

--- a/src/closures/buoyancy_gradients.jl
+++ b/src/closures/buoyancy_gradients.jl
@@ -14,10 +14,10 @@ function buoyancy_gradients(
     bg_model::EnvBuoyGrad{FT, EBG},
 ) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
 
-    g = CPP.grav(param_set)
-    molmass_ratio = CPP.molmass_ratio(param_set)
-    R_d = CPP.R_d(param_set)
-    R_v = CPP.R_v(param_set)
+    g = ICP.grav(param_set)
+    molmass_ratio = ICP.molmass_ratio(param_set)
+    R_d = ICP.R_d(param_set)
+    R_v = ICP.R_v(param_set)
 
     phase_part = TD.PhasePartition(0.0, 0.0, 0.0) # assuming R_d = R_m
     Π = TD.exner_given_pressure(param_set, bg_model.p0, phase_part)

--- a/src/closures/entr_detr.jl
+++ b/src/closures/entr_detr.jl
@@ -1,7 +1,7 @@
 #### Entrainment-Detrainment kernels
 
 function compute_turbulent_entrainment(param_set, a_up::FT, w_up::FT, tke::FT, H_up::FT) where {FT}
-    c_γ = FT(CPEDMF.c_γ(param_set))
+    c_γ = FT(ICP.c_γ(param_set))
 
     ε_turb = if w_up * a_up > 0
         2 * c_γ * sqrt(max(tke, 0)) / (w_up * H_up)
@@ -15,7 +15,7 @@ end
 function compute_inverse_timescale(param_set, b_up::FT, b_en::FT, w_up::FT, w_en::FT, tke::FT) where {FT}
     Δb = b_up - b_en
     Δw = get_Δw(param_set, w_up, w_en)
-    c_λ = FT(CPEDMF.c_λ(param_set))
+    c_λ = FT(ICP.c_λ(param_set))
 
     l_1 = c_λ * abs(Δb / sqrt(tke + 1e-8))
     l_2 = abs(Δb / Δw)
@@ -25,7 +25,7 @@ end
 
 function get_Δw(param_set, w_up::FT, w_en::FT) where {FT}
     Δw = w_up - w_en
-    Δw += copysign(FT(CPEDMF.w_min(param_set)), Δw)
+    Δw += copysign(FT(ICP.w_min(param_set)), Δw)
     return Δw
 end
 
@@ -103,7 +103,7 @@ function εδ_dyn(param_set::APS, εδ_vars, entr_dim_scale, ε_nondim, δ_nondi
 
     area_limiter = max_area_limiter(param_set, εδ_vars.max_area, εδ_vars.a_up)
 
-    c_div = FT(ICP.entrainment_massflux_div_factor(param_set))
+    c_div = FT(ECP.entrainment_massflux_div_factor(param_set))
     MdMdz_ε, MdMdz_δ = get_MdMdz(εδ_vars.M, εδ_vars.dMdz) .* c_div
 
     # fractional dynamical entrainment / detrainment [1 / m]
@@ -160,7 +160,7 @@ function compute_entr_detr!(
     aux_tc = center_aux_turbconv(state)
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
-    g::FT = CPP.grav(param_set)
+    g::FT = ICP.grav(param_set)
     w_up_c = aux_tc.w_up_c
     w_en_c = aux_tc.w_en_c
     m_entr_detr = aux_tc.ϕ_temporary
@@ -265,7 +265,7 @@ function compute_entr_detr!(
     aux_tc = center_aux_turbconv(state)
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
-    g::FT = CPP.grav(param_set)
+    g::FT = ICP.grav(param_set)
     w_up_c = aux_tc.w_up_c
     w_en_c = aux_tc.w_en_c
     m_entr_detr = aux_tc.ϕ_temporary
@@ -279,7 +279,7 @@ function compute_entr_detr!(
     Ic = CCO.InterpolateF2C()
     ∇c = CCO.DivergenceF2C()
     LB = CCO.LeftBiasedC2F(; bottom = CCO.SetValue(FT(0)))
-    c_div = FT(ICP.entrainment_massflux_div_factor(param_set))
+    c_div = FT(ECP.entrainment_massflux_div_factor(param_set))
     @inbounds for i in 1:N_up
         # compute ∇m at cell centers
         a_up = aux_up[i].area

--- a/src/closures/mixing_length.jl
+++ b/src/closures/mixing_length.jl
@@ -1,13 +1,13 @@
 function mixing_length(param_set, ml_model::MinDisspLen{FT}) where {FT}
-    c_m::FT = CPEDMF.c_m(param_set)
-    c_d::FT = CPEDMF.c_d(param_set)
-    smin_ub::FT = CPEDMF.smin_ub(param_set)
-    smin_rm::FT = CPEDMF.smin_rm(param_set)
-    l_max::FT = ICP.l_max(param_set)
-    c_b::FT = ICP.static_stab_coeff(param_set)
-    g::FT = CPP.grav(param_set)
-    molmass_ratio::FT = CPP.molmass_ratio(param_set)
-    vkc::FT = CPSGS.von_karman_const(param_set)
+    c_m::FT = ICP.c_m(param_set)
+    c_d::FT = ICP.c_d(param_set)
+    smin_ub::FT = ICP.smin_ub(param_set)
+    smin_rm::FT = ICP.smin_rm(param_set)
+    l_max::FT = ECP.l_max(param_set)
+    c_b::FT = ECP.static_stab_coeff(param_set)
+    g::FT = ICP.grav(param_set)
+    molmass_ratio::FT = ICP.molmass_ratio(param_set)
+    vkc::FT = ICP.von_karman_const(param_set)
     ustar = ml_model.ustar
     z = ml_model.z
     tke_surf = ml_model.tke_surf

--- a/src/closures/nondimensional_exchange_functions.jl
+++ b/src/closures/nondimensional_exchange_functions.jl
@@ -1,8 +1,8 @@
 #### Non-dimensional Entrainment-Detrainment functions
 function max_area_limiter(param_set, max_area, a_up)
     FT = eltype(a_up)
-    γ_lim = FT(ICP.area_limiter_scale(param_set))
-    β_lim = FT(ICP.area_limiter_power(param_set))
+    γ_lim = FT(ECP.area_limiter_scale(param_set))
+    β_lim = FT(ECP.area_limiter_power(param_set))
     logistic_term = (2 - 1 / (1 + exp(-γ_lim * (max_area - a_up))))
     return (logistic_term)^β_lim - 1
 end
@@ -11,7 +11,7 @@ function non_dimensional_groups(param_set, εδ_model_vars)
     FT = eltype(εδ_model_vars.tke_en)
     Δw = get_Δw(param_set, εδ_model_vars.w_up, εδ_model_vars.w_en)
     Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
-    Π_norm = ICP.Π_norm(param_set)
+    Π_norm = ECP.Π_norm(param_set)
     Π₁ = (εδ_model_vars.zc_i * Δb) / (Δw^2 + εδ_model_vars.wstar^2) / Π_norm[1]
     Π₂ =
         (εδ_model_vars.tke_gm - εδ_model_vars.a_en * εδ_model_vars.tke_en) / (εδ_model_vars.tke_gm + eps(FT)) /
@@ -37,14 +37,14 @@ functions following Cohen et al. (JAMES, 2020), given:
 function non_dimensional_function(param_set, εδ_model_vars, ::MDEntr)
     FT = eltype(εδ_model_vars.q_cond_up)
     Δw = get_Δw(param_set, εδ_model_vars.w_up, εδ_model_vars.w_en)
-    c_ε = FT(CPEDMF.c_ε(param_set))
-    μ_0 = FT(CPEDMF.μ_0(param_set))
-    β = FT(CPEDMF.β(param_set))
-    χ = FT(CPEDMF.χ(param_set))
+    c_ε = FT(ICP.c_ε(param_set))
+    μ_0 = FT(ICP.μ_0(param_set))
+    β = FT(ICP.β(param_set))
+    χ = FT(ICP.χ(param_set))
     c_δ = if !TD.has_condensate(εδ_model_vars.q_cond_up + εδ_model_vars.q_cond_en)
         FT(0)
     else
-        FT(CPEDMF.c_δ(param_set))
+        FT(ICP.c_δ(param_set))
     end
 
     Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
@@ -80,9 +80,9 @@ function non_dimensional_function!(
     εδ_model::FNOEntr,
 ) where {FT <: Real}
 
-    width = ICP.w_fno(param_set)
-    modes = ICP.nm_fno(param_set)
-    c_fno = ICP.c_fno(param_set)
+    width = ECP.w_fno(param_set)
+    modes = ECP.nm_fno(param_set)
+    c_fno = ECP.c_fno(param_set)
     n_params = length(c_fno)
     n_input_vars = size(Π_groups)[2]
     M = size(Π_groups)[1]
@@ -239,8 +239,8 @@ function non_dimensional_function!(
     εδ_model::NNEntrNonlocal,
 ) where {FT <: Real}
     # neural network architecture
-    nn_arc = ICP.nn_arc(param_set)
-    c_nn_params = ICP.c_nn_params(param_set)
+    nn_arc = ECP.nn_arc(param_set)
+    c_nn_params = ECP.c_nn_params(param_set)
     nn_model = construct_fully_connected_nn(nn_arc, c_nn_params; biases_bool = εδ_model.biases_bool)
     output = nn_model(Π_groups')
     nondim_ε .= output[1, :]
@@ -258,8 +258,8 @@ Uses a fully connected neural network to predict the non-dimensional components 
  - `εδ_model_type`  :: NNEntr - Neural network entrainment closure
 """
 function non_dimensional_function(param_set, εδ_model_vars, εδ_model::NNEntr)
-    nn_arc = ICP.nn_arc(param_set)
-    c_nn_params = ICP.c_nn_params(param_set)
+    nn_arc = ECP.nn_arc(param_set)
+    c_nn_params = ECP.c_nn_params(param_set)
 
     nondim_groups = collect(non_dimensional_groups(param_set, εδ_model_vars))
     # neural network architecture
@@ -278,7 +278,7 @@ Uses a simple linear model to predict the non-dimensional components of dynamica
  - `εδ_model_type`  :: LinearEntr - linear entrainment closure
 """
 function non_dimensional_function(param_set, εδ_model_vars, ::LinearEntr)
-    c_linear = ICP.c_linear(param_set)
+    c_linear = ECP.c_linear(param_set)
 
     nondim_groups = collect(non_dimensional_groups(param_set, εδ_model_vars))
     # Linear closure
@@ -306,10 +306,10 @@ function non_dimensional_function(param_set, εδ_model_vars, ::RFEntr)
     d = size(nondim_groups)[1]
 
     # Learnable and fixed parameters
-    c_rf_fix = ICP.c_rf_fix(param_set)      # 2 x m x (1 + d), fix
+    c_rf_fix = ECP.c_rf_fix(param_set)      # 2 x m x (1 + d), fix
     c_rf_fix = reshape(c_rf_fix, 2, :, 1 + d)
     m = size(c_rf_fix)[2]
-    c_rf_opt = ICP.c_rf_opt(param_set)      # 2 x (m + 1 + d), learn
+    c_rf_opt = ECP.c_rf_opt(param_set)      # 2 x (m + 1 + d), learn
     c_rf_opt = reshape(c_rf_opt, 2, m + 1 + d)
 
     # Random Features
@@ -339,7 +339,7 @@ function non_dimensional_function(param_set, εδ_model_vars, εδ_model_type::L
     FT = eltype(εδ_model_vars.q_cond_up)
     # model parameters
     mean_model = εδ_model_type.mean_model
-    c_gen_stoch = ICP.c_gen_stoch(param_set)
+    c_gen_stoch = ECP.c_gen_stoch(param_set)
     ε_σ² = c_gen_stoch[1]
     δ_σ² = c_gen_stoch[2]
 
@@ -374,7 +374,7 @@ Arguments:
 function non_dimensional_function(param_set, εδ_model_vars, εδ_model_type::NoisyRelaxationProcess)
     # model parameters
     mean_model = εδ_model_type.mean_model
-    c_gen_stoch = ICP.c_gen_stoch(param_set)
+    c_gen_stoch = ECP.c_gen_stoch(param_set)
     ε_σ² = c_gen_stoch[1]
     δ_σ² = c_gen_stoch[2]
     ε_λ = c_gen_stoch[3]

--- a/src/closures/perturbation_pressure.jl
+++ b/src/closures/perturbation_pressure.jl
@@ -39,9 +39,9 @@ function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, param_s
 
     # Note: Independence of aspect ratio hardcoded in implementation.
     α₂_asp_ratio² = FT(0)
-    α_b::FT = CPEDMF.α_b(param_set)
-    α_a::FT = CPEDMF.α_a(param_set)
-    α_d::FT = CPEDMF.α_d(param_set)
+    α_b::FT = ICP.α_b(param_set)
+    α_a::FT = ICP.α_a(param_set)
+    α_d::FT = ICP.α_d(param_set)
 
     @inbounds for i in 1:N_up
         # pressure

--- a/src/microphysics_coupling.jl
+++ b/src/microphysics_coupling.jl
@@ -69,8 +69,8 @@ function precipitation_formation(
 
         Π_m = TD.exner(param_set, ts)
         c_pm = TD.cp_m(param_set, ts)
-        L_v0 = CPP.LH_v0(param_set)
-        L_s0 = CPP.LH_s0(param_set)
+        L_v0 = ICP.LH_v0(param_set)
+        L_s0 = ICP.LH_s0(param_set)
 
         if precip_model isa CutoffPrecipitation
             qsat = TD.q_vap_saturation(param_set, ts)
@@ -88,8 +88,8 @@ function precipitation_formation(
 
         if precip_model isa Clima1M
             T = TD.air_temperature(param_set, ts)
-            T_fr = CPP.T_freeze(param_set)
-            c_vl = CPP.cv_l(param_set)
+            T_fr = ICP.T_freeze(param_set)
+            c_vl = ICP.cv_l(param_set)
             c_vm = TD.cv_m(param_set, ts)
             Rm = TD.gas_constant_air(param_set, ts)
             Lf = TD.latent_heat_fusion(param_set, ts)

--- a/src/turbulence_functions.jl
+++ b/src/turbulence_functions.jl
@@ -2,13 +2,13 @@
 get_wstar(bflux, zi) = cbrt(max(bflux * zi, 0))
 
 function buoyancy_c(param_set::APS, ρ0::FT, ρ::FT) where {FT}
-    g::FT = CPP.grav(param_set)
+    g::FT = ICP.grav(param_set)
     return g * (ρ0 - ρ) / ρ0
 end
 
 # BL height
 function get_inversion(grid::Grid{FT}, state::State, param_set::APS, Ri_bulk_crit::FT) where {FT}
-    g::FT = CPP.grav(param_set)
+    g::FT = ICP.grav(param_set)
     kc_surf = kc_surface(grid)
     θ_virt = center_aux_grid_mean(state).θ_virt
     u = center_prog_grid_mean(state).u
@@ -50,7 +50,7 @@ end
 
 # MO scaling of near surface tke and scalar variance
 function get_surface_tke(param_set::APS, ustar::FT, zLL::FT, oblength::FT) where {FT}
-    κ_star²::FT = CPEDMF.κ_star²(param_set)
+    κ_star²::FT = ICP.κ_star²(param_set)
     if oblength < 0
         return ((κ_star² + cbrt(zLL / oblength * zLL / oblength)) * ustar * ustar)
     else
@@ -68,14 +68,14 @@ function get_surface_variance(flux1::FT, flux2::FT, ustar::FT, zLL::FT, oblength
 end
 
 function gradient_Richardson_number(param_set::APS, ∂b∂z::FT, Shear²::FT, ϵ::FT) where {FT}
-    Ri_c::FT = CPEDMF.Ri_c(param_set)
+    Ri_c::FT = ICP.Ri_c(param_set)
     return min(∂b∂z / max(Shear², ϵ), Ri_c)
 end
 
 # Turbulent Prandtl number given the obukhov length sign and the gradient Richardson number
 function turbulent_Prandtl_number(param_set::APS, obukhov_length::FT, ∇Ri::FT) where {FT}
-    ω_pr::FT = CPEDMF.ω_pr(param_set)
-    Pr_n::FT = CPEDMF.Pr_n(param_set)
+    ω_pr::FT = ICP.ω_pr(param_set)
+    Pr_n::FT = ICP.Pr_n(param_set)
     if obukhov_length > 0 && ∇Ri > 0 #stable
         # CSB (Dan Li, 2019, eq. 75), where ω_pr = ω_1 + 1 = 53.0/13.0
         prandtl_nvec = Pr_n * (2 * ∇Ri / (1 + ω_pr * ∇Ri - sqrt((1 + ω_pr * ∇Ri)^2 - 4 * ∇Ri)))

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -10,7 +10,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     p0_c = center_ref_state(state).p0
     ρ0_c = center_ref_state(state).ρ0
     α0_c = center_ref_state(state).α0
-    c_m = CPEDMF.c_m(param_set)
+    c_m = ICP.c_m(param_set)
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
     obukhov_length = surf.obukhov_length


### PR DESCRIPTION
As suggested by Issue https://github.com/CliMA/TurbulenceConvection.jl/issues/997 this adds `InternalClimaParams.jl` as a way to interface with the default parameters of CliMA. The already existing `ClimaParameters.jl` file (with experimental params that are not yet part of CliMAParameters) is now renamed to `ExperimentalClimaParams.jl`.

HTH with moving parameters around!