### PR TITLE
Fix non-equilibroum buoyancy calculations

### DIFF
--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -192,7 +192,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
                 elseif edmf.moisture_model isa NonEquilibriumMoisture
                     ql = aux_up[i].q_liq[k - 1]
                     qi = aux_up[i].q_ice[k - 1]
-                    ts_up = thermo_state_pθq(param_set, p_c[k - 1], h, qt, ql, qi)
+                    ts_up = thermo_state_pθq(param_set, p_c[k], h, qt, ql, qi)
                 else
                     error("Something went wrong. emdf.moisture_model options are equilibrium or nonequilibrium")
                 end


### PR DESCRIPTION
This reverts https://github.com/CliMA/TurbulenceConvection.jl/pull/1018

Right now we are inconsistent and taking `p[k]` for equilibrium `ts` but `p[k-1]` for non-equilibrium `ts`. 

Also, taking `p[k-1]` results in no updrafts for shallow convection cases and delays TRMM convection by around an hour.  (Compare the buildkite artifacts from before and after merging https://github.com/CliMA/TurbulenceConvection.jl/pull/1018 when looking at TRMM with non-equilibrium moisture model)