### PR TITLE
Remove CasesBase

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -12,7 +12,7 @@ end
 condition_every_iter(u, t, integrator) = true
 
 function affect_io!(integrator)
-    UnPack.@unpack edmf, calibrate_io, precip_model, aux, io_nt, diagnostics, case, param_set, Stats, skip_io =
+    UnPack.@unpack edmf, calibrate_io, precip_model, aux, io_nt, diagnostics, surf_params, param_set, Stats, skip_io =
         integrator.p
     skip_io && return nothing
     t = integrator.t
@@ -32,7 +32,7 @@ function affect_io!(integrator)
         diag_col = TC.column_diagnostics(diagnostics, inds...)
 
         # TODO: is this the best location to call diagnostics?
-        compute_diagnostics!(edmf, precip_model, param_set, grid, state, diag_col, stats, case, t, calibrate_io)
+        compute_diagnostics!(edmf, precip_model, param_set, grid, state, diag_col, stats, surf_params, t, calibrate_io)
 
         cent = TC.Cent(1)
         diag_svpc = svpc_diagnostics_grid_mean(diag_col)
@@ -64,15 +64,15 @@ function affect_io!(integrator)
         io(io_nt.aux, stats, state)
         io(io_nt.diagnostics, stats, diag_col)
 
-        surf = get_surface(case.surf_params, grid, state, t, param_set)
-        io(surf, case.surf_params, grid, state, stats, t)
+        surf = get_surface(surf_params, grid, state, t, param_set)
+        io(surf, surf_params, grid, state, stats, t)
     end
 
     ODE.u_modified!(integrator, false) # We're legitamately not mutating `u` (the state vector)
 end
 
 function affect_filter!(integrator)
-    UnPack.@unpack edmf, param_set, aux, case = integrator.p
+    UnPack.@unpack edmf, param_set, aux, case, surf_params = integrator.p
     t = integrator.t
     prog = integrator.u
     tendencies = ODE.get_du(integrator)
@@ -81,7 +81,7 @@ function affect_filter!(integrator)
     for inds in TC.iterate_columns(prog.cent)
         state = TC.column_state(prog, aux, tendencies, inds...)
         grid = TC.Grid(state)
-        surf = get_surface(case.surf_params, grid, state, t, param_set)
+        surf = get_surface(surf_params, grid, state, t, param_set)
         TC.affect_filter!(edmf, grid, state, param_set, surf, t)
     end
 

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -106,7 +106,7 @@ function compute_diagnostics!(
     state::TC.State,
     diagnostics::D,
     Stats::NetCDFIO_Stats,
-    case::TC.CasesBase,
+    surf_params,
     t::Real,
     calibrate_io::Bool,
 ) where {D <: CC.Fields.FieldVector}
@@ -135,7 +135,7 @@ function compute_diagnostics!(
     diag_tc_svpc = svpc_diagnostics_turbconv(diagnostics)
     diag_svpc = svpc_diagnostics_grid_mean(diagnostics)
 
-    surf = get_surface(case.surf_params, grid, state, t, param_set)
+    surf = get_surface(surf_params, grid, state, t, param_set)
 
     @. aux_gm.s = TD.specific_entropy(param_set, ts_gm)
     @. aux_en.s = TD.specific_entropy(param_set, ts_en)

--- a/perf/common.jl
+++ b/perf/common.jl
@@ -18,6 +18,9 @@ function unpack_params(sim)
         precip_model = sim.precip_model,
         param_set = sim.param_set,
         case = sim.case,
+        radiation = sim.radiation,
+        forcing = sim.forcing,
+        surf_params = sim.surf_params,
         TS = TS,
         aux = aux,
     )

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -243,7 +243,6 @@ function compute_diffusive_fluxes(edmf::EDMFModel, grid::Grid, state::State, sur
 end
 
 function affect_filter!(edmf::EDMFModel, grid::Grid, state::State, param_set::APS, surf::SurfaceBase, t::Real)
-    # TODO: figure out why this filter kills the DryBubble results if called at t = 0.
     prog_en = center_prog_environment(state)
     aux_en = center_aux_environment(state)
     ###

--- a/src/types.jl
+++ b/src/types.jl
@@ -485,31 +485,6 @@ end
 
 rad_type(::RadiationBase{T}) where {T} = T
 
-Base.@kwdef struct CasesBase{T, SURFP, F, R, LESDataT}
-    case::T
-    casename::String
-    surf_params::SURFP
-    Fo::F
-    Rad::R
-    LESDat::LESDataT
-end
-
-function CasesBase(case::T; surf_params, Fo, Rad, LESDat = nothing, kwargs...) where {T}
-    F = typeof(Fo)
-    R = typeof(Rad)
-    SURFP = typeof(surf_params)
-    LESDataT = typeof(LESDat)
-    CasesBase{T, SURFP, F, R, LESDataT}(;
-        case = case,
-        casename = string(nameof(T)),
-        surf_params,
-        Fo,
-        Rad,
-        LESDat,
-        kwargs...,
-    )
-end
-
 struct EDMFModel{N_up, FT, MM, TCM, PM, PFM, ENT, EBGC, MLP, PMP, EC, EDS, DDS, EPG}
     surface_area::FT
     max_area::FT


### PR DESCRIPTION
This PR
 - Removes CasesBase, which was basically a form of the host atmos model, so it living in TC's src was a bit awkward.
 - Only pass CasesBase properties into functions that are needed, this will help make initialization more flexible and alleviates scope assumptions