### PR TITLE
Wrap entr_pi_subset in Tuple in edmf constructor

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -666,7 +666,7 @@ struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, EC, EDS, DDS, EPG}
             error("Something went wrong. Invalid entrainment dimension scale '$detr_dim_scale'")
         end
 
-        entr_pi_subset = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entr_pi_subset")
+        entr_pi_subset = Tuple(parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "entr_pi_subset"))
 
         EDS = typeof(entr_dim_scale)
         DDS = typeof(detr_dim_scale)


### PR DESCRIPTION
This is needed to keep the EDMF model `isbits` for typical cases.