### PR TITLE
Bump precompilation time speedup test

### DIFF
--- a/perf/precompilable_no_init.jl
+++ b/perf/precompilable_no_init.jl
@@ -23,5 +23,5 @@ close_files(sim)
 @info "precompiled/precompiling: $(t_precompiled/t_precompile))"
 
 @testset "Test runtime" begin
-    @test t_precompiled / t_precompile < 0.51
+    @test t_precompiled / t_precompile < 0.55
 end


### PR DESCRIPTION
It looks like we're a bit too close to this limit (see [this build](https://buildkite.com/clima/turbulenceconvection-ci/builds/10975)).