### PR TITLE
Limit io to callbacks, sync profiles and timeseries (v2)

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -21,6 +21,12 @@ function affect_io!(integrator)
 
     for inds in TC.iterate_columns(prog.cent)
         stats = Stats[inds...]
+        # TODO: remove `vars` hack that avoids
+        # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+        # opening/closing files every step should be okay. #removeVarsHack
+        # TurbulenceConvection.io(sim) # #removeVarsHack
+        write_simulation_time(stats, t) # #removeVarsHack
+
         state = TC.column_state(prog, aux, tendencies, inds...)
         grid = TC.Grid(state)
         diag_col = TC.column_diagnostics(diagnostics, inds...)
@@ -54,12 +60,6 @@ function affect_io!(integrator)
             write_ts(stats, "cloud_base_mean", diag_svpc.cloud_base_mean[cent])
             write_ts(stats, "cloud_top_mean", diag_svpc.cloud_top_mean[cent])
         end
-
-        # TODO: remove `vars` hack that avoids
-        # https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
-        # opening/closing files every step should be okay. #removeVarsHack
-        # TurbulenceConvection.io(sim) # #removeVarsHack
-        write_simulation_time(stats, t) # #removeVarsHack
 
         io(io_nt.aux, stats, state)
         io(io_nt.diagnostics, stats, diag_col)

--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -130,24 +130,26 @@ for ds_tc_filename in ds_tc_filenames
             test_mse(computed_mse, best_mse, k)
         end
         @testset "Post-run tests" begin
-            isnan_or_inf(x) = isnan(x) || isinf(x)
+            isnan_inf_or_filled(x) = isnan(x) || isinf(x) || x ≈ NC.fillvalue(typeof(x))
             NC.Dataset(ds_tc_filename, "r") do ds
                 profile = ds.group["profiles"]
-                @test !any(isnan_or_inf.(Array(profile["qt_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["updraft_area"])))
-                @test !any(isnan_or_inf.(Array(profile["updraft_w"])))
-                @test !any(isnan_or_inf.(Array(profile["updraft_qt"])))
-                @test !any(isnan_or_inf.(Array(profile["updraft_thetal"])))
-                @test !any(isnan_or_inf.(Array(profile["u_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["tke_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["temperature_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["ql_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["qi_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["thetal_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["Hvar_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["QTvar_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["v_mean"])))
-                @test !any(isnan_or_inf.(Array(profile["qr_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["qt_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["updraft_area"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["updraft_w"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["updraft_qt"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["updraft_thetal"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["u_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["tke_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["temperature_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["ql_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["qi_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["thetal_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["Hvar_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["QTvar_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["v_mean"])))
+                @test !any(isnan_inf_or_filled.(Array(profile["qr_mean"])))
+                timeseries = ds.group["timeseries"]
+                @test !any(isnan_inf_or_filled.(Array(timeseries["lwp_mean"])))
             end
             nothing
         end


### PR DESCRIPTION
- Synchronize first io call within main for all profiles and time series.
- Fixes #821 and #897.
- Tests for filled values in integration tests, which were not covered previously (hence the errors).
- Initializes integrator during initialization, and passes it as an argument to `run`.