### PR TITLE
Get FT from float_type (added)

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -237,7 +237,7 @@ function initialize_profiles(::Soares, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_q_tot = APL.Soares_q_tot(FT)
     prof_θ_liq_ice = APL.Soares_θ_liq_ice(FT)
     prof_u = APL.Soares_u(FT)
@@ -287,7 +287,7 @@ function initialize_profiles(::Nieuwstadt, grid::Grid, param_set, state; kwargs.
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_θ_liq_ice = APL.Nieuwstadt_θ_liq_ice(FT)
     prof_u = APL.Nieuwstadt_u(FT)
     prof_tke = APL.Nieuwstadt_tke(FT)
@@ -336,7 +336,7 @@ function initialize_profiles(::Bomex, grid::Grid, param_set, state; kwargs...)
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_q_tot = APL.Bomex_q_tot(FT)
     prof_θ_liq_ice = APL.Bomex_θ_liq_ice(FT)
     prof_u = APL.Bomex_u(FT)
@@ -377,7 +377,7 @@ function initialize_forcing(::Bomex, forcing, grid::Grid, state, param_set)
     ts_gm = aux_gm.ts
     p_c = aux_gm.p
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_ug = APL.Bomex_geostrophic_u(FT)
     prof_dTdt = APL.Bomex_dTdt(FT)
     prof_dqtdt = APL.Bomex_dqtdt(FT)
@@ -416,7 +416,7 @@ function initialize_profiles(::life_cycle_Tan2018, grid::Grid, param_set, state;
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_q_tot = APL.LifeCycleTan2018_q_tot(FT)
     prof_θ_liq_ice = APL.LifeCycleTan2018_θ_liq_ice(FT)
     prof_u = APL.LifeCycleTan2018_u(FT)
@@ -463,7 +463,7 @@ function initialize_forcing(::life_cycle_Tan2018, forcing, grid::Grid, state, pa
     p_c = aux_gm.p
     ts_gm = aux_gm.ts
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_ug = APL.LifeCycleTan2018_geostrophic_u(FT)
     prof_dTdt = APL.LifeCycleTan2018_dTdt(FT)
     prof_dqtdt = APL.LifeCycleTan2018_dqtdt(FT)
@@ -513,7 +513,7 @@ function initialize_profiles(::Rico, grid::Grid, param_set, state; kwargs...)
     p = aux_gm.p
     ρ_c = prog_gm.ρ
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_u = APL.Rico_u(FT)
     prof_v = APL.Rico_v(FT)
     prof_q_tot = APL.Rico_q_tot(FT)
@@ -577,7 +577,7 @@ function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
     ts_gm = aux_gm.ts
     p_c = aux_gm.p
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_ug = APL.Rico_geostrophic_ug(FT)
     prof_vg = APL.Rico_geostrophic_vg(FT)
     prof_dTdt = APL.Rico_dTdt(FT)
@@ -618,7 +618,7 @@ function initialize_profiles(::TRMM_LBA, grid::Grid, param_set, state; kwargs...
     ρ_c = prog_gm.ρ
     p = aux_gm.p
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     # Get profiles from AtmosphericProfilesLibrary.jl
     prof_p = APL.TRMM_LBA_p(FT)
     prof_T = APL.TRMM_LBA_T(FT)
@@ -691,7 +691,7 @@ function initialize_profiles(::ARM_SGP, grid::Grid, param_set, state; kwargs...)
     ρ_c = prog_gm.ρ
     p = aux_gm.p
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_u = APL.ARM_SGP_u(FT)
     prof_q_tot = APL.ARM_SGP_q_tot(FT)
     prof_θ_liq_ice = APL.ARM_SGP_θ_liq_ice(FT)
@@ -744,7 +744,7 @@ function update_forcing(::ARM_SGP, grid, state, t::Real, param_set)
     ts_gm = TC.center_aux_grid_mean(state).ts
     prog_gm = TC.center_prog_grid_mean(state)
     p_c = prog_gm.ρ
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     @inbounds for k in real_center_indices(grid)
         Π = TD.exner(param_set, ts_gm[k])
         z = grid.zc[k].z
@@ -768,7 +768,7 @@ function surface_ref_state(::GATE_III, param_set::APS, namelist)
 end
 
 function initialize_profiles(::GATE_III, grid::Grid, param_set, state; kwargs...)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     prog_gm_u = TC.grid_mean_u(state)
@@ -803,7 +803,7 @@ function surface_params(case::GATE_III, surf_ref_state, param_set; kwargs...)
 end
 
 function initialize_forcing(::GATE_III, forcing, grid::Grid, state, param_set)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     for k in TC.real_center_indices(grid)
         z = grid.zc[k].z
@@ -826,7 +826,7 @@ function surface_ref_state(::DYCOMS_RF01, param_set::APS, namelist)
 end
 
 function initialize_profiles(::DYCOMS_RF01, grid::Grid, param_set, state; kwargs...)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     prog_gm_u = TC.grid_mean_u(state)
@@ -915,7 +915,7 @@ function surface_ref_state(::DYCOMS_RF02, param_set::APS, namelist)
 end
 
 function initialize_profiles(::DYCOMS_RF02, grid::Grid, param_set, state; kwargs...)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     prog_gm_u = TC.grid_mean_u(state)
@@ -1011,7 +1011,7 @@ function initialize_profiles(::GABLS, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prog_gm_u = TC.grid_mean_u(state)
     prog_gm_v = TC.grid_mean_v(state)
 
@@ -1038,7 +1038,7 @@ function surface_params(case::GABLS, surf_ref_state, param_set; kwargs...)
 end
 
 function initialize_forcing(::GABLS, forcing, grid::Grid, state, param_set)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     initialize(forcing, grid, state)
     aux_gm = TC.center_aux_grid_mean(state)
     @inbounds for k in real_center_indices(grid)
@@ -1072,7 +1072,7 @@ function initialize_profiles(::DryBubble, grid::Grid, param_set, state; kwargs..
 
     # initialize Grid Mean Profiles of thetali and qt
     zc_in = grid.zc.z
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prof_θ_liq_ice = APL.DryBubble_θ_liq_ice(FT)
     aux_gm.θ_liq_ice .= prof_θ_liq_ice.(zc_in)
     parent(prog_gm_u) .= 0.01
@@ -1159,7 +1159,7 @@ end
 
 function initialize_profiles(::LES_driven_SCM, grid::Grid, param_set, state; LESDat)
 
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     prog_gm_u = TC.grid_mean_u(state)

--- a/driver/Radiation.jl
+++ b/driver/Radiation.jl
@@ -14,7 +14,7 @@ function update_radiation(self::RadiationBase{RadiationDYCOMS_RF01}, grid, state
     ρ_c = prog_gm.ρ
     # find zi (level of 8.0 g/kg isoline of qt)
     # TODO: report bug: zi and ρ_i are not initialized
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     zi = FT(0)
     ρ_i = FT(0)
     kc_surf = TC.kc_surface(grid)

--- a/driver/Surface.jl
+++ b/driver/Surface.jl
@@ -12,7 +12,7 @@ function get_surface(
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     kc_surf = TC.kc_surface(grid)
     kf_surf = TC.kf_surface(grid)
     z_sfc = FT(0)
@@ -83,7 +83,7 @@ function get_surface(
     t::Real,
     param_set::CP.AbstractEarthParameterSet,
 )
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     kc_surf = TC.kc_surface(grid)
     kf_surf = TC.kf_surface(grid)
     aux_gm_f = TC.face_aux_grid_mean(state)
@@ -144,7 +144,7 @@ function get_surface(
 )
     kc_surf = TC.kc_surface(grid)
     kf_surf = TC.kf_surface(grid)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     z_sfc = FT(0)
     z_in = grid.zc[kc_surf].z
     prog_gm = TC.center_prog_grid_mean(state)

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -110,7 +110,7 @@ function compute_diagnostics!(
     t::Real,
     calibrate_io::Bool,
 ) where {D <: CC.Fields.FieldVector}
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     N_up = TC.n_updrafts(edmf)
     aux_gm = TC.center_aux_grid_mean(state)
     aux_en = TC.center_aux_environment(state)

--- a/driver/dycore.jl
+++ b/driver/dycore.jl
@@ -63,7 +63,7 @@ function compute_ref_state!(
     param_set::PS;
     ts_g,
 ) where {PS}
-    FT = eltype(grid)
+    FT = TC.float_type(p_c)
     kf_surf = TC.kf_surface(grid)
     qtg = TD.total_specific_humidity(param_set, ts_g)
     Φ = TC.geopotential(param_set, grid.zf[kf_surf].z)
@@ -214,7 +214,7 @@ function ∑stoch_tendencies!(tendencies::FV, prog::FV, params::NT, t::Real) whe
     for inds in TC.iterate_columns(prog.cent)
 
         state = TC.column_state(prog, aux, tendencies, inds...)
-        grid = TC.Grid(state)
+        grid = TC.Grid(axes(state.prog.cent))
         surf = get_surface(surf_params, grid, state, t, param_set)
 
         # compute updraft stochastic tendencies
@@ -234,7 +234,7 @@ function ∑tendencies!(tendencies::FV, prog::FV, params::NT, t::Real) where {NT
 
     for inds in TC.iterate_columns(prog.cent)
         state = TC.column_state(prog, aux, tendencies, inds...)
-        grid = TC.Grid(state)
+        grid = TC.Grid(axes(state.prog.cent))
 
         set_thermo_state_peq!(state, grid, edmf.moisture_model, param_set)
 
@@ -295,7 +295,7 @@ function compute_gm_tendencies!(
     tendencies_gm = TC.center_tendencies_grid_mean(state)
     kc_toa = TC.kc_top_of_atmos(grid)
     kf_surf = TC.kf_surface(grid)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     prog_gm = TC.center_prog_grid_mean(state)
     prog_gm_f = TC.face_prog_grid_mean(state)
     aux_gm = TC.center_aux_grid_mean(state)

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -105,7 +105,7 @@ function initialize_updrafts_DryBubble(edmf, grid, state)
     ρ_0_c = prog_gm.ρ
     ρ_0_f = aux_gm_f.ρ
     N_up = TC.n_updrafts(edmf)
-    FT = eltype(grid)
+    FT = TC.float_type(state)
     z_in = APL.DryBubble_updrafts_z(FT)
     z_min, z_max = first(z_in), last(z_in)
     prof_θ_liq_ice = APL.DryBubble_updrafts_θ_liq_ice(FT)

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -212,8 +212,6 @@ function initialize(sim::Simulation1d)
 
     (; prog, aux, edmf, case, forcing, radiation, surf_params, param_set, surf_ref_state) = sim
     (; les_data_kwarg, skip_io, Stats, io_nt, diagnostics, truncate_stack_trace) = sim
-    FT = eltype(edmf)
-    t = FT(0)
 
     ts_gm = ["Tsurface", "shf", "lhf", "ustar", "wstar", "lwp_mean", "iwp_mean"]
     ts_edmf = [
@@ -241,7 +239,9 @@ function initialize(sim::Simulation1d)
     for inds in TC.iterate_columns(prog.cent)
         state = TC.column_prog_aux(prog, aux, inds...)
         diagnostics_col = TC.column_diagnostics(diagnostics, inds...)
-        grid = TC.Grid(state)
+        grid = TC.Grid(axes(state.prog.cent))
+        FT = TC.float_type(state)
+        t = FT(0)
         compute_ref_state!(state, grid, param_set; ts_g = surf_ref_state)
         if !skip_io
             stats = Stats[inds...]

--- a/src/EDMF_Precipitation.jl
+++ b/src/EDMF_Precipitation.jl
@@ -32,7 +32,7 @@ function compute_precipitation_advection_tendencies(
     state::State,
     param_set::APS,
 )
-    FT = eltype(grid)
+    FT = float_type(state)
 
     tendencies_pr = center_tendencies_precipitation(state)
     prog_pr = center_prog_precipitation(state)

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -32,7 +32,7 @@ end
 function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
     N_up = n_updrafts(edmf)
     tendencies_gm = center_tendencies_grid_mean(state)
-    FT = eltype(grid)
+    FT = float_type(state)
     prog_gm = center_prog_grid_mean(state)
     aux_gm = center_aux_grid_mean(state)
     prog_gm_f = face_prog_grid_mean(state)
@@ -171,7 +171,7 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
 end
 
 function compute_diffusive_fluxes(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
-    FT = eltype(grid)
+    FT = float_type(state)
     aux_bulk = center_aux_bulk(state)
     aux_tc_f = face_aux_turbconv(state)
     aux_en_f = face_aux_environment(state)
@@ -252,7 +252,7 @@ function affect_filter!(edmf::EDMFModel, grid::Grid, state::State, param_set::AP
 end
 
 function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
@@ -396,7 +396,7 @@ function get_GMV_CoVar(
 ) where {covar_sym, ϕ_sym, ψ_sym}
     N_up = n_updrafts(edmf)
     is_tke = covar_sym == :tke
-    FT = eltype(edmf)
+    FT = float_type(state)
     tke_factor = is_tke ? FT(0.5) : 1
     aux_gm_c = center_aux_grid_mean(state)
     aux_gm_f = face_aux_grid_mean(state)
@@ -466,7 +466,7 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
-    FT = eltype(grid)
+    FT = float_type(state)
 
     aux_up = center_aux_updrafts(state)
     aux_en = center_aux_environment(state)
@@ -614,7 +614,7 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kf_surf = kf_surface(grid)
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
 
     prog_up = center_prog_updrafts(state)
@@ -721,7 +721,7 @@ function compute_covariance_shear(
     prog_gm = center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
     is_tke = covar_sym == :tke
-    FT = eltype(edmf)
+    FT = float_type(state)
     tke_factor = is_tke ? FT(0.5) : 1
     k_eddy = is_tke ? aux_tc.KM : aux_tc.KH
     aux_en_2m = center_aux_environment_2m(state)
@@ -768,7 +768,7 @@ function compute_covariance_interdomain_src(
 ) where {covar_sym, ϕ_sym, ψ_sym}
     N_up = n_updrafts(edmf)
     is_tke = covar_sym == :tke
-    FT = eltype(edmf)
+    FT = float_type(state)
     tke_factor = is_tke ? FT(0.5) : 1
     aux_up = center_aux_updrafts(state)
     aux_up_f = face_aux_updrafts(state)
@@ -802,7 +802,7 @@ function compute_covariance_entr(
 ) where {covar_sym, ϕ_sym, ψ_sym}
 
     N_up = n_updrafts(edmf)
-    FT = eltype(grid)
+    FT = float_type(state)
     is_tke = covar_sym == :tke
     tke_factor = is_tke ? FT(0.5) : 1
     aux_up = center_aux_updrafts(state)
@@ -874,7 +874,7 @@ function compute_covariance_dissipation(
     ::Val{covar_sym},
     param_set::APS,
 ) where {covar_sym}
-    FT = eltype(grid)
+    FT = float_type(state)
     c_d = mixing_length_params(edmf).c_d
     aux_tc = center_aux_turbconv(state)
     prog_en = center_prog_environment(state)
@@ -921,7 +921,7 @@ function compute_en_tendencies!(
     ρ_f = aux_gm_f.ρ
     c_d = mixing_length_params(edmf).c_d
     is_tke = covar_sym == :tke
-    FT = eltype(grid)
+    FT = float_type(state)
 
     ρ_ae_K = face_aux_turbconv(state).ρ_ae_K
     KM = center_aux_turbconv(state).KM
@@ -986,7 +986,7 @@ function update_diagnostic_covariances!(
     param_set::APS,
     ::Val{covar_sym},
 ) where {covar_sym}
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kc_toa = kc_top_of_atmos(grid)
@@ -1049,7 +1049,7 @@ function GMV_third_m(
     N_up = n_updrafts(edmf)
     gm_third_m = getproperty(center_aux_grid_mean(state), gm_third_m_sym)
     kc_surf = kc_surface(grid)
-    FT = eltype(grid)
+    FT = float_type(state)
 
     aux_bulk = center_aux_bulk(state)
     aux_up_f = face_aux_updrafts(state)

--- a/src/closures/entr_detr.jl
+++ b/src/closures/entr_detr.jl
@@ -155,7 +155,7 @@ function compute_entr_detr!(
     Δt::Real,
     εδ_closure::AbstractEntrDetrModel,
 )
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
     aux_up = center_aux_updrafts(state)
     prog_up = center_prog_updrafts(state)
@@ -264,7 +264,7 @@ function compute_entr_detr!(
     Δt::Real,
     εδ_model::AbstractNonLocalEntrDetrModel,
 )
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
     aux_up = center_aux_updrafts(state)
     aux_up_f = face_aux_updrafts(state)

--- a/src/closures/perturbation_pressure.jl
+++ b/src/closures/perturbation_pressure.jl
@@ -20,7 +20,7 @@ for all updrafts, following [He2020](@cite), given:
 """
 function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
 
-    FT = eltype(grid)
+    FT = float_type(state)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
     kc_toa = kc_top_of_atmos(grid)

--- a/src/types.jl
+++ b/src/types.jl
@@ -782,3 +782,6 @@ end
 
 
 Grid(state::State) = Grid(first_center_space(state.prog))
+
+float_type(state::State) = eltype(state.prog)
+float_type(field::CC.Fields.Field) = CC.Spaces.undertype(axes(field))

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -10,7 +10,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
     obukhov_length = surf.obukhov_length
-    FT = eltype(grid)
+    FT = float_type(state)
     prog_gm = center_prog_grid_mean(state)
     aux_up = center_aux_updrafts(state)
     aux_up_f = face_aux_updrafts(state)


### PR DESCRIPTION
This PR adds `float_type(::State)`, and we grab `FT` from it everywhere. This peels off quite a bit of stuff from the ForwardDiff-compatible branch.