### PR TITLE
Remove unused initialization and variable

### DIFF
--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -10,15 +10,9 @@ const TD = Thermodynamics
 function initialize_edmf(edmf::TC.EDMFModel, grid::TC.Grid, state::TC.State, case, param_set::APS, t::Real)
     initialize_covariance(edmf, grid, state)
     surf_params = case.surf_params
-    aux_tc = TC.center_aux_turbconv(state)
     aux_gm = TC.center_aux_grid_mean(state)
     ts_gm = aux_gm.ts
-    prog_gm = TC.center_prog_grid_mean(state)
-    p_c = prog_gm.ρ
-    parent(aux_tc.prandtl_nvec) .= edmf.prandtl_number
-    @inbounds for k in TC.real_center_indices(grid)
-        aux_gm.θ_virt[k] = TD.virtual_pottemp(param_set, ts_gm[k])
-    end
+    @. aux_gm.θ_virt = TD.virtual_pottemp(param_set, ts_gm)
     surf = get_surface(surf_params, grid, state, t, param_set)
     if case.casename == "DryBubble"
         initialize_updrafts_DryBubble(edmf, grid, state)

--- a/src/types.jl
+++ b/src/types.jl
@@ -464,7 +464,6 @@ struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, EC, EDS, DDS, EPG}
     precip_model::PM
     precip_fraction_model::PFM
     en_thermo::ENT
-    prandtl_number::FT
     bg_closure::EBGC
     entr_closure::EC
     entr_dim_scale::EDS
@@ -472,8 +471,6 @@ struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, EC, EDS, DDS, EPG}
     entr_pi_subset::EPG
     set_src_seed::Bool
     function EDMFModel(::Type{FT}, namelist, precip_model) where {FT}
-        # get values from namelist
-        prandtl_number = namelist["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"]
 
         # Set the number of updrafts (1)
         n_updrafts = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "updraft_number"; default = 1)
@@ -673,7 +670,6 @@ struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, EC, EDS, DDS, EPG}
             precip_model,
             precip_fraction_model,
             en_thermo,
-            prandtl_number,
             bg_closure,
             entr_closure,
             entr_dim_scale,


### PR DESCRIPTION
When looking to refactor the code, I realized that `aux_tc.prandtl_nvec` is initialized, but then overwritten (before ever being used) in `update_aux!`. This PR removes the unused initialization. Doing this resulted in `prandtl_number` being unused, so this PR also removes this variable. `prandtl_number` was initialized to `namelist["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"]`, but that is still used in the code as a clima parameter.