### PR TITLE
Limit io to callbacks, sync profiles and timeseries

### DIFF
--- a/driver/TimeStepping.jl
+++ b/driver/TimeStepping.jl
@@ -7,6 +7,7 @@ mutable struct TimeStepping
     dt_max::Float64
     dt_max_edmf::Float64
     dt_io::Float64
+    initialized::Bool
 end
 
 function TimeStepping(namelist)
@@ -15,11 +16,12 @@ function TimeStepping(namelist)
     cfl_limit = TC.parse_namelist(namelist, "time_stepping", "cfl_limit"; default = 0.5)
     dt_max = TC.parse_namelist(namelist, "time_stepping", "dt_max"; default = 10.0)
     dt_max_edmf = 0.0
+    initialized = false
 
     # set time
     t = 0.0
     dt_io = 0.0
     nstep = 0
 
-    return TimeStepping(dt, t_max, t, nstep, cfl_limit, dt_max, dt_max_edmf, dt_io)
+    return TimeStepping(dt, t_max, t, nstep, cfl_limit, dt_max, dt_max_edmf, dt_io, initialized)
 end

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -21,6 +21,12 @@ function affect_io!(integrator)
 
     for inds in TC.iterate_columns(prog.cent)
         stats = Stats[inds...]
+        # TODO: remove `vars` hack that avoids
+        # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+        # opening/closing files every step should be okay. #removeVarsHack
+        # TurbulenceConvection.io(sim) # #removeVarsHack
+        write_simulation_time(stats, t) # #removeVarsHack
+
         state = TC.column_state(prog, aux, tendencies, inds...)
         grid = TC.Grid(state)
         diag_col = TC.column_diagnostics(diagnostics, inds...)
@@ -54,12 +60,6 @@ function affect_io!(integrator)
             write_ts(stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
             write_ts(stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
         end
-
-        # TODO: remove `vars` hack that avoids
-        # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
-        # opening/closing files every step should be okay. #removeVarsHack
-        # TurbulenceConvection.io(sim) # #removeVarsHack
-        write_simulation_time(stats, t) # #removeVarsHack
 
         io(io_nt.aux, stats, state)
         io(io_nt.diagnostics, stats, diag_col)

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -6,7 +6,7 @@ function condition_io(u, t, integrator)
         TS.dt_io = 0
         io_flag = true
     end
-    return io_flag || t ≈ 0 || t ≈ TS.t_max
+    return io_flag || t < 1e-4 || t ≈ TS.t_max
 end
 
 condition_every_iter(u, t, integrator) = true
@@ -104,14 +104,14 @@ end
 function init_dt!(integrator)
     UnPack.@unpack edmf, TS, dt_min = integrator.p
     if !TS.initialized
-        TS.dt = 1.0e-6
-        SciMLBase.set_proposed_dt!(integrator, TS.dt)
+        dt_zero = 1.0e-6
+        SciMLBase.set_proposed_dt!(integrator, dt_zero)
         ODE.u_modified!(integrator, false)
         TS.initialized = true
-    else
-        TS.dt = dt_min
-        SciMLBase.set_proposed_dt!(integrator, TS.dt)
-        ODE.u_modified!(integrator, false)
+    # else
+    #     TS.dt = dt_min
+    #     SciMLBase.set_proposed_dt!(integrator, TS.dt)
+    #     ODE.u_modified!(integrator, false)
     end
 end
 

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -104,7 +104,7 @@ end
 function init_dt!(integrator)
     UnPack.@unpack edmf, TS, dt_min = integrator.p
     if !TS.initialized
-        TS.dt = 0.0
+        TS.dt = 1.0e-6
         SciMLBase.set_proposed_dt!(integrator, TS.dt)
         ODE.u_modified!(integrator, false)
         TS.initialized = true

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -26,7 +26,7 @@ function affect_io!(integrator)
         # opening/closing files every step should be okay. #removeVarsHack
         # TurbulenceConvection.io(sim) # #removeVarsHack
         write_simulation_time(stats, t) # #removeVarsHack
-
+        println("IO at time $t.")
         state = TC.column_state(prog, aux, tendencies, inds...)
         grid = TC.Grid(state)
         diag_col = TC.column_diagnostics(diagnostics, inds...)

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -11,6 +11,8 @@ end
 
 condition_every_iter(u, t, integrator) = true
 
+condition_init(u, t, integrator) = t ≈ 0
+
 function affect_io!(integrator)
     UnPack.@unpack edmf, calibrate_io, precip_model, aux, io_nt, diagnostics, case, param_set, Stats, skip_io =
         integrator.p
@@ -102,10 +104,14 @@ end
 function init_dt!(integrator)
     UnPack.@unpack edmf, TS, dt_min = integrator.p
     if !TS.initialized
-        dt_zero = 0.0
-        SciMLBase.set_proposed_dt!(integrator, dt_zero)
+        TS.dt = 0.0
+        SciMLBase.set_proposed_dt!(integrator, TS.dt)
         ODE.u_modified!(integrator, false)
         TS.initialized = true
+    else
+        TS.dt = dt_min
+        SciMLBase.set_proposed_dt!(integrator, TS.dt)
+        ODE.u_modified!(integrator, false)
     end
 end
 

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -99,6 +99,16 @@ function adaptive_dt!(integrator)
     ODE.u_modified!(integrator, false)
 end
 
+function init_dt!(integrator)
+    UnPack.@unpack edmf, TS, dt_min = integrator.p
+    if !TS.initialized
+        dt_zero = 0.0
+        SciMLBase.set_proposed_dt!(integrator, dt_zero)
+        ODE.u_modified!(integrator, false)
+        TS.initialized = true
+    end
+end
+
 function dt_max!(integrator)
     UnPack.@unpack edmf, aux, TS = integrator.p
     prog = integrator.u

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -317,8 +317,8 @@ function solve_args(sim::Simulation1d)
 
     kwargs = (;
         progress_steps = 100,
-        save_start = true,
-        saveat = last(t_span),
+        save_start = false,
+        saveat = t_span,
         callback = callbacks,
         progress = true,
         unstable_check_kwarg(sim.case.case)...,

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -291,6 +291,7 @@ function solve_args(sim::Simulation1d)
     callback_cfl = sim.precip_model isa TC.Clima1M ? (callback_cfl,) : ()
     callback_dtmax = ODE.DiscreteCallback(condition_every_iter, dt_max!; save_positions = (false, false))
     callback_filters = ODE.DiscreteCallback(condition_every_iter, affect_filter!; save_positions = (false, false))
+    callback_init = ODE.DiscreteCallback(condition_every_iter, init_dt!; save_positions = (false, false))
     callback_adapt_dt = ODE.DiscreteCallback(condition_every_iter, adaptive_dt!; save_positions = (false, false))
     callback_adapt_dt = sim.adapt_dt ? (callback_adapt_dt,) : ()
     if sim.edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess && sim.adapt_dt
@@ -299,7 +300,7 @@ function solve_args(sim::Simulation1d)
         callback_adapt_dt = ()
     end
 
-    callbacks = ODE.CallbackSet(callback_adapt_dt..., callback_dtmax, callback_cfl..., callback_filters, callback_io...)
+    callbacks = ODE.CallbackSet(callback_adapt_dt..., callback_dtmax, callback_cfl..., callback_filters, callback_io..., callback_init)
 
     if sim.edmf.entr_closure isa TC.PrognosticNoisyRelaxationProcess
         prob = SDE.SDEProblem(∑tendencies!, ∑stoch_tendencies!, prog, t_span, params; dt = sim.TS.dt)

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -317,7 +317,7 @@ function solve_args(sim::Simulation1d)
 
     kwargs = (;
         progress_steps = 100,
-        save_start = false,
+        save_start = true,
         saveat = last(t_span),
         callback = callbacks,
         progress = true,

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -253,22 +253,6 @@ function initialize(sim::Simulation1d)
         initialize_io(stats.nc_filename, io_nt.aux, io_nt.diagnostics)
         initialize_io(stats.nc_filename, ts_list)
         surf = get_surface(case.surf_params, grid, state, t, param_set)
-        open_files(stats)
-        try
-            write_simulation_time(stats, t)
-            io(io_nt.aux, stats, state)
-            io(io_nt.diagnostics, stats, diagnostics_col)
-            io(surf, case.surf_params, grid, state, stats, t)
-        catch e
-            if truncate_stack_trace
-                @warn "IO during initialization failed."
-            else
-                @warn "IO during initialization failed." exception = (e, catch_backtrace())
-            end
-            return :simulation_crashed
-        finally
-            close_files(stats)
-        end
     end
 
     return


### PR DESCRIPTION
- Deletes the first io call within main, and limits all io calls to callbacks.
- Syncs timeseries and profiles writing time.
- Fixes #821 and #897 