### PR TITLE
Only allocate for precip when using Clima1M

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -313,15 +313,17 @@ function compute_diagnostics!(
 
     diag_svpc.lwp_mean[cent] = sum(ρ0_c .* aux_gm.q_liq)
     diag_svpc.iwp_mean[cent] = sum(ρ0_c .* aux_gm.q_ice)
-    diag_svpc.rwp_mean[cent] = sum(ρ0_c .* prog_pr.q_rai)
-    diag_svpc.swp_mean[cent] = sum(ρ0_c .* prog_pr.q_sno)
+    if precip_model isa TC.Clima1M
+        diag_svpc.rwp_mean[cent] = sum(ρ0_c .* prog_pr.q_rai)
+        diag_svpc.swp_mean[cent] = sum(ρ0_c .* prog_pr.q_sno)
+    end
 
     diag_tc_svpc.env_lwp[cent] = sum(ρ0_c .* aux_en.q_liq .* aux_en.area)
     diag_tc_svpc.env_iwp[cent] = sum(ρ0_c .* aux_en.q_ice .* aux_en.area)
 
     #TODO - change to rain rate that depends on rain model choice
     ρ_cloud_liq = CP.Planet.ρ_cloud_liq(param_set)
-    if (precip_model isa TC.Clima0M)
+    if precip_model isa TC.Clima0M
         f =
             (aux_en.qt_tendency_precip_formation .+ aux_bulk.qt_tendency_precip_formation) .* ρ0_c ./ ρ_cloud_liq .*
             3.6 .* 1e6
@@ -353,14 +355,20 @@ function compute_diagnostics!(
     write_ts(Stats, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
     write_ts(Stats, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
 
-    write_ts(Stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
     write_ts(Stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
     write_ts(Stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
     write_ts(Stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
     write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
     write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
-    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
-    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
+
+    if precip_model isa TC.Clima0M
+        write_ts(Stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
+    end
+
+    if precip_model isa TC.Clima1M
+        write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
+        write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
+    end
 
     return
 end

--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -467,15 +467,23 @@ function compute_gm_tendencies!(
         tendencies_gm.ρq_tot[k] +=
             ρ0_c[k] * (
                 aux_bulk.qt_tendency_precip_formation[k] +
-                aux_en.qt_tendency_precip_formation[k] +
-                aux_tc.qt_tendency_precip_sinks[k]
+                aux_en.qt_tendency_precip_formation[k]
             )
         tendencies_gm.ρθ_liq_ice[k] +=
             ρ0_c[k] * (
                 aux_bulk.θ_liq_ice_tendency_precip_formation[k] +
-                aux_en.θ_liq_ice_tendency_precip_formation[k] +
-                aux_tc.θ_liq_ice_tendency_precip_sinks[k]
+                aux_en.θ_liq_ice_tendency_precip_formation[k]
             )
+        if edmf.precip_model isa TC.Clima1M
+            tendencies_gm.ρq_tot[k] +=
+                ρ0_c[k] * (
+                    aux_tc.qt_tendency_precip_sinks[k]
+                )
+            tendencies_gm.ρθ_liq_ice[k] +=
+                ρ0_c[k] * (
+                    aux_tc.θ_liq_ice_tendency_precip_sinks[k]
+                )
+        end
         if edmf.moisture_model isa TC.NonEquilibriumMoisture
             tendencies_gm.q_liq[k] += aux_bulk.ql_tendency_precip_formation[k] + aux_en.ql_tendency_precip_formation[k]
             tendencies_gm.q_ice[k] += aux_bulk.qi_tendency_precip_formation[k] + aux_en.qi_tendency_precip_formation[k]

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -156,7 +156,7 @@ function Simulation1d(namelist)
 
     calibrate_io = namelist["stats_io"]["calibrate_io"]
     aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate(precip_model) : TC.io_dictionary_aux(precip_model)
-    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics(precip_model)
+    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics()
 
     io_nt = (; aux = aux_dict, diagnostics = diagnostics_dict)
 

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -155,8 +155,8 @@ function Simulation1d(namelist)
     case = Cases.CasesBase(case_type; inversion_type, surf_params, Fo, Rad, spk...)
 
     calibrate_io = namelist["stats_io"]["calibrate_io"]
-    aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate() : TC.io_dictionary_aux()
-    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics()
+    aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate(precip_model) : TC.io_dictionary_aux(precip_model)
+    diagnostics_dict = calibrate_io ? Dict() : io_dictionary_diagnostics(precip_model)
 
     io_nt = (; aux = aux_dict, diagnostics = diagnostics_dict)
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -14,7 +14,7 @@ These functions return a dictionary whose
 
 #! format: off
 # TODO: use a better name, this exports fields from the prognostic state, and the aux state.
-function io_dictionary_aux()
+function io_dictionary_aux(precip_model)
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
         "updraft_area" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).area),
@@ -95,9 +95,6 @@ function io_dictionary_aux()
         "diffusive_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).diffusive_flux_s),
         "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
 
-        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
-        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
-
         "mixing_length" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).mixing_length),
 
         "updraft_cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).cloud_fraction),
@@ -119,11 +116,16 @@ function io_dictionary_aux()
 
         "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).dTdt_rad),
         "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).f_rad),
+
+        if precip_model isa Clima1M
+            "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+            "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
+        end
     )
     return io_dict
 end
 
-function io_dictionary_aux_calibrate()
+function io_dictionary_aux_calibrate(precip_model)
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
         "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).u),
@@ -131,17 +133,20 @@ function io_dictionary_aux_calibrate()
         "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
         "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_tot),
         "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),
+        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
         "total_flux_h" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_h .+ face_aux_turbconv(state).massflux_h),
         "total_flux_qt" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_turbconv(state).diffusive_flux_qt .+ face_aux_turbconv(state).massflux_qt),
         "total_flux_s" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).massflux_s .+ face_aux_grid_mean(state).diffusive_flux_s),
         "thetal_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).θ_liq_ice),
         "tke_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).tke),
-        "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
-        "qi_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_ice),
-        "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
         "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
         "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
         "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
+
+        if precip_model isa Clima1M
+            "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
+            "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
+        end
     )
     return io_dict
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -116,12 +116,11 @@ function io_dictionary_aux(precip_model)
 
         "rad_dTdt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).dTdt_rad),
         "rad_flux" => (; dims = ("zf", "t"), group = "profiles", field = state -> face_aux_grid_mean(state).f_rad),
-
-        if precip_model isa Clima1M
-            "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
-            "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
-        end
     )
+    if precip_model isa Clima1M
+        io_dict["qr_mean"] = (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai)
+        io_dict["qs_mean"] = (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno)
+    end
     return io_dict
 end
 
@@ -142,12 +141,11 @@ function io_dictionary_aux_calibrate(precip_model)
         "cloud_fraction" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).cloud_fraction), # was this "cloud_fraction_mean"?
         "RH_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).RH),
         "temperature_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).T),
-
-        if precip_model isa Clima1M
-            "qr_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai),
-            "qs_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno),
-        end
     )
+    if precip_model isa Clima1M
+        io_dict["qr_mean"] = (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_rai)
+        io_dict["qs_mean"] = (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_precipitation(state).q_sno)
+    end
     return io_dict
 end
 #! format: on

--- a/src/microphysics_coupling.jl
+++ b/src/microphysics_coupling.jl
@@ -43,17 +43,10 @@ end
 Computes the tendencies to qt and θ_liq_ice due to precipitation formation
 (autoconversion + accretion)
 """
-function precipitation_formation(
-    param_set::APS,
-    precip_model::NoPrecipitation,
+function precipitation_formation( # NoPrecipitation
     area::FT,
-    ρ0::FT,
-    Δt::Real,
-    ts,
 ) where {FT}
 
-    # TODO - when using adaptive timestepping we are limiting the source terms
-    #        with the previous timestep Δt
     qt_tendency = FT(0)
     ql_tendency = FT(0)
     qi_tendency = FT(0)
@@ -63,9 +56,8 @@ function precipitation_formation(
 
     return PrecipFormation{FT}(θ_liq_ice_tendency, qt_tendency, ql_tendency, qi_tendency, qr_tendency, qs_tendency)
 end
-function precipitation_formation(
+function precipitation_formation( #Clima0M
     param_set::APS,
-    precip_model::Clima0M,
     area::FT,
     ρ0::FT,
     Δt::Real,
@@ -105,9 +97,8 @@ function precipitation_formation(
     end
     return PrecipFormation{FT}(θ_liq_ice_tendency, qt_tendency, ql_tendency, qi_tendency, qr_tendency, qs_tendency)
 end
-function precipitation_formation(
+function precipitation_formation( # Clima1M
     param_set::APS,
-    precip_model::Clima1M,
     qr::FT,
     qs::FT,
     area::FT,

--- a/src/microphysics_coupling.jl
+++ b/src/microphysics_coupling.jl
@@ -45,7 +45,69 @@ Computes the tendencies to qt and θ_liq_ice due to precipitation formation
 """
 function precipitation_formation(
     param_set::APS,
-    precip_model::AbstractPrecipitationModel,
+    precip_model::NoPrecipitation,
+    area::FT,
+    ρ0::FT,
+    Δt::Real,
+    ts,
+) where {FT}
+
+    # TODO - when using adaptive timestepping we are limiting the source terms
+    #        with the previous timestep Δt
+    qt_tendency = FT(0)
+    ql_tendency = FT(0)
+    qi_tendency = FT(0)
+    qr_tendency = FT(0)
+    qs_tendency = FT(0)
+    θ_liq_ice_tendency = FT(0)
+
+    return PrecipFormation{FT}(θ_liq_ice_tendency, qt_tendency, ql_tendency, qi_tendency, qr_tendency, qs_tendency)
+end
+function precipitation_formation(
+    param_set::APS,
+    precip_model::Clima0M,
+    area::FT,
+    ρ0::FT,
+    Δt::Real,
+    ts,
+) where {FT}
+
+    # TODO - when using adaptive timestepping we are limiting the source terms
+    #        with the previous timestep Δt
+    qt_tendency = FT(0)
+    ql_tendency = FT(0)
+    qi_tendency = FT(0)
+    qr_tendency = FT(0)
+    qs_tendency = FT(0)
+    θ_liq_ice_tendency = FT(0)
+
+    if area > 0
+
+        q = TD.PhasePartition(param_set, ts)
+
+        Π_m = TD.exner(param_set, ts)
+        c_pm = TD.cp_m(param_set, ts)
+        L_v0 = ICP.LH_v0(param_set)
+        L_s0 = ICP.LH_s0(param_set)
+
+        qsat = TD.q_vap_saturation(param_set, ts)
+        λ = TD.liquid_fraction(param_set, ts)
+
+        S_qt = -min((q.liq + q.ice) / Δt, -CM0.remove_precipitation(param_set, q, qsat))
+
+        qr_tendency -= S_qt * λ
+        qs_tendency -= S_qt * (1 - λ)
+        qt_tendency += S_qt
+        ql_tendency += S_qt * λ
+        qi_tendency += S_qt * (1 - λ)
+        θ_liq_ice_tendency -= S_qt / Π_m / c_pm * (L_v0 * λ + L_s0 * (1 - λ))
+
+    end
+    return PrecipFormation{FT}(θ_liq_ice_tendency, qt_tendency, ql_tendency, qi_tendency, qr_tendency, qs_tendency)
+end
+function precipitation_formation(
+    param_set::APS,
+    precip_model::Clima1M,
     qr::FT,
     qs::FT,
     area::FT,
@@ -72,91 +134,75 @@ function precipitation_formation(
         L_v0 = ICP.LH_v0(param_set)
         L_s0 = ICP.LH_s0(param_set)
 
-        if precip_model isa Clima0M
-            qsat = TD.q_vap_saturation(param_set, ts)
-            λ = TD.liquid_fraction(param_set, ts)
+        T = TD.air_temperature(param_set, ts)
+        T_fr = ICP.T_freeze(param_set)
+        c_vl = ICP.cv_l(param_set)
+        c_vm = TD.cv_m(param_set, ts)
+        Rm = TD.gas_constant_air(param_set, ts)
+        Lf = TD.latent_heat_fusion(param_set, ts)
 
-            S_qt = -min((q.liq + q.ice) / Δt, -CM0.remove_precipitation(param_set, q, qsat))
+        # Autoconversion of cloud ice to snow is done with a simplified rate.
+        # The saturation adjustment scheme prevents using the
+        # 1-moment snow autoconversion rate that assumes
+        # that the supersaturation is present in the domain.
+        S_qt_rain = -min(q.liq / Δt, CM1.conv_q_liq_to_q_rai(param_set, q.liq))
+        S_qt_snow = -min(q.ice / Δt, CM1.conv_q_ice_to_q_sno_no_supersat(param_set, q.ice))
+        qr_tendency -= S_qt_rain
+        qs_tendency -= S_qt_snow
+        qt_tendency += S_qt_rain + S_qt_snow
+        ql_tendency += S_qt_rain
+        qi_tendency += S_qt_snow
+        θ_liq_ice_tendency -= 1 / Π_m / c_pm * (L_v0 * S_qt_rain + L_s0 * S_qt_snow)
 
-            qr_tendency -= S_qt * λ
-            qs_tendency -= S_qt * (1 - λ)
+        # accretion cloud water + rain
+        S_qr = min(q.liq / Δt, CM1.accretion(param_set, liq_type, rain_type, q.liq, qr, ρ0))
+        qr_tendency += S_qr
+        qt_tendency -= S_qr
+        ql_tendency -= S_qr
+        θ_liq_ice_tendency += S_qr / Π_m / c_pm * L_v0
+
+        # accretion cloud ice + snow
+        S_qs = min(q.ice / Δt, CM1.accretion(param_set, ice_type, snow_type, q.ice, qs, ρ0))
+        qs_tendency += S_qs
+        qt_tendency -= S_qs
+        qi_tendency -= S_qs
+        θ_liq_ice_tendency += S_qs / Π_m / c_pm * L_s0
+
+        # sink of cloud water via accretion cloud water + snow
+        S_qt = -min(q.liq / Δt, CM1.accretion(param_set, liq_type, snow_type, q.liq, qs, ρ0))
+        if T < T_fr # cloud droplets freeze to become snow)
+            qs_tendency -= S_qt
             qt_tendency += S_qt
-            ql_tendency += S_qt * λ
-            qi_tendency += S_qt * (1 - λ)
-            θ_liq_ice_tendency -= S_qt / Π_m / c_pm * (L_v0 * λ + L_s0 * (1 - λ))
+            ql_tendency += S_qt
+            θ_liq_ice_tendency -= S_qt / Π_m / c_pm * Lf * (1 + Rm / c_vm)
+        else # snow melts, both cloud water and snow become rain
+            α::FT = c_vl / Lf * (T - T_fr)
+            qt_tendency += S_qt
+            ql_tendency += S_qt
+            qs_tendency += S_qt * α
+            qr_tendency -= S_qt * (1 + α)
+            θ_liq_ice_tendency += S_qt / Π_m / c_pm * (Lf * (1 + Rm / c_vm) * α - L_v0)
         end
 
-        if precip_model isa Clima1M
-            T = TD.air_temperature(param_set, ts)
-            T_fr = ICP.T_freeze(param_set)
-            c_vl = ICP.cv_l(param_set)
-            c_vm = TD.cv_m(param_set, ts)
-            Rm = TD.gas_constant_air(param_set, ts)
-            Lf = TD.latent_heat_fusion(param_set, ts)
+        # sink of cloud ice via accretion cloud ice - rain
+        S_qt = -min(q.ice / Δt, CM1.accretion(param_set, ice_type, rain_type, q.ice, qr, ρ0))
+        # sink of rain via accretion cloud ice - rain
+        S_qr = -min(qr / Δt, CM1.accretion_rain_sink(param_set, q.ice, qr, ρ0))
+        qt_tendency += S_qt
+        qi_tendency += S_qt
+        qr_tendency += S_qr
+        qs_tendency += -(S_qt + S_qr)
+        θ_liq_ice_tendency -= 1 / Π_m / c_pm * (S_qr * Lf * (1 + Rm / c_vm) + S_qt * L_s0)
 
-            # Autoconversion of cloud ice to snow is done with a simplified rate.
-            # The saturation adjustment scheme prevents using the
-            # 1-moment snow autoconversion rate that assumes
-            # that the supersaturation is present in the domain.
-            S_qt_rain = -min(q.liq / Δt, CM1.conv_q_liq_to_q_rai(param_set, q.liq))
-            S_qt_snow = -min(q.ice / Δt, CM1.conv_q_ice_to_q_sno_no_supersat(param_set, q.ice))
-            qr_tendency -= S_qt_rain
-            qs_tendency -= S_qt_snow
-            qt_tendency += S_qt_rain + S_qt_snow
-            ql_tendency += S_qt_rain
-            qi_tendency += S_qt_snow
-            θ_liq_ice_tendency -= 1 / Π_m / c_pm * (L_v0 * S_qt_rain + L_s0 * S_qt_snow)
-
-            # accretion cloud water + rain
-            S_qr = min(q.liq / Δt, CM1.accretion(param_set, liq_type, rain_type, q.liq, qr, ρ0))
-            qr_tendency += S_qr
-            qt_tendency -= S_qr
-            ql_tendency -= S_qr
-            θ_liq_ice_tendency += S_qr / Π_m / c_pm * L_v0
-
-            # accretion cloud ice + snow
-            S_qs = min(q.ice / Δt, CM1.accretion(param_set, ice_type, snow_type, q.ice, qs, ρ0))
-            qs_tendency += S_qs
-            qt_tendency -= S_qs
-            qi_tendency -= S_qs
-            θ_liq_ice_tendency += S_qs / Π_m / c_pm * L_s0
-
-            # sink of cloud water via accretion cloud water + snow
-            S_qt = -min(q.liq / Δt, CM1.accretion(param_set, liq_type, snow_type, q.liq, qs, ρ0))
-            if T < T_fr # cloud droplets freeze to become snow)
-                qs_tendency -= S_qt
-                qt_tendency += S_qt
-                ql_tendency += S_qt
-                θ_liq_ice_tendency -= S_qt / Π_m / c_pm * Lf * (1 + Rm / c_vm)
-            else # snow melts, both cloud water and snow become rain
-                α::FT = c_vl / Lf * (T - T_fr)
-                qt_tendency += S_qt
-                ql_tendency += S_qt
-                qs_tendency += S_qt * α
-                qr_tendency -= S_qt * (1 + α)
-                θ_liq_ice_tendency += S_qt / Π_m / c_pm * (Lf * (1 + Rm / c_vm) * α - L_v0)
-            end
-
-            # sink of cloud ice via accretion cloud ice - rain
-            S_qt = -min(q.ice / Δt, CM1.accretion(param_set, ice_type, rain_type, q.ice, qr, ρ0))
-            # sink of rain via accretion cloud ice - rain
-            S_qr = -min(qr / Δt, CM1.accretion_rain_sink(param_set, q.ice, qr, ρ0))
-            qt_tendency += S_qt
-            qi_tendency += S_qt
-            qr_tendency += S_qr
-            qs_tendency += -(S_qt + S_qr)
-            θ_liq_ice_tendency -= 1 / Π_m / c_pm * (S_qr * Lf * (1 + Rm / c_vm) + S_qt * L_s0)
-
-            # accretion rain - snow
-            if T < T_fr
-                S_qs = min(qr / Δt, CM1.accretion_snow_rain(param_set, snow_type, rain_type, qs, qr, ρ0))
-            else
-                S_qs = -min(qs / Δt, CM1.accretion_snow_rain(param_set, rain_type, snow_type, qr, qs, ρ0))
-            end
-            qs_tendency += S_qs
-            qr_tendency -= S_qs
-            θ_liq_ice_tendency += S_qs * Lf / Π_m / c_vm
+        # accretion rain - snow
+        if T < T_fr
+            S_qs = min(qr / Δt, CM1.accretion_snow_rain(param_set, snow_type, rain_type, qs, qr, ρ0))
+        else
+            S_qs = -min(qs / Δt, CM1.accretion_snow_rain(param_set, rain_type, snow_type, qr, qs, ρ0))
         end
+        qs_tendency += S_qs
+        qr_tendency -= S_qs
+        θ_liq_ice_tendency += S_qs * Lf / Π_m / c_vm
     end
     return PrecipFormation{FT}(θ_liq_ice_tendency, qt_tendency, ql_tendency, qi_tendency, qr_tendency, qs_tendency)
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -71,6 +71,19 @@ cent_aux_vars_edmf_moisture(FT, ::NonEquilibriumMoisture) = (;
     diffusive_tendency_qi = FT(0),
 )
 cent_aux_vars_edmf_moisture(FT, ::EquilibriumMoisture) = NamedTuple()
+
+cent_aux_vars_edmf_precipitation(FT, ::Union{NoPrecipitation, Clima0M}) = NamedTuple()
+cent_aux_vars_edmf_precipitation(FT, ::Clima1M) = (;
+    θ_liq_ice_tendency_precip_sinks = FT(0),
+    qt_tendency_precip_sinks = FT(0),
+    qr_tendency_evap = FT(0),
+    qs_tendency_melt = FT(0),
+    qs_tendency_dep_sub = FT(0),
+    qr_tendency_advection = FT(0),
+    qs_tendency_advection = FT(0),
+    term_vel_rain = FT(0),
+    term_vel_snow = FT(0),
+)
 cent_aux_vars_edmf(FT, edmf) = (;
     turbconv = (;
         ϕ_temporary = FT(0),
@@ -118,21 +131,12 @@ cent_aux_vars_edmf(FT, edmf) = (;
             QTvar_rain_dt = FT(0),
             HQTcov_rain_dt = FT(0),
         ),
-        θ_liq_ice_tendency_precip_sinks = FT(0),
-        qt_tendency_precip_sinks = FT(0),
-        qr_tendency_evap = FT(0),
-        qs_tendency_melt = FT(0),
-        qs_tendency_dep_sub = FT(0),
-        qr_tendency_advection = FT(0),
-        qs_tendency_advection = FT(0),
         en_2m = (;
             tke = cent_aux_vars_en_2m(FT),
             Hvar = cent_aux_vars_en_2m(FT),
             QTvar = cent_aux_vars_en_2m(FT),
             HQTcov = cent_aux_vars_en_2m(FT),
         ),
-        term_vel_rain = FT(0),
-        term_vel_snow = FT(0),
         KM = FT(0),
         KH = FT(0),
         mixing_length = FT(0),
@@ -141,6 +145,7 @@ cent_aux_vars_edmf(FT, edmf) = (;
         diffusive_tendency_h = FT(0),
         diffusive_tendency_qt = FT(0),
         cent_aux_vars_edmf_moisture(FT, edmf.moisture_model)...,
+        cent_aux_vars_edmf_precipitation(FT, edmf.precip_model)...,
         prandtl_nvec = FT(0),
         # Added by Ignacio : Length scheme in use (mls), and smooth min effect (ml_ratio)
         # Variable Prandtl number initialized as neutral value.
@@ -258,11 +263,13 @@ cent_prognostic_vars_en(::Type{FT}, edmf) where {FT} =
 cent_prognostic_vars_en_thermo(::Type{FT}, ::DiagnosticThermoCovariances) where {FT} = NamedTuple()
 cent_prognostic_vars_en_thermo(::Type{FT}, ::PrognosticThermoCovariances) where {FT} =
     (; ρaHvar = FT(0), ρaQTvar = FT(0), ρaHQTcov = FT(0))
+cent_prognostic_vars_precip(::Type{FT}, ::Union{NoPrecipitation, Clima0M}) where{FT} = NamedTuple()
+cent_prognostic_vars_precip(::Type{FT}, ::Clima1M) where{FT} = (; q_rai = FT(0), q_sno = FT(0))
 cent_prognostic_vars_edmf(::Type{FT}, edmf) where {FT} = (;
     turbconv = (;
         en = cent_prognostic_vars_en(FT, edmf),
         up = ntuple(i -> cent_prognostic_vars_up(FT, edmf), Val(n_updrafts(edmf))),
-        pr = (; q_rai = FT(0), q_sno = FT(0)),
+        pr = cent_prognostic_vars_precip(FT, edmf.precip_model),
     )
 )
 # cent_prognostic_vars_edmf(FT, edmf) = (;) # could also use this for empty model


### PR DESCRIPTION
I wanted to remove the prognostic and auxiliary variables related to precipitation when using `NoPrecipitation` or `Clima0M` schemes. However this turns out to be more involved than anticipated and I don't have a good idea how to do it without creating a lot of code. 

This branch shows all the places that assume those variables exist. 