### PR TITLE
Remove overloading +- for Covariant3Vectors

### DIFF
--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -88,9 +88,9 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     ts_gm = center_aux_grid_mean(state).ts
     @. h_tot_gm = total_enthalpy(param_set, prog_gm.ρe_tot / ρ_c, ts_gm)
     # Compute the mass flux and associated scalar fluxes
-    @. massflux = ρ_f * Ifae(a_en) * (w_en - w_gm)
-    @. massflux_h = ρ_f * Ifae(a_en) * (w_en - w_gm) * (If(aux_en.h_tot) - If(h_tot_gm))
-    @. massflux_qt = ρ_f * Ifae(a_en) * (w_en - w_gm) * (If(q_tot_en) - If(q_tot_gm))
+    @. massflux = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm))
+    @. massflux_h = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm)) * (If(aux_en.h_tot) - If(h_tot_gm))
+    @. massflux_qt = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm)) * (If(q_tot_en) - If(q_tot_gm))
     @inbounds for i in 1:N_up
         aux_up_f_i = aux_up_f[i]
         aux_up_i = aux_up[i]
@@ -100,9 +100,9 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
         w_up_i = aux_up_f[i].w
         q_tot_up = aux_up_i.q_tot
         h_tot_up = aux_up_i.h_tot
-        @. aux_up_f[i].massflux = ρ_f * Ifau(a_up) * (w_up_i - w_gm)
-        @. massflux_h += ρ_f * (Ifau(a_up) * (w_up_i - w_gm) * (If(h_tot_up) - If(h_tot_gm)))
-        @. massflux_qt += ρ_f * (Ifau(a_up) * (w_up_i - w_gm) * (If(q_tot_up) - If(q_tot_gm)))
+        @. aux_up_f[i].massflux = ρ_f * Ifau(a_up) * (w_up_i - toscalar(w_gm))
+        @. massflux_h += ρ_f * (Ifau(a_up) * (w_up_i - toscalar(w_gm)) * (If(h_tot_up) - If(h_tot_gm)))
+        @. massflux_qt += ρ_f * (Ifau(a_up) * (w_up_i - toscalar(w_gm)) * (If(q_tot_up) - If(q_tot_gm)))
     end
 
     if edmf.moisture_model isa NonEquilibriumMoisture
@@ -113,7 +113,7 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
         q_ice_en = aux_en.q_ice
         q_liq_gm = prog_gm.q_liq
         q_ice_gm = prog_gm.q_ice
-        @. massflux_en = ρ_f * Ifae(a_en) * (w_en - w_gm)
+        @. massflux_en = ρ_f * Ifae(a_en) * (w_en - toscalar(w_gm))
         @. massflux_ql = massflux_en * (If(q_liq_en) - If(q_liq_gm))
         @. massflux_qi = massflux_en * (If(q_ice_en) - If(q_ice_gm))
         @inbounds for i in 1:N_up
@@ -425,6 +425,7 @@ function get_GMV_CoVar(
     gmv_covar = getproperty(center_aux_grid_mean(state), covar_sym)
     covar_e = getproperty(center_aux_environment(state), covar_sym)
     gm = is_tke ? prog_gm_f : aux_gm_c
+    to_scalar = is_tke ? toscalar : x -> x
     ϕ_gm = getproperty(gm, ϕ_sym)
     ψ_gm = getproperty(gm, ψ_sym)
     ϕ_en = getproperty(aux_en, ϕ_sym)
@@ -432,11 +433,11 @@ function get_GMV_CoVar(
     area_en = aux_en_c.area
 
     Icd = is_tke ? CCO.InterpolateF2C() : x -> x
-    @. gmv_covar = tke_factor * area_en * Icd(ϕ_en - ϕ_gm) * Icd(ψ_en - ψ_gm) + area_en * covar_e
+    @. gmv_covar = tke_factor * area_en * Icd(ϕ_en - to_scalar(ϕ_gm)) * Icd(ψ_en - to_scalar(ψ_gm)) + area_en * covar_e
     @inbounds for i in 1:N_up
         ϕ_up = getproperty(aux_up[i], ϕ_sym)
         ψ_up = getproperty(aux_up[i], ψ_sym)
-        @. gmv_covar += tke_factor * aux_up_c[i].area * Icd(ϕ_up - ϕ_gm) * Icd(ψ_up - ψ_gm)
+        @. gmv_covar += tke_factor * aux_up_c[i].area * Icd(ϕ_up - to_scalar(ϕ_gm)) * Icd(ψ_up - to_scalar(ψ_gm))
     end
     return nothing
 end
@@ -824,6 +825,7 @@ function compute_covariance_entr(
     ρ_c = prog_gm.ρ
     gm = is_tke ? prog_gm_f : aux_gm_c
     prog_up = is_tke ? aux_up_f : aux_up
+    to_scalar = is_tke ? toscalar : x -> x
     ϕ_gm = getproperty(gm, ϕ_sym)
     ψ_gm = getproperty(gm, ψ_sym)
     aux_en_2m = center_aux_environment_2m(state)
@@ -864,7 +866,10 @@ function compute_covariance_entr(
                 a_up *
                 abs(Ic(w_up)) *
                 eps_turb *
-                ((Idc(ϕ_en) - Idc(ϕ_gm)) * (Idc(ψ_up) - Idc(ψ_en)) + (Idc(ψ_en) - Idc(ψ_gm)) * (Idc(ϕ_up) - Idc(ϕ_en)))
+                (
+                    (Idc(ϕ_en) - Idc(to_scalar(ϕ_gm))) * (Idc(ψ_up) - Idc(ψ_en)) +
+                    (Idc(ψ_en) - Idc(to_scalar(ψ_gm))) * (Idc(ϕ_up) - Idc(ϕ_en))
+                )
             )
 
         @. detr_loss += Int(a_up > min_area) * tke_factor * ρ_c * a_up * abs(Ic(w_up)) * (entr_sc + eps_turb) * covar

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -17,9 +17,7 @@ Base.:<(h1::Cent, h2::Cent) = h1.i < h2.i
 Base.max(h1::Cent, h2::Cent) = Cent(max(h1.i, h2.i))
 Base.min(h1::Cent, h2::Cent) = Cent(min(h1.i, h2.i))
 
-# TODO: remove this:
-Base.:-(a::FT, b::CCG.Covariant3Vector{FT}) where {FT} = a .- b.u₃
-Base.:+(a::FT, b::CCG.Covariant3Vector{FT}) where {FT} = a .+ b.u₃
+toscalar(x::CCG.Covariant3Vector) = x.u₃
 
 const FDFields = Union{CC.Fields.ExtrudedFiniteDifferenceField, CC.Fields.FiniteDifferenceField}
 

--- a/src/closures/entr_detr.jl
+++ b/src/closures/entr_detr.jl
@@ -188,7 +188,7 @@ function compute_entr_detr!(
         w_up = aux_up_f[i].w
         w_en = aux_en_f.w
         w_gm = prog_gm_f.w
-        @. m_entr_detr = a_up * (Ic(w_up) - Ic(w_gm))
+        @. m_entr_detr = a_up * (Ic(w_up) - toscalar(Ic(w_gm)))
         @. ∇m_entr_detr = ∇c(wvec(LB(m_entr_detr)))
         @. w_up_c = Ic(w_up)
         @. w_en_c = Ic(w_en)
@@ -303,7 +303,7 @@ function compute_entr_detr!(
         w_up = aux_up_f[i].w
         w_en = aux_en_f.w
         w_gm = prog_gm_f.w
-        @. m_entr_detr = a_up * (Ic(w_up) - Ic(w_gm))
+        @. m_entr_detr = a_up * (Ic(w_up) - Ic(toscalar(w_gm)))
         @. ∇m_entr_detr = ∇c(wvec(LB(m_entr_detr)))
         @. w_up_c = Ic(w_up)
         @. w_en_c = Ic(w_en)


### PR DESCRIPTION
This PR fixes the TODO:

```julia
# TODO: remove this:
Base.:-(a::FT, b::CCG.Covariant3Vector{FT}) where {FT} = a .- b.u₃
Base.:+(a::FT, b::CCG.Covariant3Vector{FT}) where {FT} = a .+ b.u₃
```
by removing this overloading.

Closes #1022.