### PR TITLE
Update to 0.27.6 (fixed reference state)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.27.5"
+version = "0.27.6"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

- Minor release of theta-var branch that includes the MSE reference state fix, which should enable calibration of the deep convective cases without spurious results near the tropopause.