### PR TITLE
Make RF broken test true

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,7 +110,7 @@ steps:
         artifact_paths: "Output.Bomex.01_FNO/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with RF"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr RF --skip_tests true --suffix _RF"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr RF --skip_tests true --broken_tests true --suffix _RF"
         artifact_paths: "Output.Bomex.01_RF/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with noisy_relaxation_process"


### PR DESCRIPTION
I'm finding that the RF test is very brittle (e.g., in #1074 and #1062). We can add it back in once that model is initialized with sensible values.