### PR TITLE
Fix buildkite job for Bomex with Gaussian

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,7 +90,7 @@ steps:
     steps:
 
       - label: ":partly_sunny: Bomex with gaussian"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --quad_type gaussian --skip_tests true --suffix _gaussian"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --sgs quadrature --quad_type gaussian --skip_tests true --suffix _gaussian"
         artifact_paths: "Output.Bomex.01_gaussian/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with stretched grid"


### PR DESCRIPTION
This PR changes/fixes with buildkite flag for the Bomex with Gaussian quadrature test.

The model very well may work fine if the namelist were properly set, this bug is specific to specifying the CL overwrites.

I'm going to re-push once #1121 merges.