### PR TITLE
fix cutoff precipitation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,6 +129,10 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --moisture_model nonequilibrium --skip_tests true --suffix _nonequilibrium_moisture"
         artifact_paths: "Output.TRMM_LBA.01_nonequilibrium_moisture/stats/comparison/*"
 
+      - label: ":scissors: TRMM_LBA with 0-moment precipitation"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --precipitation_model cutoff --skip_tests true --suffix _0moment_precipitation"
+        artifact_paths: "Output.TRMM_LBA.01_0moment_precipitation/stats/comparison/*"
+
       - label: ":partly_sunny: Bomex with calibrate_io_true"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true --skip_post_proc true --suffix _calibrate_io_true"
         artifact_paths: "Output.Bomex.01_calibrate_io_true/stats/comparison/*"

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -320,13 +320,11 @@ function compute_diagnostics!(
     diag_tc_svpc.env_iwp[cent] = sum(ρ0_c .* aux_en.q_ice .* aux_en.area)
 
     #TODO - change to rain rate that depends on rain model choice
-
-    # TODO: Move rho_cloud_liq to CLIMAParameters
-    rho_cloud_liq = 1e3
-    if (precip_model isa TC.CutoffPrecipitation)
+    ρ_cloud_liq = CP.Planet.ρ_cloud_liq(param_set)
+    if (precip_model isa TC.Clima0M)
         f =
-            (aux_en.qt_tendency_precip_formation .+ aux_bulk.qt_tendency_precip_formation) .* ρ0_c ./
-            TC.rho_cloud_liq .* 3.6 .* 1e6
+            (aux_en.qt_tendency_precip_formation .+ aux_bulk.qt_tendency_precip_formation) .* ρ0_c ./ ρ_cloud_liq .*
+            3.6 .* 1e6
         diag_svpc.cutoff_precipitation_rate[cent] = sum(f)
     end
 

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -354,7 +354,7 @@ function TRMM_LBA(namelist_defaults)
     namelist["time_stepping"]["dt_max"] = 5.0
     namelist["time_stepping"]["dt_min"] = 1.0
 
-    namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+    namelist["microphysics"]["precipitation_model"] = "clima_1m" # "cutoff"
     namelist["microphysics"]["τ_acnv_rai"] = 2500.0
     namelist["microphysics"]["τ_acnv_sno"] = 100.0
     namelist["microphysics"]["q_liq_threshold"] = 0.5e-3

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -98,7 +98,7 @@ function Simulation1d(namelist)
     precip_model = if precip_name == "None"
         TC.NoPrecipitation()
     elseif precip_name == "cutoff"
-        TC.CutoffPrecipitation()
+        TC.Clima0M()
     elseif precip_name == "clima_1m"
         TC.Clima1M()
     else
@@ -331,7 +331,7 @@ function solve_args(sim::Simulation1d)
     callback_adapt_dt = ODE.DiscreteCallback(condition_every_iter, adaptive_dt!; save_positions = (false, false))
     callback_adapt_dt = sim.adapt_dt ? (callback_adapt_dt,) : ()
     if sim.edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess && sim.adapt_dt
-        @warn("The prognostic noisy relaxation process currently uses a Euler-Maruyama time stepping method, 
+        @warn("The prognostic noisy relaxation process currently uses a Euler-Maruyama time stepping method,
               which does not support adaptive time stepping. Adaptive time stepping disabled.")
         callback_adapt_dt = ()
     end

--- a/integration_tests/3dBomex.jl
+++ b/integration_tests/3dBomex.jl
@@ -198,7 +198,7 @@ function get_edmf_cache(grid, hv_center_space, hv_face_space, namelist)
     precip_model = if precip_name == "None"
         TC.NoPrecipitation()
     elseif precip_name == "cutoff"
-        TC.CutoffPrecipitation()
+        TC.Clima0M()
     elseif precip_name == "clima_1m"
         TC.Clima1M()
     else

--- a/integration_tests/baroclinic_wave.jl
+++ b/integration_tests/baroclinic_wave.jl
@@ -199,7 +199,7 @@ function get_edmf_cache(grid, namelist)
     precip_model = if precip_name == "None"
         TC.NoPrecipitation()
     elseif precip_name == "cutoff"
-        TC.CutoffPrecipitation()
+        TC.Clima0M()
     elseif precip_name == "clima_1m"
         TC.Clima1M()
     else

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -41,6 +41,8 @@ function parse_commandline()
         arg_type = Int
         "--moisture_model" # Moisture model (equilibrium or non-equilibrium)
         arg_type = String
+        "--precipitation_model" # Precipitation model (None, cutoff or clima_1m)
+        arg_type = String
         "--thermo_covariance_model" # covariance model (prognostic or diagnostic)
         arg_type = String
         "--trunc_field_type_print"

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -38,6 +38,7 @@ overwrite_namelist_map = Dict(
 "skip_io"                 => (nl, pa, key) -> (nl["stats_io"]["skip"] = pa[key]),
 "n_up"                    => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
 "moisture_model"          => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
+"precipitation_model"     => (nl, pa, key) -> (nl["microphysics"]["precipitation_model"] = pa[key]),
 "thermo_covariance_model" => (nl, pa, key) -> (nl["thermodynamics"]["thermo_covariance_model"] = pa[key]),
 )
 no_overwrites = (

--- a/src/microphysics_coupling.jl
+++ b/src/microphysics_coupling.jl
@@ -72,7 +72,7 @@ function precipitation_formation(
         L_v0 = ICP.LH_v0(param_set)
         L_s0 = ICP.LH_s0(param_set)
 
-        if precip_model isa CutoffPrecipitation
+        if precip_model isa Clima0M
             qsat = TD.q_vap_saturation(param_set, ts)
             λ = TD.liquid_fraction(param_set, ts)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -185,7 +185,7 @@ struct DiagnosticThermoCovariances <: AbstractCovarianceModel end
 
 abstract type AbstractPrecipitationModel end
 struct NoPrecipitation <: AbstractPrecipitationModel end
-struct CutoffPrecipitation <: AbstractPrecipitationModel end
+struct Clima0M <: AbstractPrecipitationModel end
 struct Clima1M <: AbstractPrecipitationModel end
 
 abstract type AbstractQuadratureType end


### PR DESCRIPTION
In response to issue https://github.com/CliMA/TurbulenceConvection.jl/issues/1009

This PR:
- fixes the `rho_cloud_liquid` problem by using the `CliMAParameters.jl` defined liquid water density
- adds TRMM + cutoff microphysics to Vanilla + Deviations tests in the buildkite CI
- renames `CutoffPrecipitation` precipitation model to `Clima0M` precipitation model. This is done to be more consistent with the notation used in the `CloudMicrophysics.jl` package.