### PR TITLE
Write water paths to file if calibrate_io

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -174,6 +174,18 @@ function compute_diagnostics!(
         @. massflux_s += aux_up_f[i].massflux * (If(aux_up[i].s) - If(aux_en.s))
     end
 
+    # Mean water paths for calibration
+    cent = TC.Cent(1)
+    diag_svpc.lwp_mean[cent] = sum(ρ_c .* aux_gm.q_liq)
+    diag_svpc.iwp_mean[cent] = sum(ρ_c .* aux_gm.q_ice)
+    diag_svpc.rwp_mean[cent] = sum(ρ_c .* prog_pr.q_rai)
+    diag_svpc.swp_mean[cent] = sum(ρ_c .* prog_pr.q_sno)
+
+    write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
+    write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
+    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
+    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
+
     # We only need computations above here for calibration io.
     calibrate_io && return nothing
 
@@ -208,7 +220,6 @@ function compute_diagnostics!(
     # while the updraft classes are assumed to have no overlap at all.
     # Thus total updraft cover is the sum of each updraft's cover
 
-    cent = TC.Cent(1)
     diag_tc_svpc.updraft_cloud_cover[cent] = sum(cloud_cover_up)
     diag_tc_svpc.updraft_cloud_base[cent] = minimum(abs.(cloud_base_up))
     diag_tc_svpc.updraft_cloud_top[cent] = maximum(abs.(cloud_top_up))
@@ -311,11 +322,6 @@ function compute_diagnostics!(
 
     TC.update_cloud_frac(edmf, grid, state)
 
-    diag_svpc.lwp_mean[cent] = sum(ρ_c .* aux_gm.q_liq)
-    diag_svpc.iwp_mean[cent] = sum(ρ_c .* aux_gm.q_ice)
-    diag_svpc.rwp_mean[cent] = sum(ρ_c .* prog_pr.q_rai)
-    diag_svpc.swp_mean[cent] = sum(ρ_c .* prog_pr.q_sno)
-
     diag_tc_svpc.env_lwp[cent] = sum(ρ_c .* aux_en.q_liq .* aux_en.area)
     diag_tc_svpc.env_iwp[cent] = sum(ρ_c .* aux_en.q_ice .* aux_en.area)
 
@@ -357,10 +363,6 @@ function compute_diagnostics!(
     write_ts(Stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
     write_ts(Stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
     write_ts(Stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
-    write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
-    write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
-    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
-    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
 
     return
 end


### PR DESCRIPTION
We need to calibrate and validate to the water path diagnostics, without a need for fluxes etc that slow down IO.

This PR allows writing to file the `xWP` diagnostics to file even if calibrate_io.