### PR TITLE
Move overwrite namelist into a separate function

### DIFF
--- a/integration_tests/driver.jl
+++ b/integration_tests/driver.jl
@@ -21,74 +21,12 @@ using Test
 const tc_dir = pkgdir(TurbulenceConvection)
 include(joinpath(tc_dir, "driver", "main.jl"))
 include(joinpath(tc_dir, "driver", "generate_namelist.jl"))
+include(joinpath(tc_dir, "integration_tests", "overwrite_namelist.jl"))
 import .NameList
 
 namelist = NameList.default_namelist(case_name)
 namelist["meta"]["uuid"] = "01$suffix"
-
-#! format: off
-overwrite_namelist_map = Dict(
-"sgs"                     => (nl, pa, key) -> (nl["thermodynamics"]["sgs"] = pa[key]),
-"quad_type"               => (nl, pa, key) -> (nl["thermodynamics"]["quadrature_type"] = pa[key]),
-"entr"                    => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = pa[key]),
-"entr_dim_scale"          => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = pa[key]),
-"detr_dim_scale"          => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["detr_dim_scale"] = pa[key]),
-"area_limiter_power"      => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["area_limiter_power"] = pa[key]),
-"nn_ent_biases"           => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["nn_ent_biases"] = pa[key]),
-"stoch_entr"              => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = pa[key]),
-"t_max"                   => (nl, pa, key) -> (nl["time_stepping"]["t_max"] = pa[key]),
-"adapt_dt"                => (nl, pa, key) -> (nl["time_stepping"]["adapt_dt"] = pa[key]),
-"dt"                      => (nl, pa, key) -> (nl["time_stepping"]["dt_min"] = pa[key]),
-"dt_max"                  => (nl, pa, key) -> (nl["time_stepping"]["dt_max"] = pa[key]),
-"calibrate_io"            => (nl, pa, key) -> (nl["stats_io"]["calibrate_io"] = pa[key]),
-"stretch_grid"            => (nl, pa, key) -> (nl["grid"]["stretch"]["flag"] = pa[key]),
-"skip_io"                 => (nl, pa, key) -> (nl["stats_io"]["skip"] = pa[key]),
-"n_up"                    => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
-"moisture_model"          => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
-"precipitation_model"     => (nl, pa, key) -> (nl["microphysics"]["precipitation_model"] = pa[key]),
-"precip_fraction_model"   => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_model"] = pa[key]),
-"prescribed_precip_frac_value" => (nl, pa, key) -> (nl["microphysics"]["prescribed_precip_frac_value"] = pa[key]),
-"precip_fraction_limiter" => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_limiter"] = pa[key]),
-"thermo_covariance_model" => (nl, pa, key) -> (nl["thermodynamics"]["thermo_covariance_model"] = pa[key]),
-"config"                  => (nl, pa, key) -> (nl["config"] = pa[key]),
-"set_src_seed"            => (nl, pa, key) -> (nl["set_src_seed"] = pa[key]),
-"test_duals"              => (nl, pa, key) -> (nl["test_duals"] = pa[key]),
-)
-no_overwrites = (
-    "case", # default_namelist already overwrites namelist["meta"]["casename"]
-    "skip_post_proc",
-    "skip_tests",
-    "broken_tests",
-    "trunc_field_type_print",
-    "suffix",
-)
-#! format: on
-for key in keys(overwrite_namelist_map)
-    if !isnothing(parsed_args[key])
-        @warn "Parameter `$key` overwriting namelist"
-        overwrite_namelist_map[key](namelist, parsed_args, key)
-    end
-end
-
-# Error check overwrites:
-# A tuple of strings for all CL arguments that do _not_
-overwrite_list = map(collect(keys(overwrite_namelist_map))) do key
-    (key, !isnothing(parsed_args[key]))
-end
-filter!(x -> x[2], overwrite_list)
-cl_list = map(collect(keys(parsed_args))) do key
-    (key, !isnothing(parsed_args[key]) && !(key in no_overwrites))
-end
-filter!(x -> x[2], cl_list)
-if length(overwrite_list) ≠ length(cl_list)
-    error(
-        string(
-            "A prescribed CL argument is not overwriting the namelist.",
-            "It seems that a CL argument was added, and the `no_overwrites`",
-            "or `overwrite_namelist_map` must be updated.",
-        ),
-    )
-end
+overwrite_namelist!(namelist, parsed_args)
 
 integrator, ds_tc_filenames, return_code = main(namelist);
 

--- a/integration_tests/overwrite_namelist.jl
+++ b/integration_tests/overwrite_namelist.jl
@@ -1,0 +1,66 @@
+function overwrite_namelist!(namelist, parsed_args)
+    #! format: off
+    overwrite_namelist_map = Dict(
+    "sgs"                          => (nl, pa, key) -> (nl["thermodynamics"]["sgs"] = pa[key]),
+    "quad_type"                    => (nl, pa, key) -> (nl["thermodynamics"]["quadrature_type"] = pa[key]),
+    "entr"                         => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entrainment"] = pa[key]),
+    "entr_dim_scale"               => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["entr_dim_scale"] = pa[key]),
+    "detr_dim_scale"               => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["detr_dim_scale"] = pa[key]),
+    "area_limiter_power"           => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["area_limiter_power"] = pa[key]),
+    "nn_ent_biases"                => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["nn_ent_biases"] = pa[key]),
+    "stoch_entr"                   => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["stochastic_entrainment"] = pa[key]),
+    "t_max"                        => (nl, pa, key) -> (nl["time_stepping"]["t_max"] = pa[key]),
+    "adapt_dt"                     => (nl, pa, key) -> (nl["time_stepping"]["adapt_dt"] = pa[key]),
+    "dt"                           => (nl, pa, key) -> (nl["time_stepping"]["dt_min"] = pa[key]),
+    "dt_max"                       => (nl, pa, key) -> (nl["time_stepping"]["dt_max"] = pa[key]),
+    "calibrate_io"                 => (nl, pa, key) -> (nl["stats_io"]["calibrate_io"] = pa[key]),
+    "stretch_grid"                 => (nl, pa, key) -> (nl["grid"]["stretch"]["flag"] = pa[key]),
+    "skip_io"                      => (nl, pa, key) -> (nl["stats_io"]["skip"] = pa[key]),
+    "n_up"                         => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
+    "moisture_model"               => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
+    "precipitation_model"          => (nl, pa, key) -> (nl["microphysics"]["precipitation_model"] = pa[key]),
+    "precip_fraction_model"        => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_model"] = pa[key]),
+    "prescribed_precip_frac_value" => (nl, pa, key) -> (nl["microphysics"]["prescribed_precip_frac_value"] = pa[key]),
+    "precip_fraction_limiter"      => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_limiter"] = pa[key]),
+    "thermo_covariance_model"      => (nl, pa, key) -> (nl["thermodynamics"]["thermo_covariance_model"] = pa[key]),
+    "config"                       => (nl, pa, key) -> (nl["config"] = pa[key]),
+    "set_src_seed"                 => (nl, pa, key) -> (nl["set_src_seed"] = pa[key]),
+    "test_duals"                   => (nl, pa, key) -> (nl["test_duals"] = pa[key]),
+    )
+    no_overwrites = (
+        "case", # default_namelist already overwrites namelist["meta"]["casename"]
+        "skip_post_proc",
+        "skip_tests",
+        "broken_tests",
+        "trunc_field_type_print",
+        "suffix",
+    )
+    #! format: on
+    for key in keys(overwrite_namelist_map)
+        if !isnothing(parsed_args[key])
+            @warn "Parameter `$key` overwriting namelist"
+            overwrite_namelist_map[key](namelist, parsed_args, key)
+        end
+    end
+
+    # Error check overwrites:
+    # A tuple of strings for all CL arguments that do _not_
+    overwrite_list = map(collect(keys(overwrite_namelist_map))) do key
+        (key, !isnothing(parsed_args[key]))
+    end
+    filter!(x -> x[2], overwrite_list)
+    cl_list = map(collect(keys(parsed_args))) do key
+        (key, !isnothing(parsed_args[key]) && !(key in no_overwrites))
+    end
+    filter!(x -> x[2], cl_list)
+    if length(overwrite_list) ≠ length(cl_list)
+        error(
+            string(
+                "A prescribed CL argument is not overwriting the namelist.",
+                "It seems that a CL argument was added, and the `no_overwrites`",
+                "or `overwrite_namelist_map` must be updated.",
+            ),
+        )
+    end
+    return nothing
+end


### PR DESCRIPTION
This PR moves all of the namelist overwrite logic and logging into a separate function, so that we can more easily configure non-vanilla jobs for other analysis (e.g., performance).