### PR TITLE
Add/use thermo parameter wrapper

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -228,10 +228,11 @@ initialize_forcing(::AbstractCaseType, forcing, grid::Grid, state, param_set) = 
 ForcingBase(case::Soares, param_set::APS; kwargs...) = ForcingBase(get_forcing_type(case); apply_coriolis = false)
 
 function surface_ref_state(::Soares, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1000.0 * 100.0
     qtg = 5.0e-3
     Tg = 300.0
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::Soares, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -254,17 +255,18 @@ function initialize_profiles(::Soares, grid::Grid, param_set, state; kwargs...)
 end
 
 function surface_params(case::Soares, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
-    ρ_f_surf = TD.air_density(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     zrough::FT = 0.16 #1.0e-4 0.16 is the value specified in the Nieuwstadt paper.
     Tsurface::FT = 300.0
     qsurface::FT = 5.0e-3
     θ_flux::FT = 6.0e-2
     qt_flux::FT = 2.5e-5
-    ts = TD.PhaseEquil_pTq(param_set, p_f_surf, Tsurface, qsurface)
-    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(param_set, ts)
-    shf = θ_flux * TD.cp_m(param_set, ts) * ρ_f_surf
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
     ustar::FT = 0.28 # just to initilize grid mean covariances
     kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
@@ -277,10 +279,11 @@ end
 ForcingBase(case::Nieuwstadt, param_set::APS; kwargs...) = ForcingBase(get_forcing_type(case); apply_coriolis = false)
 
 function surface_ref_state(::Nieuwstadt, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1000.0 * 100.0
     Tg = 300.0
     qtg = 0.0
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::Nieuwstadt, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -302,16 +305,17 @@ function initialize_profiles(::Nieuwstadt, grid::Grid, param_set, state; kwargs.
 end
 
 function surface_params(case::Nieuwstadt, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
-    ρ_f_surf = TD.air_density(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     zrough::FT = 0.16 #1.0e-4 0.16 is the value specified in the Nieuwstadt paper.
     Tsurface::FT = 300.0
     qsurface::FT = 0.0
     θ_flux::FT = 6.0e-2
     lhf::FT = 0.0 # It would be 0.0 if we follow Nieuwstadt.
-    ts = TD.PhaseEquil_pTq(param_set, p_f_surf, Tsurface, qsurface)
-    shf = θ_flux * TD.cp_m(param_set, ts) * ρ_f_surf
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
     ustar::FT = 0.28 # just to initilize grid mean covariances
     kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.VariableFrictionVelocity; kwargs...)
@@ -325,10 +329,11 @@ ForcingBase(case::Bomex, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, coriolis_param = 0.376e-4) #= s^{-1} =#
 
 function surface_ref_state(::Bomex, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1.015e5 #Pressure at ground
     Tg = 300.4 #Temperature at ground
     qtg = 0.02245#Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::Bomex, grid::Grid, param_set, state; kwargs...)
@@ -353,18 +358,19 @@ function initialize_profiles(::Bomex, grid::Grid, param_set, state; kwargs...)
 end
 
 function surface_params(case::Bomex, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
-    ρ_f_surf = TD.air_density(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     zrough::FT = 1.0e-4
     qsurface::FT = 22.45e-3 # kg/kg
     θ_surface::FT = 299.1
     θ_flux::FT = 8.0e-3
     qt_flux::FT = 5.2e-5
-    ts = TD.PhaseEquil_pθq(param_set, p_f_surf, θ_surface, qsurface)
-    Tsurface = TD.air_temperature(param_set, ts)
-    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(param_set, ts)
-    shf = θ_flux * TD.cp_m(param_set, ts) * ρ_f_surf
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    lhf = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
     ustar::FT = 0.28 # m/s
     kwargs = (; zrough, Tsurface, qsurface, shf, lhf, ustar, Ri_bulk_crit)
     return TC.FixedSurfaceFlux(FT, TC.FixedFrictionVelocity; kwargs...)
@@ -406,10 +412,11 @@ ForcingBase(case::life_cycle_Tan2018, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, coriolis_param = 0.376e-4) #= s^{-1} =#
 
 function surface_ref_state(::life_cycle_Tan2018, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1.015e5  #Pressure at ground
     Tg = 300.4  #Temperature at ground
     qtg = 0.02245   #Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::life_cycle_Tan2018, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -433,18 +440,19 @@ function initialize_profiles(::life_cycle_Tan2018, grid::Grid, param_set, state;
 end
 
 function surface_params(case::life_cycle_Tan2018, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
-    ρ_f_surf = TD.air_density(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
+    ρ_f_surf = TD.air_density(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     zrough::FT = 1.0e-4 # not actually used, but initialized to reasonable value
     qsurface::FT = 22.45e-3 # kg/kg
     θ_surface::FT = 299.1
     θ_flux::FT = 8.0e-3
     qt_flux::FT = 5.2e-5
-    ts = TD.PhaseEquil_pθq(param_set, p_f_surf, θ_surface, qsurface)
-    Tsurface = TD.air_temperature(param_set, ts)
-    lhf0 = qt_flux * ρ_f_surf * TD.latent_heat_vapor(param_set, ts)
-    shf0 = θ_flux * TD.cp_m(param_set, ts) * ρ_f_surf
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
+    lhf0 = qt_flux * ρ_f_surf * TD.latent_heat_vapor(thermo_params, ts)
+    shf0 = θ_flux * TD.cp_m(thermo_params, ts) * ρ_f_surf
 
     weight_factor(t) = FT(0.01) + FT(0.99) * (cos(2 * FT(π) * t / 3600) + 1) / 2
     weight::FT = 1.0
@@ -457,6 +465,7 @@ function surface_params(case::life_cycle_Tan2018, surf_ref_state, param_set; Ri_
 end
 
 function initialize_forcing(::life_cycle_Tan2018, forcing, grid::Grid, state, param_set)
+    thermo_params = TC.thermodynamics_params(param_set)
     initialize(forcing, grid, state)
     prog_gm = TC.center_prog_grid_mean(state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -473,7 +482,7 @@ function initialize_forcing(::life_cycle_Tan2018, forcing, grid::Grid, state, pa
         z = grid.zc[k].z
         # Geostrophic velocity profiles. vg = 0
         aux_gm.ug[k] = prof_ug(z)
-        Π = TD.exner(param_set, ts_gm[k])
+        Π = TD.exner(thermo_params, ts_gm[k])
         # Set large-scale cooling
         aux_gm.dTdt_hadv[k] = prof_dTdt(Π, z)
         # Set large-scale drying
@@ -499,14 +508,16 @@ function ForcingBase(case::Rico, param_set::APS; kwargs...)
 end
 
 function surface_ref_state(::Rico, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     molmass_ratio = TCP.molmass_ratio(param_set)
     Pg = 1.0154e5  #Pressure at ground
     Tg = 299.8  #Temperature at ground
-    pvg = TD.saturation_vapor_pressure(param_set, Tg, TD.Liquid())
+    pvg = TD.saturation_vapor_pressure(thermo_params, Tg, TD.Liquid())
     qtg = (1 / molmass_ratio) * pvg / (Pg - pvg)   #Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::Rico, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TC.thermodynamics_params(param_set)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     aux_tc = TC.center_aux_turbconv(state)
@@ -533,8 +544,8 @@ function initialize_profiles(::Rico, grid::Grid, param_set, state; kwargs...)
     @inbounds for k in real_center_indices(grid)
         # Thermo state field cache is not yet
         # defined, so we can't use it yet.
-        ts = TD.PhaseEquil_pθq(param_set, p[k], aux_gm.θ_liq_ice[k], aux_gm.q_tot[k])
-        aux_gm.θ_virt[k] = TD.virtual_pottemp(param_set, ts)
+        ts = TD.PhaseEquil_pθq(thermo_params, p[k], aux_gm.θ_liq_ice[k], aux_gm.q_tot[k])
+        aux_gm.θ_virt[k] = TD.virtual_pottemp(thermo_params, ts)
     end
     zi = FT(0.6) * get_inversion(grid, state, param_set, FT(0.2))
 
@@ -549,7 +560,8 @@ function initialize_profiles(::Rico, grid::Grid, param_set, state; kwargs...)
 end
 
 function surface_params(case::Rico, surf_ref_state, param_set; kwargs...)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
 
     zrough::FT = 0.00015
@@ -564,13 +576,14 @@ function surface_params(case::Rico, surf_ref_state, param_set; kwargs...)
     Tsurface::FT = 299.8
 
     # For Rico we provide values of transfer coefficients
-    ts = TD.PhaseEquil_pTq(param_set, p_f_surf, Tsurface, FT(0)) # TODO: is this correct?
-    qsurface = TD.q_vap_saturation(param_set, ts)
+    ts = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, FT(0)) # TODO: is this correct?
+    qsurface = TD.q_vap_saturation(thermo_params, ts)
     kwargs = (; zrough, Tsurface, qsurface, cm, ch, kwargs...)
     return TC.FixedSurfaceCoeffs(FT; kwargs...)
 end
 
 function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
+    thermo_params = TC.thermodynamics_params(param_set)
     initialize(forcing, grid, state)
     prog_gm = TC.center_prog_grid_mean(state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -586,7 +599,7 @@ function initialize_forcing(::Rico, forcing, grid::Grid, state, param_set)
 
     @inbounds for k in real_center_indices(grid)
         z = grid.zc[k].z
-        Π = TD.exner(param_set, ts_gm[k])
+        Π = TD.exner(thermo_params, ts_gm[k])
         # Geostrophic velocity profiles
         aux_gm.ug[k] = prof_ug(z)
         aux_gm.vg[k] = prof_vg(z)
@@ -605,14 +618,16 @@ ForcingBase(case::TRMM_LBA, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = false, kwargs...)
 
 function surface_ref_state(::TRMM_LBA, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     molmass_ratio = TCP.molmass_ratio(param_set)
     Pg = 991.3 * 100  #Pressure at ground
     Tg = 296.85   # surface values for reference state (RS) which outputs p, ρ
-    pvg = TD.saturation_vapor_pressure(param_set, Tg, TD.Liquid())
+    pvg = TD.saturation_vapor_pressure(thermo_params, Tg, TD.Liquid())
     qtg = (1 / molmass_ratio) * pvg / (Pg - pvg) #Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::TRMM_LBA, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TC.thermodynamics_params(param_set)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
@@ -639,26 +654,27 @@ function initialize_profiles(::TRMM_LBA, grid::Grid, param_set, state; kwargs...
 
     @inbounds for k in real_center_indices(grid)
         z = grid.zc[k].z
-        pv_star = TD.saturation_vapor_pressure(param_set, aux_gm.T[k], TD.Liquid())
+        pv_star = TD.saturation_vapor_pressure(thermo_params, aux_gm.T[k], TD.Liquid())
         # eq. 37 in pressel et al and the def of RH
         RH = prof_RH(z)
         denom = (prof_p(z) - pv_star + (1 / molmass_ratio) * pv_star * RH / 100)
         qv_star = pv_star * (1 / molmass_ratio) / denom
         aux_gm.q_tot[k] = qv_star * RH / 100
         phase_part = TD.PhasePartition(aux_gm.q_tot[k], FT(0), FT(0)) # initial state is not saturated
-        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(param_set, aux_gm.T[k], p[k], phase_part)
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(thermo_params, aux_gm.T[k], p[k], phase_part)
         aux_gm.tke[k] = prof_tke(z)
     end
 end
 
 function surface_params(case::TRMM_LBA, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     # zrough = 1.0e-4 # not actually used, but initialized to reasonable value
     qsurface::FT = 22.45e-3 # kg/kg
     θ_surface::FT = (273.15 + 23)
-    ts = TD.PhaseEquil_pθq(param_set, p_f_surf, θ_surface, qsurface)
-    Tsurface = TD.air_temperature(param_set, ts)
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
     ustar::FT = 0.28 # this is taken from Bomex -- better option is to approximate from LES tke above the surface
     lhf = t -> 554 * max(0, cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)))^FT(1.3)
     shf = t -> 270 * max(0, cos(FT(π) / 2 * ((FT(5.25) * 3600 - t) / FT(5.25) / 3600)))^FT(1.5)
@@ -678,13 +694,15 @@ ForcingBase(case::ARM_SGP, param_set::APS; kwargs...) =
     ForcingBase(get_forcing_type(case); apply_coriolis = true, coriolis_param = 8.5e-5)
 
 function surface_ref_state(::ARM_SGP, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 970.0 * 100 #Pressure at ground
     Tg = 299.0   # surface values for reference state (RS) which outputs  p, ρ
     qtg = 15.2 / 1000 #Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::ARM_SGP, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TC.thermodynamics_params(param_set)
     # ARM_SGP inputs
     prog_gm = TC.center_prog_grid_mean(state)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -702,22 +720,23 @@ function initialize_profiles(::ARM_SGP, grid::Grid, param_set, state; kwargs...)
         z = grid.zc[k].z
         # TODO figure out how to use ts here
         phase_part = TD.PhasePartition(aux_gm.q_tot[k], aux_gm.q_liq[k], FT(0))
-        Π = TD.exner_given_pressure(param_set, p[k], phase_part)
+        Π = TD.exner_given_pressure(thermo_params, p[k], phase_part)
         prog_gm_u[k] = prof_u(z)
         aux_gm.q_tot[k] = prof_q_tot(z)
         aux_gm.T[k] = prof_θ_liq_ice(z) * Π
-        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(param_set, aux_gm.T[k], p[k], phase_part)
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp_given_pressure(thermo_params, aux_gm.T[k], p[k], phase_part)
         aux_gm.tke[k] = prof_tke(z)
     end
 end
 
 function surface_params(case::ARM_SGP, surf_ref_state, param_set; Ri_bulk_crit)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
     qsurface::FT = 15.2e-3 # kg/kg
     θ_surface::FT = 299.0
-    ts = TD.PhaseEquil_pθq(param_set, p_f_surf, θ_surface, qsurface)
-    Tsurface = TD.air_temperature(param_set, ts)
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, θ_surface, qsurface)
+    Tsurface = TD.air_temperature(thermo_params, ts)
     ustar::FT = 0.28 # this is taken from Bomex -- better option is to approximate from LES tke above the surface
 
     t_Sur_in = arr_type(FT[0.0, 4.0, 6.5, 7.5, 10.0, 12.5, 14.5]) .* 3600 #LES time is in sec
@@ -740,13 +759,14 @@ function initialize_forcing(::ARM_SGP, forcing, grid::Grid, state, param_set)
 end
 
 function update_forcing(::ARM_SGP, grid, state, t::Real, param_set)
+    thermo_params = TC.thermodynamics_params(param_set)
     aux_gm = TC.center_aux_grid_mean(state)
     ts_gm = TC.center_aux_grid_mean(state).ts
     prog_gm = TC.center_prog_grid_mean(state)
     p_c = prog_gm.ρ
     FT = TC.float_type(state)
     @inbounds for k in real_center_indices(grid)
-        Π = TD.exner(param_set, ts_gm[k])
+        Π = TD.exner(thermo_params, ts_gm[k])
         z = grid.zc[k].z
         aux_gm.dTdt_hadv[k] = APL.ARM_SGP_dTdt(FT)(t, z)
         aux_gm.dqtdt_hadv[k] = APL.ARM_SGP_dqtdt(FT)(Π, t, z)
@@ -761,13 +781,15 @@ end
 ForcingBase(case::GATE_III, param_set::APS; kwargs...) = ForcingBase(get_forcing_type(case); apply_coriolis = false)
 
 function surface_ref_state(::GATE_III, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1013.0 * 100  #Pressure at ground
     Tg = 299.184   # surface values for reference state (RS) which outputs p, ρ
     qtg = 16.5 / 1000 #Total water mixing ratio at surface
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::GATE_III, grid::Grid, param_set, state; kwargs...)
+    thermo_params = TC.thermodynamics_params(param_set)
     FT = TC.float_type(state)
     aux_gm = TC.center_aux_grid_mean(state)
     prog_gm = TC.center_prog_grid_mean(state)
@@ -779,14 +801,15 @@ function initialize_profiles(::GATE_III, grid::Grid, param_set, state; kwargs...
         aux_gm.q_tot[k] = APL.GATE_III_q_tot(FT)(z)
         aux_gm.T[k] = APL.GATE_III_T(FT)(z)
         prog_gm_u[k] = APL.GATE_III_u(FT)(z)
-        ts = TD.PhaseEquil_pTq(param_set, p[k], aux_gm.T[k], aux_gm.q_tot[k])
-        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp(param_set, ts)
+        ts = TD.PhaseEquil_pTq(thermo_params, p[k], aux_gm.T[k], aux_gm.q_tot[k])
+        aux_gm.θ_liq_ice[k] = TD.liquid_ice_pottemp(thermo_params, ts)
         aux_gm.tke[k] = APL.GATE_III_tke(FT)(z)
     end
 end
 
 function surface_params(case::GATE_III, surf_ref_state, param_set; kwargs...)
-    p_f_surf = TD.air_pressure(param_set, surf_ref_state)
+    thermo_params = TC.thermodynamics_params(param_set)
+    p_f_surf = TD.air_pressure(thermo_params, surf_ref_state)
     FT = eltype(p_f_surf)
 
     qsurface::FT = 16.5 / 1000.0 # kg/kg
@@ -796,8 +819,8 @@ function surface_params(case::GATE_III, surf_ref_state, param_set; kwargs...)
     Tsurface::FT = 299.184
 
     # For GATE_III we provide values of transfer coefficients
-    ts = TD.PhaseEquil_pθq(param_set, p_f_surf, Tsurface, qsurface)
-    qsurface = TD.q_vap_saturation(param_set, ts)
+    ts = TD.PhaseEquil_pθq(thermo_params, p_f_surf, Tsurface, qsurface)
+    qsurface = TD.q_vap_saturation(thermo_params, ts)
     kwargs = (; Tsurface, qsurface, cm, ch, kwargs...)
     return TC.FixedSurfaceCoeffs(FT; kwargs...)
 end
@@ -817,12 +840,13 @@ end
 #####
 
 function surface_ref_state(::DYCOMS_RF01, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1017.8 * 100.0
     qtg = 9.0 / 1000.0
     θ_surf = 289.0
-    ts = TD.PhaseEquil_pθq(param_set, Pg, θ_surf, qtg)
-    Tg = TD.air_temperature(param_set, ts)
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    ts = TD.PhaseEquil_pθq(thermo_params, Pg, θ_surf, qtg)
+    Tg = TD.air_temperature(thermo_params, ts)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::DYCOMS_RF01, grid::Grid, param_set, state; kwargs...)
@@ -906,12 +930,13 @@ end
 #####
 
 function surface_ref_state(::DYCOMS_RF02, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1017.8 * 100.0
     qtg = 9.0 / 1000.0
     θ_surf = 288.3
-    ts = TD.PhaseEquil_pθq(param_set, Pg, θ_surf, qtg)
-    Tg = TD.air_temperature(param_set, ts)
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    ts = TD.PhaseEquil_pθq(thermo_params, Pg, θ_surf, qtg)
+    Tg = TD.air_temperature(thermo_params, ts)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::DYCOMS_RF02, grid::Grid, param_set, state; kwargs...)
@@ -1002,10 +1027,11 @@ function ForcingBase(case::GABLS, param_set::APS; kwargs...)
 end
 
 function surface_ref_state(::GABLS, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1.0e5  #Pressure at ground,
     Tg = 265.0  #Temperature at ground,
     qtg = 0.0
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 function initialize_profiles(::GABLS, grid::Grid, param_set, state; kwargs...)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -1057,10 +1083,11 @@ end
 ForcingBase(case::DryBubble, param_set::APS; kwargs...) = ForcingBase(get_forcing_type(case); apply_coriolis = false)
 
 function surface_ref_state(::DryBubble, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     Pg = 1.0e5  #Pressure at ground
     Tg = 296.0
     qtg = 1.0e-5
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::DryBubble, grid::Grid, param_set, state; kwargs...)
@@ -1142,6 +1169,7 @@ function ForcingBase(case::LES_driven_SCM, param_set::APS; kwargs...)
 end
 
 function surface_ref_state(::LES_driven_SCM, param_set::APS, namelist)
+    thermo_params = TC.thermodynamics_params(param_set)
     les_filename = namelist["meta"]["lesfile"]
 
     Pg, Tg, qtg = NC.Dataset(les_filename, "r") do data
@@ -1154,7 +1182,7 @@ function surface_ref_state(::LES_driven_SCM, param_set::APS, namelist)
         qtg = ql_ground + qv_ground + qi_ground #Total water mixing ratio at surface
         (Pg, Tg, qtg)
     end
-    return TD.PhaseEquil_pTq(param_set, Pg, Tg, qtg)
+    return TD.PhaseEquil_pTq(thermo_params, Pg, Tg, qtg)
 end
 
 function initialize_profiles(::LES_driven_SCM, grid::Grid, param_set, state; LESDat)

--- a/driver/Surface.jl
+++ b/driver/Surface.jl
@@ -29,8 +29,9 @@ function get_surface(
     lhf = TC.latent_heat_flux(surf_params, t)
     Ri_bulk_crit = surf_params.Ri_bulk_crit
     zrough = surf_params.zrough
+    thermo_params = TC.thermodynamics_params(param_set)
 
-    ts_sfc = TD.PhaseEquil_pTq(param_set, p_f_surf, Tsurface, qsurface)
+    ts_sfc = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
     ts_in = aux_gm.ts[kc_surf]
     universal_func = UF.Businger()
     scheme = SF.FVScheme()
@@ -69,7 +70,7 @@ function get_surface(
         ρu_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτxz,
         ρv_flux = surf_params.zero_uv_fluxes ? FT(0) : result.ρτyz,
         ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
         wstar = convective_vel,
         ρq_liq_flux = FT(0),
         ρq_ice_flux = FT(0),
@@ -99,12 +100,13 @@ function get_surface(
     cm = surf_params.cm(zc_surf)
     ch = surf_params.ch(zc_surf)
     Ri_bulk_crit = surf_params.Ri_bulk_crit
+    thermo_params = TC.thermodynamics_params(param_set)
 
     universal_func = UF.Businger()
     scheme = SF.FVScheme()
     z_sfc = FT(0)
     z_in = grid.zc[kc_surf].z
-    ts_sfc = TD.PhaseEquil_pθq(param_set, p_f_surf, Tsurface, qsurface)
+    ts_sfc = TD.PhaseEquil_pθq(thermo_params, p_f_surf, Tsurface, qsurface)
     ts_in = aux_gm.ts[kc_surf]
     u_sfc = SA.SVector{2, FT}(0, 0)
     u_in = SA.SVector{2, FT}(u_gm_surf, v_gm_surf)
@@ -127,7 +129,7 @@ function get_surface(
         ρu_flux = result.ρτxz,
         ρv_flux = result.ρτyz,
         ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
         bflux = result.buoy_flux,
         wstar = convective_vel,
         ρq_liq_flux = FT(0),
@@ -158,10 +160,11 @@ function get_surface(
     qsurface = TC.surface_q_tot(surf_params, t)
     zrough = surf_params.zrough
     Ri_bulk_crit = surf_params.Ri_bulk_crit
+    thermo_params = TC.thermodynamics_params(param_set)
 
     universal_func = UF.Businger()
     scheme = SF.FVScheme()
-    ts_sfc = TD.PhaseEquil_pTq(param_set, p_f_surf, Tsurface, qsurface)
+    ts_sfc = TD.PhaseEquil_pTq(thermo_params, p_f_surf, Tsurface, qsurface)
     ts_in = ts_gm[kc_surf]
 
     u_sfc = SA.SVector{2, FT}(0, 0)
@@ -184,7 +187,7 @@ function get_surface(
         ρu_flux = result.ρτxz,
         ρv_flux = result.ρτyz,
         ρe_tot_flux = shf + lhf,
-        ρq_tot_flux = lhf / TD.latent_heat_vapor(param_set, ts_in),
+        ρq_tot_flux = lhf / TD.latent_heat_vapor(thermo_params, ts_in),
         bflux = result.buoy_flux,
         wstar = convective_vel,
         ρq_liq_flux = FT(0),

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -110,6 +110,7 @@ function compute_diagnostics!(
     t::Real,
     calibrate_io::Bool,
 ) where {D <: CC.Fields.FieldVector}
+    thermo_params = TC.thermodynamics_params(param_set)
     FT = TC.float_type(state)
     N_up = TC.n_updrafts(edmf)
     aux_gm = TC.center_aux_grid_mean(state)
@@ -137,8 +138,8 @@ function compute_diagnostics!(
 
     surf = get_surface(surf_params, grid, state, t, param_set)
 
-    @. aux_gm.s = TD.specific_entropy(param_set, ts_gm)
-    @. aux_en.s = TD.specific_entropy(param_set, ts_en)
+    @. aux_gm.s = TD.specific_entropy(thermo_params, ts_gm)
+    @. aux_en.s = TD.specific_entropy(thermo_params, ts_en)
 
     @inbounds for k in TC.real_center_indices(grid)
         @inbounds for i in 1:N_up
@@ -155,7 +156,7 @@ function compute_diagnostics!(
                     aux_up[i].q_tot[k],
                     thermo_args...,
                 )
-                TD.specific_entropy(param_set, ts_up)
+                TD.specific_entropy(thermo_params, ts_up)
             else
                 FT(0)
             end

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -8,10 +8,11 @@ import Thermodynamics
 const TD = Thermodynamics
 
 function initialize_edmf(edmf::TC.EDMFModel, grid::TC.Grid, state::TC.State, surf_params, param_set::APS, t::Real, case)
+    thermo_params = TC.thermodynamics_params(param_set)
     initialize_covariance(edmf, grid, state)
     aux_gm = TC.center_aux_grid_mean(state)
     ts_gm = aux_gm.ts
-    @. aux_gm.θ_virt = TD.virtual_pottemp(param_set, ts_gm)
+    @. aux_gm.θ_virt = TD.virtual_pottemp(thermo_params, ts_gm)
     surf = get_surface(surf_params, grid, state, t, param_set)
     if case isa Cases.DryBubble
         initialize_updrafts_DryBubble(edmf, grid, state)

--- a/src/EDMF_Precipitation.jl
+++ b/src/EDMF_Precipitation.jl
@@ -86,6 +86,7 @@ function compute_precipitation_sink_tendencies(
     param_set::APS,
     Δt::Real,
 )
+    thermo_params = thermodynamics_params(param_set)
     aux_gm = center_aux_grid_mean(state)
     aux_tc = center_aux_turbconv(state)
     prog_gm = center_prog_grid_mean(state)
@@ -104,23 +105,23 @@ function compute_precipitation_sink_tendencies(
         T_gm = aux_gm.T[k]
         # When we fuse loops, this should hopefully disappear
         ts = ts_gm[k]
-        q = TD.PhasePartition(param_set, ts)
-        qv = TD.vapor_specific_humidity(param_set, ts)
+        q = TD.PhasePartition(thermo_params, ts)
+        qv = TD.vapor_specific_humidity(thermo_params, ts)
 
-        Π_m = TD.exner(param_set, ts)
-        c_pm = TD.cp_m(param_set, ts)
-        c_vm = TD.cv_m(param_set, ts)
-        R_m = TD.gas_constant_air(param_set, ts)
+        Π_m = TD.exner(thermo_params, ts)
+        c_pm = TD.cp_m(thermo_params, ts)
+        c_vm = TD.cv_m(thermo_params, ts)
+        R_m = TD.gas_constant_air(thermo_params, ts)
         R_v = TCP.R_v(param_set)
         L_v0 = TCP.LH_v0(param_set)
         L_s0 = TCP.LH_s0(param_set)
-        L_v = TD.latent_heat_vapor(param_set, ts)
-        L_s = TD.latent_heat_sublim(param_set, ts)
-        L_f = TD.latent_heat_fusion(param_set, ts)
+        L_v = TD.latent_heat_vapor(thermo_params, ts)
+        L_s = TD.latent_heat_sublim(thermo_params, ts)
+        L_f = TD.latent_heat_fusion(thermo_params, ts)
 
-        I_l = TD.internal_energy_liquid(param_set, ts)
-        I_i = TD.internal_energy_ice(param_set, ts)
-        I = TD.internal_energy(param_set, ts)
+        I_l = TD.internal_energy_liquid(thermo_params, ts)
+        I_i = TD.internal_energy_ice(thermo_params, ts)
+        I = TD.internal_energy(thermo_params, ts)
         Φ = geopotential(param_set, grid.zc.z[k])
 
         α_evp = TCP.microph_scaling(param_set)

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -252,6 +252,7 @@ function affect_filter!(edmf::EDMFModel, grid::Grid, state::State, param_set::AP
 end
 
 function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBase, param_set::APS)
+    thermo_params = thermodynamics_params(param_set)
     FT = float_type(state)
     N_up = n_updrafts(edmf)
     kc_surf = kc_surface(grid)
@@ -264,7 +265,7 @@ function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::Su
     prog_up_f = face_prog_updrafts(state)
     aux_bulk = center_aux_bulk(state)
     ts_gm = aux_gm.ts
-    cp = TD.cp_m(param_set, ts_gm[kc_surf])
+    cp = TD.cp_m(thermo_params, ts_gm[kc_surf])
     ρ_c = prog_gm.ρ
     ρ_f = aux_gm_f.ρ
     ae_surf::FT = 1
@@ -345,12 +346,13 @@ function θ_surface_bc(
     i::Int,
     param_set::APS,
 )::FT where {FT}
+    thermo_params = thermodynamics_params(param_set)
     aux_gm = center_aux_grid_mean(state)
     prog_gm = center_prog_grid_mean(state)
     ρ_c = prog_gm.ρ
     kc_surf = kc_surface(grid)
     ts_gm = aux_gm.ts
-    c_p = TD.cp_m(param_set, ts_gm[kc_surf])
+    c_p = TD.cp_m(thermo_params, ts_gm[kc_surf])
     UnPack.@unpack ustar, zLL, oblength, ρLL = surface_helper(surf, grid, state)
 
     surf.bflux > 0 || return FT(0)

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -157,4 +157,6 @@ include("closures/nondimensional_exchange_functions.jl")
 include("closures/mixing_length.jl")
 include("closures/buoyancy_gradients.jl")
 
+thermodynamics_params(ps::APS) = ps.thermo_params
+
 end

--- a/src/closures/buoyancy_gradients.jl
+++ b/src/closures/buoyancy_gradients.jl
@@ -14,21 +14,22 @@ function buoyancy_gradients(
     bg_model::EnvBuoyGrad{FT, EBG},
 ) where {FT <: Real, EBG <: AbstractEnvBuoyGradClosure}
 
+    thermo_params = thermodynamics_params(param_set)
     g = TCP.grav(param_set)
     molmass_ratio = TCP.molmass_ratio(param_set)
     R_d = TCP.R_d(param_set)
     R_v = TCP.R_v(param_set)
 
     phase_part = TD.PhasePartition(FT(0), FT(0), FT(0)) # assuming R_d = R_m
-    Π = TD.exner_given_pressure(param_set, bg_model.p, phase_part)
+    Π = TD.exner_given_pressure(thermo_params, bg_model.p, phase_part)
 
     ∂b∂θv = g * (R_d * bg_model.ρ / bg_model.p) * Π
 
     if bg_model.en_cld_frac > 0.0
         ts_sat = thermo_state_pθq(param_set, bg_model.p, bg_model.θ_liq_ice_sat, bg_model.qt_sat)
-        phase_part = TD.PhasePartition(param_set, ts_sat)
-        lh = TD.latent_heat_liq_ice(param_set, phase_part)
-        cp_m = TD.cp_m(param_set, ts_sat)
+        phase_part = TD.PhasePartition(thermo_params, ts_sat)
+        lh = TD.latent_heat_liq_ice(thermo_params, phase_part)
+        cp_m = TD.cp_m(thermo_params, ts_sat)
         ∂b∂θl_sat = (
             ∂b∂θv * (1 + molmass_ratio * (1 + lh / R_v / bg_model.t_sat) * bg_model.qv_sat - bg_model.qt_sat) /
             (1 + lh * lh / cp_m / R_v / bg_model.t_sat / bg_model.t_sat * bg_model.qv_sat)

--- a/src/thermodynamics.jl
+++ b/src/thermodynamics.jl
@@ -2,12 +2,14 @@ function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT) whe
     # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
     # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
     config = ()
-    return TD.PhaseEquil_pθq(param_set, p, θ_liq_ice, q_tot, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseEquil_pθq(thermo_params, p, θ_liq_ice, q_tot, config...)
 end
 function thermo_state_pθq(param_set::APS, p::FT, θ_liq_ice::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
     config = ()
     q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    return TD.PhaseNonEquil_pθq(param_set, p, θ_liq_ice, q, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_pθq(thermo_params, p, θ_liq_ice, q, config...)
 end
 
 
@@ -15,26 +17,28 @@ function thermo_state_peq(param_set::APS, p::FT, e_int::FT, q_tot::FT) where {FT
     # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
     # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
     config = ()
-    return TD.PhaseEquil_peq(param_set, p, e_int, q_tot, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseEquil_peq(thermo_params, p, e_int, q_tot, config...)
 end
 
 function thermo_state_peq(param_set::APS, p::FT, e_int::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
     config = ()
     q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    return TD.PhaseNonEquil_peq(param_set, p, e_int, q, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_peq(thermo_params, p, e_int, q, config...)
 end
 
 function thermo_state_phq(param_set::APS, p::FT, h::FT, q_tot::FT) where {FT}
-    # config = (50, 1e-3, RootSolvers.RegulaFalsiMethod)
-    # config = (50, 1e-3, RootSolvers.NewtonMethodAD)
     config = ()
-    return TD.PhaseEquil_phq(param_set, p, h, q_tot, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseEquil_phq(thermo_params, p, h, q_tot, config...)
 end
 
 function thermo_state_phq(param_set::APS, p::FT, h::FT, q_tot::FT, q_liq::FT, q_ice::FT) where {FT}
     config = ()
     q = TD.PhasePartition(q_tot, q_liq, q_ice)
-    return TD.PhaseNonEquil_phq(param_set, p, h, q, config...)
+    thermo_params = thermodynamics_params(param_set)
+    return TD.PhaseNonEquil_phq(thermo_params, p, h, q, config...)
 end
 
 function geopotential(param_set, z::FT) where {FT}
@@ -44,8 +48,9 @@ end
 
 # TODO: move to Thermodynamics.jl
 function total_enthalpy(param_set::APS, e_tot::FT, ts) where {FT}
-    Rm = TD.gas_constant_air(param_set, ts)
-    T = TD.air_temperature(param_set, ts)
+    thermo_params = thermodynamics_params(param_set)
+    Rm = TD.gas_constant_air(thermo_params, ts)
+    T = TD.air_temperature(thermo_params, ts)
     return e_tot + Rm * T
 end
 


### PR DESCRIPTION
This PR:
 - Adds a wrapper `thermodynamics_params(ps) = ps.thermo_params` in TC, and uses this to extract the thermodynamics parameter set from the `param_set`. For now, it just returns a `ThermodynamicsParameters` that we define locally (and overload the appropriate clima parameter methods). When we change to the new parameter system, we can just change `ThermodynamicsParameters` to `TD.ThermodynamicsParameters` with the appropriate parameters.

Arguably, there are some places where we could extract the thermo params and pass them into function calls to limit which variables those functions have access to, however, if we need to (for example) add ice contributions to some term (which need microphysics parameters) then we'd need to change the interface back to include more parameters. So, the approach taken here is: extract the thermo params _just before_ calling `TD.thermo_function`. We can apply the same pattern to SurfaceFluxes and CloudMicryophysics. That said, now that I'm reviewing this, our thermo wrappers may be an exception to this since they're only there for experimenting with the thermo configs..

This is the best way I can think about bracing for impact when we switch to the new parameter system.