### PR TITLE
Conditionally compute parsed args

### DIFF
--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -1,6 +1,8 @@
 include("cli_options.jl")
 
-(s, parsed_args) = parse_commandline()
+if !@isdefined parsed_args
+    (s, parsed_args) = parse_commandline()
+end
 
 suffix = parsed_args["suffix"]
 if !@isdefined case_name


### PR DESCRIPTION
This PR adds a condition around `(s, parsed_args) = parse_commandline()`, so that users can use something like

```julia
using Revise
include("integration_tests/cli_options.jl");
(s, parsed_args) = parse_commandline();
parsed_args["config"] = "sphere";
include("integration_tests/driver.jl")
```

To run the driver with their own configured parsed args. I have been continually doing this and then commenting the first few driver lines to run cases locally.