### PR TITLE
Limit benchmark samples

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -1,23 +1,26 @@
 include(joinpath(@__DIR__, "common.jl"))
 import BenchmarkTools
 
-sim = init_sim("Bomex"; prefix = "bm_Bomex")
+sim = init_sim("Bomex"; prefix = "bm_Bomex", single_timestep = false)
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
-trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+b = BenchmarkTools.@benchmarkable ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+trial = BenchmarkTools.run(b, samples = floor(Int, TS.t_max / TS.dt))
 show(stdout, MIME("text/plain"), trial)
 println()
 
-sim = init_sim("TRMM_LBA"; prefix = "bm_TRMM_LBA")
+sim = init_sim("TRMM_LBA"; prefix = "bm_TRMM_LBA", single_timestep = false)
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
-trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+b = BenchmarkTools.@benchmarkable ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+trial = BenchmarkTools.run(b, samples = floor(Int, TS.t_max / TS.dt))
 show(stdout, MIME("text/plain"), trial)
 println()
 
-sim = init_sim("Rico"; prefix = "bm_Rico")
+sim = init_sim("Rico"; prefix = "bm_Rico", single_timestep = false)
 (; tendencies, prog, params, TS) = unpack_params(sim)
 ∑tendencies!(tendencies, prog, params, TS.t) # compile first
-trial = BenchmarkTools.@benchmark ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+b = BenchmarkTools.@benchmarkable ∑tendencies!($tendencies, $prog, $params, $(TS.t))
+trial = BenchmarkTools.run(b, samples = floor(Int, TS.t_max / TS.dt))
 show(stdout, MIME("text/plain"), trial)
 println()

--- a/perf/benchmark_step.jl
+++ b/perf/benchmark_step.jl
@@ -3,24 +3,31 @@ import BenchmarkTools
 # Use a NullLogger to avoid highly excessive progress bar printing
 Logging.with_logger(Logging.NullLogger()) do
 
-    sim = init_sim("Bomex"; prefix = "bm_step_Bomex")
+    sim = init_sim("Bomex"; prefix = "bm_step_Bomex", single_timestep = false)
     (prob, alg, kwargs) = solve_args(sim)
     integrator = ODE.init(prob, alg; kwargs...)
-    trial = BenchmarkTools.@benchmark ODE.step!($integrator)
+    ODE.step!(integrator) # compile first
+    b = BenchmarkTools.@benchmarkable ODE.step!($integrator)
+    tfinal = integrator.sol.prob.tspan[2]
+    trial = BenchmarkTools.run(b, samples = floor(Int, tfinal / integrator.dt))
     show(stdout, MIME("text/plain"), trial)
     println()
 
-    sim = init_sim("TRMM_LBA"; prefix = "bm_step_TRMM_LBA")
+    sim = init_sim("TRMM_LBA"; prefix = "bm_step_TRMM_LBA", single_timestep = false)
     (prob, alg, kwargs) = solve_args(sim)
-    integrator = ODE.init(prob, alg; kwargs...)
-    trial = BenchmarkTools.@benchmark ODE.step!($integrator)
+    ODE.step!(integrator) # compile first
+    b = BenchmarkTools.@benchmarkable ODE.step!($integrator)
+    tfinal = integrator.sol.prob.tspan[2]
+    trial = BenchmarkTools.run(b, samples = floor(Int, tfinal / integrator.dt))
     show(stdout, MIME("text/plain"), trial)
     println()
 
-    sim = init_sim("Rico"; prefix = "bm_step_Rico")
+    sim = init_sim("Rico"; prefix = "bm_step_Rico", single_timestep = false)
     (prob, alg, kwargs) = solve_args(sim)
-    integrator = ODE.init(prob, alg; kwargs...)
-    trial = BenchmarkTools.@benchmark ODE.step!($integrator)
+    ODE.step!(integrator) # compile first
+    b = BenchmarkTools.@benchmarkable ODE.step!($integrator)
+    tfinal = integrator.sol.prob.tspan[2]
+    trial = BenchmarkTools.run(b, samples = floor(Int, tfinal / integrator.dt))
     show(stdout, MIME("text/plain"), trial)
     println()
 end


### PR DESCRIPTION
We currently don't limit the number of samples in our benchmark, which is problematic for cases that are not intended to be run past a certain time. This PR limits the samples based on the final time and dt.