### PR TITLE
Remove inversion types

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -124,14 +124,6 @@ get_case_name(case_type::AbstractCaseType) = string(case_type)
 ##### Case configurations
 #####
 
-inversion_type(::AbstractCaseType) = TC.CriticalRiInversion()
-inversion_type(::TRMM_LBA) = TC.max∇θInversion()
-inversion_type(::ARM_SGP) = TC.max∇θInversion()
-inversion_type(::GATE_III) = TC.max∇θInversion()
-inversion_type(::DYCOMS_RF01) = TC.max∇θInversion()
-inversion_type(::DYCOMS_RF02) = TC.max∇θInversion()
-inversion_type(::DryBubble) = TC.θρInversion()
-
 get_forcing_type(::AbstractCaseType) = TC.ForcingStandard # default
 get_forcing_type(::Soares) = TC.ForcingNone
 get_forcing_type(::Nieuwstadt) = TC.ForcingNone

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -166,8 +166,7 @@ function Simulation1d(namelist)
     Ri_bulk_crit = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     spk = Cases.surface_param_kwargs(case_type, namelist)
     surf_params = Cases.surface_params(case_type, surf_ref_state, param_set; Ri_bulk_crit = Ri_bulk_crit, spk...)
-    inversion_type = Cases.inversion_type(case_type)
-    case = Cases.CasesBase(case_type; inversion_type, surf_params, Fo, Rad, spk...)
+    case = Cases.CasesBase(case_type; surf_params, Fo, Rad, spk...)
 
     calibrate_io = namelist["stats_io"]["calibrate_io"]
     aux_dict = calibrate_io ? TC.io_dictionary_aux_calibrate() : TC.io_dictionary_aux()

--- a/src/types.jl
+++ b/src/types.jl
@@ -422,31 +422,23 @@ end
 
 rad_type(::RadiationBase{T}) where {T} = T
 
-abstract type AbstractInversion end
-struct CriticalRiInversion <: AbstractInversion end
-struct max∇θInversion <: AbstractInversion end
-struct θρInversion <: AbstractInversion end
-
-Base.@kwdef struct CasesBase{T, IT, SURFP, F, R, LESDataT}
+Base.@kwdef struct CasesBase{T, SURFP, F, R, LESDataT}
     case::T
     casename::String
-    inversion_type::IT
     surf_params::SURFP
     Fo::F
     Rad::R
     LESDat::LESDataT
 end
 
-function CasesBase(case::T; inversion_type, surf_params, Fo, Rad, LESDat = nothing, kwargs...) where {T}
+function CasesBase(case::T; surf_params, Fo, Rad, LESDat = nothing, kwargs...) where {T}
     F = typeof(Fo)
     R = typeof(Rad)
-    IT = typeof(inversion_type)
     SURFP = typeof(surf_params)
     LESDataT = typeof(LESDat)
-    CasesBase{T, IT, SURFP, F, R, LESDataT}(;
+    CasesBase{T, SURFP, F, R, LESDataT}(;
         case = case,
         casename = string(nameof(T)),
-        inversion_type,
         surf_params,
         Fo,
         Rad,


### PR DESCRIPTION
I just realized that we no longer use `inversion_type`, can we remove it?