### PR TITLE
Correct grid truncation by enforcing z_top.

### DIFF
--- a/driver/common_spaces.jl
+++ b/driver/common_spaces.jl
@@ -71,7 +71,6 @@ function construct_mesh(namelist; FT = Float64)
     end
 
     z₀, z₁ = FT(0), FT(nz * Δz)
-    z_stretch = CC.Meshes.Uniform()
 
     z_mesh = if truncated_gcm_mesh
         nzₛ = namelist["grid"]["stretch"]["nz"]


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

The current truncated mesh represents a truncation of the GCM mesh that retains enough elements of the GCM mesh to cover the entire requested space, without modifying the mesh points. This means that if a `z_top=4000.0` is requested, the last element of `TC.Grid(mesh).zf.z` is greater or equal than 4000.0, but may be e.g. 4200.0. This causes inconsistencies in the forcing of different benchmarks. How do we force/initialize beyond the original domain? The answer is non-trivial, case-specific and prone to error.

The new truncated mesh retains the number of degrees of freedom or the original truncated mesh, but recomputes the stretch necessary to reach `z_top` exactly. This means that in the end we have  `vec(`TC.Grid(mesh).zf.z`)[end] == 4000.0`.

## Benefits and Risks

Avoids serious problems in the definition of fields outside the original domain. Right now, we are doing a constant extrapolation beyond `z_top`, which means for example that we are relaxing to mixed layers in LES_driven_SCM.
