### PR TITLE
Construct grid with spaces

### DIFF
--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -57,10 +57,10 @@ struct Grid{FT, NZ, CS, FS, SC, SF, SVPCS}
     zc::SC
     zf::SF
     svpc_space::SVPCS
-    function Grid(mesh)
+    function Grid(space::CC.Spaces.CenterFiniteDifferenceSpace)
 
-        nz = length(mesh.faces) - 1
-        cs = CC.Spaces.CenterFiniteDifferenceSpace(mesh)
+        nz = length(space)
+        cs = space
         fs = CC.Spaces.FaceFiniteDifferenceSpace(cs)
         zc = CC.Fields.coordinate_field(cs)
         zf = CC.Fields.coordinate_field(fs)
@@ -88,6 +88,8 @@ struct Grid{FT, NZ, CS, FS, SC, SF, SVPCS}
 end
 
 single_value_per_col_space(grid::Grid) = grid.svpc_space
+
+Grid(mesh::CC.Meshes.IntervalMesh) = Grid(CC.Spaces.CenterFiniteDifferenceSpace(mesh))
 
 function Grid(Δz::FT, nz::Int) where {FT <: AbstractFloat}
     z₀, z₁ = FT(0), FT(nz * Δz)

--- a/test/clima_core_extensions.jl
+++ b/test/clima_core_extensions.jl
@@ -66,6 +66,21 @@ function ∫field(field::CC.Fields.FiniteDifferenceField, field_zmin = 0)
     return sol
 end
 
+@testset "Grid space view" begin
+    FT = Float64
+    nz, Δz = 10, FT(0.1)
+    domain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint{FT}(0),
+        CC.Geometry.ZPoint{FT}(nz * Δz),
+        boundary_tags = (:bottom, :top),
+    )
+    mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
+    grid = TC.Grid(mesh)
+    grid1 = TC.Grid(axes(grid.zc))
+    grid2 = TC.Grid(axes(grid.zc))
+    @test axes(grid1.zc) === axes(grid2.zc)
+    @test axes(grid1.zf) === axes(grid2.zf)
+end
 
 @testset "Vertical integrals" begin
     cent_state = TC.FieldFromNamedTuple(center_space(grid), (; y = FT(0)))


### PR DESCRIPTION
This PR allows us to build a grid given a space, so that our internal space (for `z`-coordinates) are indistinguishable from other fields.