### PR TITLE
Fix subtype bug, remove unused method definition

### DIFF
--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -103,7 +103,7 @@ function print_repl_script(str)
     ib *= """(s, parsed_args) = parse_commandline();\n"""
     parsed_args = parsed_args_from_command_line_flags(str)
     for (flag, val) in parsed_args
-        if val isa String
+        if val isa AbstractString
             ib *= "parsed_args[\"$flag\"] = \"$val\";\n"
         else
             ib *= "parsed_args[\"$flag\"] = $val;\n"

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -104,11 +104,6 @@ function first_face_space(fv::CC.Fields.FieldVector)
     error("Unfound space")
 end
 
-function set_z!(field::CC.Fields.Field)
-    z = CC.Fields.coordinate_field(axes(field)).z
-    @. field = CCG.Covariant12Vector(CCG.UVVector(u(z), v(z)))
-end
-
 const CallableZType = Union{Function, Dierckx.Spline1D}
 
 function set_z!(field::CC.Fields.Field, u::CallableZType = x -> x, v::CallableZType = y -> y)


### PR DESCRIPTION
This PR:

 - Removes an unused method, `set_z!`, which I forgot to remove in #1173.
 - Fixes a sub/super type bug: need to use `val isa AbstractString` in `print_repl_script`.