### PR TITLE
Fully run duals test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -164,7 +164,7 @@ steps:
     steps:
 
       - label: ":partly_sunny: Bomex duals"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --test_duals true --skip_tests true --skip_io true --skip_post_proc true --dt 1.0 --t_max 2.0 --suffix _duals"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --test_duals true --suffix _duals"
         artifact_paths: "Output.Bomex.01_duals/stats/comparison/*"
 
   - group: "Performance monitoring"

--- a/driver/NetCDFIO.jl
+++ b/driver/NetCDFIO.jl
@@ -121,6 +121,12 @@ end
 ##### Performance critical IO
 #####
 
+write_field(
+    self::NetCDFIO_Stats,
+    var_name::String,
+    data::T,
+    group,
+) where {FT <: ForwardDiff.Dual, T <: AbstractArray{FT}} = write_field(self, var_name, ForwardDiff.value.(data), group)
 function write_field(
     self::NetCDFIO_Stats,
     var_name::String,
@@ -135,6 +141,8 @@ function write_field(
     # @inbounds var[end, :] = data :: T
 end
 
+add_write_field(ds, var_name::String, data::T, args...) where {FT <: ForwardDiff.Dual, T <: AbstractArray{FT}} =
+    add_write_field(ds, var_name, ForwardDiff.value.(data), args...)
 function add_write_field(
     ds,
     var_name::String,
@@ -149,6 +157,7 @@ function add_write_field(
     return nothing
 end
 
+write_ts(self, var_name, data::ForwardDiff.Dual) = write_ts(self, var_name, ForwardDiff.value(data))
 function write_ts(self::NetCDFIO_Stats, var_name::String, data::FT) where {FT <: AbstractFloat}
     # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
     @inbounds self.vars["timeseries"][var_name][end] = data::FT
@@ -157,6 +166,7 @@ function write_ts(self::NetCDFIO_Stats, var_name::String, data::FT) where {FT <:
     # @inbounds var[end+1] = data :: FT
 end
 
+write_simulation_time(self, t::ForwardDiff.Dual) = write_simulation_time(self, ForwardDiff.value(t))
 function write_simulation_time(self::NetCDFIO_Stats, t::FT) where {FT <: AbstractFloat}
     # # Write to profiles group
     profile_t = self.profiles_grp["t"]

--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -105,6 +105,8 @@ function dt_max!(integrator)
     tendencies = ODE.get_du(integrator)
     prog = integrator.u
 
+    to_float(f) = f isa ForwardDiff.Dual ? ForwardDiff.value(f) : f
+
     for inds in TC.iterate_columns(prog.cent)
         state = TC.column_state(prog, aux, tendencies, inds...)
         grid = TC.Grid(state)
@@ -143,7 +145,7 @@ function dt_max!(integrator)
             # Check diffusion CFL (i.e., Fourier number)
             dt_max = min(dt_max, CFL_limit * Δzc[k]^2 / (max(KH[k], KM[k]) + eps(Float32)))
         end
-        TS.dt_max_edmf = dt_max
+        TS.dt_max_edmf = to_float(dt_max)
     end
 
     ODE.u_modified!(integrator, false)

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -182,7 +182,7 @@ function Simulation1d(namelist)
     forcing = Cases.ForcingBase(case, FT; Cases.forcing_kwargs(case, namelist)...)
 
     radiation = Cases.RadiationBase(case, FT)
-    TS = TimeStepping(FTD, namelist)
+    TS = TimeStepping(FT, namelist)
 
     Ri_bulk_crit::FTD = namelist["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"]
     les_data_kwarg = Cases.les_data_kwarg(case, namelist)
@@ -274,8 +274,8 @@ function initialize(sim::Simulation1d)
         initialize_edmf(edmf, grid, state, surf_params, param_set, t, case)
         if !skip_io
             stats = Stats[inds...]
-            initialize_io(stats.nc_filename, FT, io_nt.aux, io_nt.diagnostics)
-            initialize_io(stats.nc_filename, FT, ts_list)
+            initialize_io(stats.nc_filename, eltype(grid), io_nt.aux, io_nt.diagnostics)
+            initialize_io(stats.nc_filename, eltype(grid), ts_list)
         end
     end
 


### PR DESCRIPTION
This PR changes our duals test to fully run with duals: we will run (and test) the exact same vanilla Bomex case with Float64 and with Dual numbers.

If our duals test pass (our duals simulation output will be compared with the results from the vanilla Bomex), then everything regarding running TC with duals should be fine on the TC side. cc @dennisYatunin.

Next, I'll try initializing EDMFModel with Float64, but I'm not exactly sure how many changes that this will require.