### PR TITLE
Add prescribed and diagnostic precip fraction

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,6 +133,14 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --precipitation_model cutoff --skip_tests true --suffix _0moment_precipitation"
         artifact_paths: "Output.TRMM_LBA.01_0moment_precipitation/stats/comparison/*"
 
+      - label: ":scissors: TRMM_LBA with prescribed precipitation fraction"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --precipitation_model clima_1m --precip_fraction_model prescribed --prescribed_precip_frac_value 0.42 --skip_tests true --suffix _prescribed_precipitation_fraction"
+        artifact_paths: "Output.TRMM_LBA.01_prescribed_precipitation_fraction/stats/comparison/*"
+
+      - label: ":scissors: TRMM_LBA with diagnostic precipitation fraction"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case TRMM_LBA --sgs mean --adapt_dt false --dt 1.0 --precipitation_model clima_1m --precip_fraction_model cloud_cover --precip_fraction_limiter 0.42 --skip_tests true --suffix _diagnostic_precipitation_fraction"
+        artifact_paths: "Output.TRMM_LBA.01_diagnostic_precipitation_fraction/stats/comparison/*"
+
       - label: ":partly_sunny: Bomex with calibrate_io_true"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --calibrate_io true --skip_post_proc true --suffix _calibrate_io_true"
         artifact_paths: "Output.Bomex.01_calibrate_io_true/stats/comparison/*"

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -324,6 +324,9 @@ function Rico(namelist_defaults)
     namelist["time_stepping"]["dt_min"] = 1.5
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
     namelist["microphysics"]["τ_acnv_rai"] = 2500.0
     namelist["microphysics"]["τ_acnv_sno"] = 100.0
     namelist["microphysics"]["q_liq_threshold"] = 0.5e-3
@@ -356,6 +359,9 @@ function TRMM_LBA(namelist_defaults)
     namelist["time_stepping"]["dt_min"] = 1.0
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m" # "cutoff"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
     namelist["microphysics"]["τ_acnv_rai"] = 2500.0
     namelist["microphysics"]["τ_acnv_sno"] = 100.0
     namelist["microphysics"]["q_liq_threshold"] = 0.5e-3
@@ -442,6 +448,9 @@ function DYCOMS_RF02(namelist_defaults)
     namelist["time_stepping"]["dt_min"] = 1.0
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+    namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
+    namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
+    namelist["microphysics"]["precip_fraction_limiter"] = 0.3
     namelist["microphysics"]["τ_acnv_rai"] = 2500.0
     namelist["microphysics"]["τ_acnv_sno"] = 100.0
     namelist["microphysics"]["q_liq_threshold"] = 0.5e-3

--- a/driver/parameter_set.jl
+++ b/driver/parameter_set.jl
@@ -142,6 +142,8 @@ function create_parameter_set(namelist)
         smin_rm = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_rm"),
         l_max = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "l_max"; default = 1.0e6),
         covar_lim = TC.parse_namelist(namelist, "thermodynamics", "diagnostic_covar_limiter"),
+        prescribed_precip_frac_value = TC.parse_namelist(namelist, "microphysics", "prescribed_precip_frac_value"; default = 1.0),
+        precip_fraction_limiter = TC.parse_namelist(namelist, "microphysics", "precip_fraction_limiter"; default = 0.3),
         entr_closure_kwargs...,
         ## Stochastic parameters
         c_gen_stoch = TC.parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "general_stochastic_ent_params"),

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -46,6 +46,12 @@ function parse_commandline()
         default = "rhotheta"
         "--precipitation_model" # Precipitation model (None, cutoff or clima_1m)
         arg_type = String
+        "--precip_fraction_model" # Precipitation model (prescribed or cloud_cover)
+        arg_type = String
+        "--prescribed_precip_frac_value" # Value of the precipitation fraction, if prescribed
+        arg_type = Float64
+        "--precip_fraction_limiter" # Minimum precipitation fraction, if diagnostic
+        arg_type = Float64
         "--thermo_covariance_model" # covariance model (prognostic or diagnostic)
         arg_type = String
         "--trunc_field_type_print"

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -39,6 +39,9 @@ overwrite_namelist_map = Dict(
 "n_up"                    => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
 "moisture_model"          => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
 "precipitation_model"     => (nl, pa, key) -> (nl["microphysics"]["precipitation_model"] = pa[key]),
+"precip_fraction_model"   => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_model"] = pa[key]),
+"prescribed_precip_frac_value" => (nl, pa, key) -> (nl["microphysics"]["prescribed_precip_frac_value"] = pa[key]),
+"precip_fraction_limiter" => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_limiter"] = pa[key]),
 "thermo_covariance_model" => (nl, pa, key) -> (nl["thermodynamics"]["thermo_covariance_model"] = pa[key]),
 "energy_var"              => (nl, pa, key) -> (nl["energy_var"] = pa[key]),
 )

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -61,6 +61,8 @@ function compute_precipitation_formation_tendencies(
     p_c = aux_gm.p
     ρ_c = prog_gm.ρ
 
+    precip_fraction = compute_precip_fraction(edmf, state, param_set)
+
     @inbounds for i in 1:N_up
         @inbounds for k in real_center_indices(grid)
             T_up = aux_up[i].T[k]
@@ -88,6 +90,7 @@ function compute_precipitation_formation_tendencies(
                 ρ_c[k],
                 Δt,
                 ts_up,
+                precip_fraction,
             )
             aux_up[i].qt_tendency_precip_formation[k] = mph.qt_tendency * aux_up[i].area[k]
             aux_up[i].θ_liq_ice_tendency_precip_formation[k] = mph.θ_liq_ice_tendency * aux_up[i].area[k]

--- a/src/ExperimentalClimaParams.jl
+++ b/src/ExperimentalClimaParams.jl
@@ -39,4 +39,8 @@ c_gen_stoch(ps::APS) = ps.nt.c_gen_stoch
 """ diagnostic covariances limiter """
 covar_lim(ps::APS) = ps.nt.covar_lim
 
+""" prescribed precipitation fraction """
+prescribed_precip_frac_value(ps::APS) = ps.nt.prescribed_precip_frac_value
+precip_fraction_limiter(ps::APS) = ps.nt.precip_fraction_limiter
+
 end

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -485,7 +485,6 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
 
     compute_diffusive_fluxes(edmf, grid, state, surf, param_set)
 
-
     # TODO: use dispatch
     if edmf.precip_model isa Clima1M
         # helper to calculate the rain velocity
@@ -495,9 +494,11 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
         term_vel_snow = aux_tc.term_vel_snow
         prog_pr = center_prog_precipitation(state)
 
+        #precip_fraction = compute_precip_fraction(edmf, state, param_set)
+
         @inbounds for k in real_center_indices(grid)
-            term_vel_rain[k] = CM1.terminal_velocity(param_set, CM1.RainType(), ρ_c[k], prog_pr.q_rai[k])
-            term_vel_snow[k] = CM1.terminal_velocity(param_set, CM1.SnowType(), ρ_c[k], prog_pr.q_sno[k])
+            term_vel_rain[k] = CM1.terminal_velocity(param_set, CM1.RainType(), ρ_c[k], prog_pr.q_rai[k])# / precip_fraction)
+            term_vel_snow[k] = CM1.terminal_velocity(param_set, CM1.SnowType(), ρ_c[k], prog_pr.q_sno[k])# / precip_fraction)
         end
     end
 


### PR DESCRIPTION
This PR adds a precipitation fraction model. The supported options are:
 - prescribed (done via experimental parameter, defaults to precipitation_fraction = 1, which is what we have now)
 - diagnostic based on the max cloud fraction (it has an experimental parameter that limits the precip fraction to to be smaller than the limiter value)
 
The basic idea is to divide the precipitation variables by the precip fraction before computing any source terms with them. And then multiply by precip fraction at the end to recover back the grid mean tendency. The non-linearities in the microphysics source terms should make a difference compared to precipitation fraction = 1

Edit: After some discussions with @yairchn and @ilopezgp we decided to apply this only to source terms. We need to think more on how to handle advection term and if we want to include those non-linear effects there.