### PR TITLE
Add truncated GCM mesh back in

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,9 +97,9 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --sgs quadrature --quad_type gaussian --skip_tests true --suffix _gaussian"
         artifact_paths: "Output.Bomex.01_gaussian/stats/comparison/*"
 
-      - label: ":partly_sunny: Bomex with stretched grid"
-        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --stretch_grid true --skip_tests true --suffix _stretch_grid_true"
-        artifact_paths: "Output.Bomex.01_stretch_grid_true/stats/comparison/*"
+      - label: ":partly_sunny: LES_driven_SCM with stretched grid"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case LES_driven_SCM --stretch_grid true --skip_tests true --suffix _stretch_grid_true"
+        artifact_paths: "Output.LES_driven_SCM.01_stretch_grid_true/stats/comparison/*"
 
       - label: ":partly_sunny: Bomex with NN_nonlocal"
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Bomex --entr NN_nonlocal --entr_dim_scale inv_z --detr_dim_scale inv_z --area_limiter_power 0.0 --dt_max 2.0 --nn_ent_biases true --skip_tests true --suffix _NN_nonlocal"

--- a/driver/common_spaces.jl
+++ b/driver/common_spaces.jl
@@ -30,10 +30,8 @@ function make_horizontal_space(mesh, quad)
     return space
 end
 
-function make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
-    FT = eltype(z_max)
-    z_domain = CC.Domains.IntervalDomain(CCG.ZPoint(zero(z_max)), CCG.ZPoint(z_max); boundary_tags = (:bottom, :top))
-    z_mesh = CC.Meshes.IntervalMesh(z_domain, z_stretch; nelems = z_elem)
+function make_hybrid_spaces(h_space, z_mesh)
+    FT = CC.Geometry.float_type(z_mesh.domain)
     @info "z heights" z_mesh.faces
     z_topology = CC.Topologies.IntervalTopology(z_mesh)
     z_space = CC.Spaces.CenterFiniteDifferenceSpace(z_topology)
@@ -74,7 +72,30 @@ function construct_mesh(namelist; FT = Float64)
 
     z₀, z₁ = FT(0), FT(nz * Δz)
     z_stretch = CC.Meshes.Uniform()
-    return (; z_stretch, z_max = z₁, z_elem = nz)
+
+    z_mesh = if truncated_gcm_mesh
+        nzₛ = namelist["grid"]["stretch"]["nz"]
+        Δzₛ_surf = FT(namelist["grid"]["stretch"]["dz_surf"])
+        Δzₛ_top = FT(namelist["grid"]["stretch"]["dz_toa"])
+        zₛ_toa = FT(namelist["grid"]["stretch"]["z_toa"])
+        stretch = CC.Meshes.GeneralizedExponentialStretching(Δzₛ_surf, Δzₛ_top)
+        domain = CC.Domains.IntervalDomain(
+            CC.Geometry.ZPoint{FT}(z₀),
+            CC.Geometry.ZPoint{FT}(zₛ_toa),
+            boundary_tags = (:bottom, :top),
+        )
+        gcm_mesh = CC.Meshes.IntervalMesh(domain, stretch; nelems = nzₛ)
+        TC.TCMeshFromGCMMesh(gcm_mesh; z_max = z₁)
+    else
+        stretch = CC.Meshes.Uniform()
+        domain = CC.Domains.IntervalDomain(
+            CC.Geometry.ZPoint{FT}(z₀),
+            CC.Geometry.ZPoint{FT}(z₁),
+            boundary_tags = (:bottom, :top),
+        )
+        CC.Meshes.IntervalMesh(domain, stretch; nelems = nz)
+    end
+    return (; z_mesh)
 end
 
 
@@ -84,40 +105,16 @@ function get_spaces(namelist, param_set, FT)
         quad = CC.Spaces.Quadratures.GLL{2}()
         horizontal_mesh = cubed_sphere_mesh(; radius = FT(TCP.planet_radius(param_set)), h_elem)
         h_space = make_horizontal_space(horizontal_mesh, quad)
-        (; z_stretch, z_max, z_elem) = construct_mesh(namelist; FT = FT)
-        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
+        (; z_mesh) = construct_mesh(namelist; FT = FT)
+        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_mesh)
         center_space, face_space, svpc_space
     elseif namelist["config"] == "column" # single column (default)
         Δx = FT(1) # Note: This value shouldn't matter, since we only have 1 column.
         quad = CC.Spaces.Quadratures.GL{1}()
         horizontal_mesh = periodic_rectangle_mesh(; x_max = Δx, y_max = Δx, x_elem = 1, y_elem = 1)
         h_space = make_horizontal_space(horizontal_mesh, quad)
-        (; z_stretch, z_max, z_elem) = construct_mesh(namelist; FT = FT)
-        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_max, z_elem, z_stretch)
+        (; z_mesh) = construct_mesh(namelist; FT = FT)
+        center_space, face_space, svpc_space = make_hybrid_spaces(h_space, z_mesh)
         center_space, face_space, svpc_space
     end
-    # if truncated_gcm_mesh
-    #     nzₛ = namelist["grid"]["stretch"]["nz"]
-    #     Δzₛ_surf = FT(namelist["grid"]["stretch"]["dz_surf"])
-    #     Δzₛ_top = FT(namelist["grid"]["stretch"]["dz_toa"])
-    #     zₛ_toa = FT(namelist["grid"]["stretch"]["z_toa"])
-    #     stretch = CC.Meshes.GeneralizedExponentialStretching(Δzₛ_surf, Δzₛ_top)
-    #     domain = CC.Domains.IntervalDomain(
-    #         CC.Geometry.ZPoint{FT}(z₀),
-    #         CC.Geometry.ZPoint{FT}(zₛ_toa),
-    #         boundary_tags = (:bottom, :top),
-    #     )
-    #     gcm_mesh = CC.Meshes.IntervalMesh(domain, stretch; nelems = nzₛ)
-    #     mesh = TC.TCMeshFromGCMMesh(gcm_mesh; z_max = z₁)
-    # else
-    #     CC.Meshes.Uniform()
-    #     domain = CC.Domains.IntervalDomain(
-    #         CC.Geometry.ZPoint{FT}(z₀),
-    #         CC.Geometry.ZPoint{FT}(z₁),
-    #         boundary_tags = (:bottom, :top),
-    #     )
-    #     mesh = CC.Meshes.IntervalMesh(domain, nelems = nz)
-    # end
-    # @info "z heights" mesh.faces
-    # return TC.Grid(mesh)
 end

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -33,6 +33,7 @@ function parse_commandline()
         "--calibrate_io"   # Test that calibration IO passes regression tests
         arg_type = Bool
         default = false
+        # TODO: Improve this name, it's confusing!!
         "--stretch_grid"   # Test stretched grid option
         arg_type = Bool
         "--skip_io"        # Test that skipping IO passes regression tests
@@ -96,7 +97,10 @@ Generate a block of code to run a particular
 buildkite job given the `command:` string.
 
 Example:
-
+```julia
+include("integration_tests/cli_options.jl")
+print_repl_script("...")
+```
 """
 function print_repl_script(str)
     ib = """"""


### PR DESCRIPTION
This PR:
 - Adds the truncated GCM mesh capability back in
 - Changes that test to run `LES_driven_SCM` (cc @trontrytel, @ilopezgp)
 - Adds a doc string snippet to `print_repl_script`