### PR TITLE
Test that CI does not crash for non-vanilla cases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,15 +98,15 @@ steps:
         artifact_paths: "Output.Bomex.01_stretch_grid_true/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with NN_nonlocal"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal --skip_tests true --suffix _NN_nonlocal"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal --skip_tests true --broken_tests true --suffix _NN_nonlocal"
         artifact_paths: "Output.Bomex.01_NN_nonlocal/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with NN"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN --skip_tests true --suffix _NN"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN --skip_tests true  --broken_tests true --suffix _NN"
         artifact_paths: "Output.Bomex.01_NN/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with FNO"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr FNO --skip_tests true --suffix _FNO"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr FNO --skip_tests true --broken_tests true --suffix _FNO"
         artifact_paths: "Output.Bomex.01_FNO/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with RF"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.27.0"
+version = "0.28.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -22,6 +22,33 @@ function affect_io!(integrator)
     # TODO: is this the best location to call diagnostics?
     compute_diagnostics!(edmf, precip_model, param_set, grid, state, diagnostics, Stats, case, t, calibrate_io)
 
+    cent = TC.Cent(1)
+    diag_svpc = svpc_diagnostics_grid_mean(diagnostics)
+    diag_tc_svpc = svpc_diagnostics_turbconv(diagnostics)
+    write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
+    write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
+    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
+    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
+
+    if !calibrate_io
+        write_ts(Stats, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
+        write_ts(Stats, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])
+        write_ts(Stats, "updraft_cloud_top", diag_tc_svpc.updraft_cloud_top[cent])
+        write_ts(Stats, "env_cloud_cover", diag_tc_svpc.env_cloud_cover[cent])
+        write_ts(Stats, "env_cloud_base", diag_tc_svpc.env_cloud_base[cent])
+        write_ts(Stats, "env_cloud_top", diag_tc_svpc.env_cloud_top[cent])
+        write_ts(Stats, "env_lwp", diag_tc_svpc.env_lwp[cent])
+        write_ts(Stats, "env_iwp", diag_tc_svpc.env_iwp[cent])
+        write_ts(Stats, "Hd", diag_tc_svpc.Hd[cent])
+        write_ts(Stats, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
+        write_ts(Stats, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
+
+        write_ts(Stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
+        write_ts(Stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
+        write_ts(Stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
+        write_ts(Stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
+    end
+
     # TODO: remove `vars` hack that avoids
     # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
     # opening/closing files every step should be okay. #removeVarsHack
@@ -31,10 +58,8 @@ function affect_io!(integrator)
     io(io_nt.aux, Stats, state)
     io(io_nt.diagnostics, Stats, diagnostics)
 
-    if !calibrate_io
-        surf = get_surface(case.surf_params, grid, state, t, param_set)
-        io(surf, case.surf_params, grid, state, Stats, t)
-    end
+    surf = get_surface(case.surf_params, grid, state, t, param_set)
+    io(surf, case.surf_params, grid, state, Stats, t)
 
     ODE.u_modified!(integrator, false) # We're legitamately not mutating `u` (the state vector)
 end

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -184,14 +184,6 @@ function compute_diagnostics!(
     diag_svpc.rwp_mean[cent] = sum(ρ_c .* prog_pr.q_rai)
     diag_svpc.swp_mean[cent] = sum(ρ_c .* prog_pr.q_sno)
 
-    write_ts(Stats, "lwp_mean", diag_svpc.lwp_mean[cent])
-    write_ts(Stats, "iwp_mean", diag_svpc.iwp_mean[cent])
-    write_ts(Stats, "rwp_mean", diag_svpc.rwp_mean[cent])
-    write_ts(Stats, "swp_mean", diag_svpc.swp_mean[cent])
-
-    # We only need computations above here for calibration io.
-    calibrate_io && return nothing
-
     #####
     ##### Cloud base, top and cover
     #####
@@ -350,26 +342,6 @@ function compute_diagnostics!(
     diag_tc_svpc.updraft_lwp[cent] = lwp
     diag_tc_svpc.updraft_iwp[cent] = iwp
     diag_tc_svpc.Hd[cent] = StatsBase.mean(plume_scale_height)
-
-    # Demonstration of how we can move all of the `write_ts` calls
-    # outside of `compute_diagnostics!`, which currently computes
-    # _and_ exports (some) diagnostics.
-    write_ts(Stats, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
-    write_ts(Stats, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])
-    write_ts(Stats, "updraft_cloud_top", diag_tc_svpc.updraft_cloud_top[cent])
-    write_ts(Stats, "env_cloud_cover", diag_tc_svpc.env_cloud_cover[cent])
-    write_ts(Stats, "env_cloud_base", diag_tc_svpc.env_cloud_base[cent])
-    write_ts(Stats, "env_cloud_top", diag_tc_svpc.env_cloud_top[cent])
-    write_ts(Stats, "env_lwp", diag_tc_svpc.env_lwp[cent])
-    write_ts(Stats, "env_iwp", diag_tc_svpc.env_iwp[cent])
-    write_ts(Stats, "Hd", diag_tc_svpc.Hd[cent])
-    write_ts(Stats, "updraft_lwp", diag_tc_svpc.updraft_lwp[cent])
-    write_ts(Stats, "updraft_iwp", diag_tc_svpc.updraft_iwp[cent])
-
-    write_ts(Stats, "cutoff_precipitation_rate", diag_svpc.cutoff_precipitation_rate[cent])
-    write_ts(Stats, "cloud_cover_mean", diag_svpc.cloud_cover_mean[cent])
-    write_ts(Stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
-    write_ts(Stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
 
     return
 end

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -34,6 +34,9 @@ function parse_commandline()
         "--skip_tests"     # Skip regression tests
         arg_type = Bool
         default = false
+        "--broken_tests"     # Tests are broken, skip tests
+        arg_type = Bool
+        default = false
         "--suffix"         # A suffix for the artifact folder
         arg_type = String
         default = ""

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -48,6 +48,7 @@ no_overwrites = (
     "case", # default_namelist already overwrites namelist["meta"]["casename"]
     "skip_post_proc",
     "skip_tests",
+    "broken_tests",
     "trunc_field_type_print",
     "suffix",
 )
@@ -80,6 +81,15 @@ if length(overwrite_list) ≠ length(cl_list)
 end
 
 ds_tc_filename, return_code = main(namelist)
+
+parsed_args["broken_tests"] && exit()
+
+@testset "Simulation completion" begin
+    # Test that the simulation has actually finished,
+    # and not aborted early.
+    @test !(return_code == :simulation_aborted)
+    @test return_code == :success
+end
 
 # Post-processing case kwargs
 include(joinpath(tc_dir, "post_processing", "case_kwargs.jl"))
@@ -122,13 +132,6 @@ end
             @test !any(isnan_or_inf.(Array(profile["qr_mean"])))
         end
         nothing
-    end
-
-    @testset "Simulation completion" begin
-        # Test that the simulation has actually finished,
-        # and not aborted early.
-        @test !(return_code == :simulation_aborted)
-        @test return_code == :success
     end
     nothing
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -126,8 +126,8 @@ end
 function io_dictionary_aux_calibrate()
     DT = NamedTuple{(:dims, :group, :field), Tuple{Tuple{String, String}, String, Any}}
     io_dict = Dict{String, DT}(
-        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).u),
-        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_prog_grid_mean(state).v),
+        "u_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> grid_mean_u(state)),
+        "v_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> grid_mean_v(state)),
         "s_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).s),
         "qt_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_tot),
         "ql_mean" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_grid_mean(state).q_liq),


### PR DESCRIPTION
This PR
 - Fixes the currently broken `calibrate_io = true` non-vanilla test
 - Adds a `broken_test` CL argument, since some other non-vanilla tests are broken too (and bails before testing that the simulation has not crashed)
 - Moves the testing that simulations have not crashed immediately after solving, so that all tests, not just vanilla tests, have this sanity check.