### PR TITLE
Bump main to v.034, potential candidate to deprecate v0.27.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.33.0"
+version = "0.34.0"
 
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

- Minor release set to substitute the theta-var series v0.27.x
