### PR TITLE
Fix some type instabilities, make code more type-generic

### DIFF
--- a/driver/NetCDFIO.jl
+++ b/driver/NetCDFIO.jl
@@ -101,9 +101,9 @@ end
 ##### Generic field
 #####
 
-function add_field(ds, var_name::String, dims, group)
+function add_field(ds, var_name::String, dims, group, ::Type{FT}) where {FT <: AbstractFloat}
     profile_grp = ds.group[group]
-    new_var = NC.defVar(profile_grp, var_name, Float64, dims)
+    new_var = NC.defVar(profile_grp, var_name, FT, dims)
     return nothing
 end
 
@@ -111,9 +111,9 @@ end
 ##### Time-series data
 #####
 
-function add_ts(ds, var_name::String)
+function add_ts(ds, var_name::String, ::Type{FT}) where {FT <: AbstractFloat}
     ts_grp = ds.group["timeseries"]
-    new_var = NC.defVar(ts_grp, var_name, Float64, ("t",))
+    new_var = NC.defVar(ts_grp, var_name, FT, ("t",))
     return nothing
 end
 

--- a/driver/TimeStepping.jl
+++ b/driver/TimeStepping.jl
@@ -1,25 +1,25 @@
-mutable struct TimeStepping
-    dt::Float64
-    t_max::Float64
-    t::Float64
+mutable struct TimeStepping{FT}
+    dt::FT
+    t_max::FT
+    t::FT
     nstep::Int
-    cfl_limit::Float64
-    dt_max::Float64
-    dt_max_edmf::Float64
-    dt_io::Float64
+    cfl_limit::FT
+    dt_max::FT
+    dt_max_edmf::FT
+    dt_io::FT
 end
 
-function TimeStepping(namelist)
-    dt = TC.parse_namelist(namelist, "time_stepping", "dt_min"; default = 1.0)
-    t_max = TC.parse_namelist(namelist, "time_stepping", "t_max"; default = 7200.0)
-    cfl_limit = TC.parse_namelist(namelist, "time_stepping", "cfl_limit"; default = 0.5)
-    dt_max = TC.parse_namelist(namelist, "time_stepping", "dt_max"; default = 10.0)
-    dt_max_edmf = 0.0
+function TimeStepping(::Type{FT}, namelist) where {FT}
+    dt = TC.parse_namelist(namelist, "time_stepping", "dt_min"; default = FT(1.0))
+    t_max = TC.parse_namelist(namelist, "time_stepping", "t_max"; default = FT(7200.0))
+    cfl_limit = TC.parse_namelist(namelist, "time_stepping", "cfl_limit"; default = FT(0.5))
+    dt_max = TC.parse_namelist(namelist, "time_stepping", "dt_max"; default = FT(10.0))
+    dt_max_edmf = FT(0)
 
     # set time
-    t = 0.0
-    dt_io = 0.0
+    t = FT(0)
+    dt_io = FT(0)
     nstep = 0
 
-    return TimeStepping(dt, t_max, t, nstep, cfl_limit, dt_max, dt_max_edmf, dt_io)
+    return TimeStepping{FT}(dt, t_max, t, nstep, cfl_limit, dt_max, dt_max_edmf, dt_io)
 end

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -70,20 +70,20 @@ function io(io_dict::Dict, Stats::NetCDFIO_Stats, state)
 end
 
 
-function initialize_io(nc_filename, ts_list)
+function initialize_io(nc_filename, FT, ts_list)
     NC.Dataset(nc_filename, "a") do ds
         for var_name in ts_list
-            add_ts(ds, var_name)
+            add_ts(ds, var_name, FT)
         end
     end
     return nothing
 end
 
-function initialize_io(nc_filename, io_dicts::Dict...)
+function initialize_io(nc_filename, FT, io_dicts::Dict...)
     NC.Dataset(nc_filename, "a") do ds
         for io_dict in io_dicts
             for var_name in keys(io_dict)
-                add_field(ds, var_name, io_dict[var_name].dims, io_dict[var_name].group)
+                add_field(ds, var_name, io_dict[var_name].dims, io_dict[var_name].group, FT)
             end
         end
     end

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -161,7 +161,7 @@ function Simulation1d(namelist)
 
     Fo = TC.ForcingBase(case_type, param_set; Cases.forcing_kwargs(case_type, namelist)...)
     Rad = TC.RadiationBase(case_type)
-    TS = TimeStepping(namelist)
+    TS = TimeStepping(FT, namelist)
 
     Ri_bulk_crit = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     spk = Cases.surface_param_kwargs(case_type, namelist)
@@ -250,8 +250,8 @@ function initialize(sim::Simulation1d)
         initialize_edmf(edmf, grid, state, case, param_set, t)
         if !skip_io
             stats = Stats[inds...]
-            initialize_io(stats.nc_filename, io_nt.aux, io_nt.diagnostics)
-            initialize_io(stats.nc_filename, ts_list)
+            initialize_io(stats.nc_filename, FT, io_nt.aux, io_nt.diagnostics)
+            initialize_io(stats.nc_filename, FT, ts_list)
         end
     end
 

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -1668,10 +1668,10 @@ uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 version = "0.3.4"
 
 [[deps.TurbulenceConvection]]
-deps = ["CLIMAParameters", "ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "StaticArrays", "StatsBase", "StochasticDiffEq", "Thermodynamics", "UnPack"]
+deps = ["CLIMAParameters", "ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "Thermodynamics", "UnPack"]
 path = ".."
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "0.29.1"
+version = "0.29.2"
 
 [[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"


### PR DESCRIPTION
This PR fixes some type instabilities, and makes the code a bit more type-generic. I also ran `resolve`, which added `Random` to the Manifest. This was missed in #1097.

A step towards #133.