### PR TITLE
Fix/cleanup some diagnostics

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -137,10 +137,9 @@ function compute_diagnostics!(
 
     surf = get_surface(case.surf_params, grid, state, t, param_set)
 
-    @inbounds for k in TC.real_center_indices(grid)
-        aux_gm.s[k] = TD.specific_entropy(param_set, ts_gm[k])
-        aux_en.s[k] = TD.specific_entropy(param_set, ts_en[k])
-    end
+    @. aux_gm.s = TD.specific_entropy(param_set, ts_gm)
+    @. aux_en.s = TD.specific_entropy(param_set, ts_en)
+
     @inbounds for k in TC.real_center_indices(grid)
         @inbounds for i in 1:N_up
             aux_up[i].s[k] = if aux_up[i].area[k] > 0.0
@@ -259,12 +258,12 @@ function compute_diagnostics!(
 
     @inbounds for k in TC.real_center_indices(grid)
         a_up_bulk_k = a_up_bulk[k]
-        diag_tc.entr_sc[k] = 0.0
-        diag_tc.ε_nondim[k] = 0.0
-        diag_tc.detr_sc[k] = 0.0
-        diag_tc.δ_nondim[k] = 0.0
-        diag_tc.asp_ratio[k] = 0.0
-        diag_tc.frac_turb_entr[k] = 0.0
+        diag_tc.entr_sc[k] = 0
+        diag_tc.ε_nondim[k] = 0
+        diag_tc.detr_sc[k] = 0
+        diag_tc.δ_nondim[k] = 0
+        diag_tc.asp_ratio[k] = 0
+        diag_tc.frac_turb_entr[k] = 0
         if a_up_bulk_k > 0.0
             @inbounds for i in 1:N_up
                 aux_up_i = aux_up[i]
@@ -278,27 +277,21 @@ function compute_diagnostics!(
         end
     end
 
-    a_up_bulk_f = copy(diag_tc_f.nh_pressure)
     a_bulk_bcs = TC.a_bulk_boundary_conditions(surf, edmf)
-    Ifa = CCO.InterpolateC2F(; a_bulk_bcs...)
-    @. a_up_bulk_f = Ifa(a_up_bulk)
-
-    a_up_bulk_f = copy(diag_tc_f.nh_pressure)
-    a_up_f = copy(a_up_bulk_f)
     Ifabulk = CCO.InterpolateC2F(; a_bulk_bcs...)
-    @. a_up_bulk_f = Ifabulk(a_up_bulk)
+    a_up_bulk_f = @. Ifabulk(a_up_bulk)
 
     RB_precip = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
 
-    @inbounds for k in TC.real_face_indices(grid)
-        @inbounds for i in 1:N_up
-            a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
-            Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
-            @. a_up_f = Ifaup(aux_up[i].area)
-            diag_tc_f.nh_pressure[k] = 0.0
-            diag_tc_f.nh_pressure_b[k] = 0.0
-            diag_tc_f.nh_pressure_adv[k] = 0.0
-            diag_tc_f.nh_pressure_drag[k] = 0.0
+    @inbounds for i in 1:N_up
+        a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
+        Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
+        a_up_f = @. Ifaup(aux_up[i].area)
+        @inbounds for k in TC.real_face_indices(grid)
+            diag_tc_f.nh_pressure[k] = 0
+            diag_tc_f.nh_pressure_b[k] = 0
+            diag_tc_f.nh_pressure_adv[k] = 0
+            diag_tc_f.nh_pressure_drag[k] = 0
             if a_up_bulk_f[k] > 0.0
                 diag_tc_f.nh_pressure[k] += a_up_f[k] * aux_up_f[i].nh_pressure[k] / a_up_bulk_f[k]
                 diag_tc_f.nh_pressure_b[k] += a_up_f[k] * aux_up_f[i].nh_pressure_b[k] / a_up_bulk_f[k]
@@ -329,7 +322,7 @@ function compute_diagnostics!(
     if (precip_model isa TC.Clima0M)
         f =
             (aux_en.qt_tendency_precip_formation .+ aux_bulk.qt_tendency_precip_formation) .* ρ_c ./ ρ_cloud_liq .*
-            3.6 .* 1e6
+            FT(3.6) .* 1e6
         diag_svpc.cutoff_precipitation_rate[cent] = sum(f)
     end
 


### PR DESCRIPTION
This PR cleans up some of the diagnostics. More importantly it moves `@. a_up_f = Ifaup(aux_up[i].area)` outside of a `k`-loop.