### PR TITLE
Fix parsed_args_from_cl_args

### DIFF
--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -124,7 +124,7 @@ function parsed_args_from_command_line_flags(str, parsed_args = Dict())
     parsed_args_list = split(s, " ")
     @assert iseven(length(parsed_args_list))
     parsed_arg_pairs = map(1:2:(length(parsed_args_list) - 1)) do i
-        Pair(parsed_args_list[i], parsed_args_list[i + 1])
+        Pair(parsed_args_list[i], strip(parsed_args_list[i + 1], '\"'))
     end
     function parse_arg(val)
         for T in (Bool, Int, Float32, Float64)


### PR DESCRIPTION
A mirror of [CA#560](https://github.com/CliMA/ClimaAtmos.jl/pull/560).

This should fix the `"true""` in this REPL script:

```julia
using Revise; include("integration_tests/cli_options.jl");

(s, parsed_args) = parse_commandline();
parsed_args["case"] = "Bomex";
parsed_args["dt_max"] = 8.0;
parsed_args["suffix"] = "_n_up_2";
parsed_args["n_up"] = 2;
parsed_args["skip_tests"] = "true"";

include("integration_tests/driver.jl")
```