### PR TITLE
Add most missing pieces from theta-var.

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -41,6 +41,9 @@ function affect_io!(integrator)
         write_ts(stats, "rwp_mean", diag_svpc.rwp_mean[cent])
         write_ts(stats, "swp_mean", diag_svpc.swp_mean[cent])
 
+        write_ts(stats, "integ_total_flux_qt", diag_svpc.integ_total_flux_qt[cent])
+        write_ts(stats, "integ_total_flux_s", diag_svpc.integ_total_flux_s[cent])
+
         if !calibrate_io
             write_ts(stats, "updraft_cloud_cover", diag_tc_svpc.updraft_cloud_cover[cent])
             write_ts(stats, "updraft_cloud_base", diag_tc_svpc.updraft_cloud_base[cent])

--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -189,6 +189,13 @@ function compute_diagnostics!(
     diag_svpc.rwp_mean[cent] = sum(ρ_c .* prog_pr.q_rai)
     diag_svpc.swp_mean[cent] = sum(ρ_c .* prog_pr.q_sno)
 
+    # Integrated vertical subgrid-scale fluxes (already multiplied by density)
+    diag_svpc.integ_total_flux_qt[cent] = sum(aux_tc_f.massflux_qt .+ aux_tc_f.diffusive_flux_qt)
+    diag_svpc.integ_total_flux_s[cent] = sum(aux_gm_f.massflux_s .+ aux_gm_f.diffusive_flux_s)
+
+    # We only need computations above here for calibration io.
+    calibrate_io && return nothing
+
     #####
     ##### Cloud base, top and cover
     #####

--- a/driver/dycore_variables.jl
+++ b/driver/dycore_variables.jl
@@ -112,6 +112,8 @@ single_value_per_col_diagnostic_vars_gm(FT) = (;
     cloud_base_mean = FT(0),
     cloud_top_mean = FT(0),
     cloud_cover_mean = FT(0),
+    integ_total_flux_qt = FT(0),
+    integ_total_flux_s = FT(0),
 )
 single_value_per_col_diagnostic_vars(FT, edmf) =
     (; single_value_per_col_diagnostic_vars_gm(FT)..., TC.single_value_per_col_diagnostic_vars_edmf(FT, edmf)...)

--- a/driver/main.jl
+++ b/driver/main.jl
@@ -244,6 +244,8 @@ function initialize(sim::Simulation1d)
         "swp_mean",
         "cutoff_precipitation_rate",
         "Hd",
+        "integ_total_flux_qt",
+        "integ_total_flux_s",
     ]
     ts_list = vcat(ts_gm, ts_edmf)
 

--- a/src/closures/nondimensional_exchange_functions.jl
+++ b/src/closures/nondimensional_exchange_functions.jl
@@ -309,7 +309,7 @@ function non_dimensional_function(εδ_model::RFEntr{d, m}, εδ_model_vars) whe
     # Square output for nonnegativity for prediction
     nondim_ε = sum(c_rf_opt[1, 1:m] .* f_entr) / sqrt(m)
     nondim_δ = sum(c_rf_opt[2, 1:m] .* f_detr) / sqrt(m)
-    return nondim_ε^2, nondim_δ^2
+    return Flux.relu(nondim_ε), Flux.relu(nondim_δ)
 end
 
 """


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

- Merges #1217 to main branch,
- Merges #1229 to main branch,
- Adds back the `calibrate_io` clause, which seems to have been deleted. Was this intentional @charleskawczynski ? Are we missing it in other parts of the code?

## Benefits and Risks

- Benefit: Potentially return to the main branch for research purposes.