### PR TITLE
Add 2-moment, prescribed Nd autoconversions and accretions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -161,6 +161,11 @@ steps:
         command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Rico --thermo_covariance_model prognostic --skip_tests true --suffix _prognostic_covarinaces"
         artifact_paths: "Output.Rico.01_prognostic_covarinaces/stats/comparison/*"
 
+      - label: ":partly_sunny: Rico with KK2000 microphysics"
+        command: "julia --color=yes --project=integration_tests integration_tests/driver.jl --case Rico --skip_tests true --precipitation_model clima_1m --rain_formation_scheme KK2000 --prescribed_Nd 2e8 --suffix _two_moment_micro_KK2000"
+        artifact_paths: "Output.Rico.01_prognostic_covarinaces/stats/comparison/*"
+
+
   - group: "Sphere cases"
     steps:
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.34.2"
+version = "0.34.3"
 
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -399,6 +399,8 @@ function Rico(namelist_defaults)
     namelist["forcing"]["coriolis"] = 4.5e-5
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m"
+    namelist["microphysics"]["rain_formation_scheme"] = "clima_1m_default"
+    namelist["microphysics"]["prescribed_Nd"] = 1e8
     namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
     namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
     namelist["microphysics"]["precip_fraction_limiter"] = 0.3
@@ -440,6 +442,8 @@ function TRMM_LBA(namelist_defaults)
     namelist["time_stepping"]["dt_min"] = 1.0
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m" # "cutoff"
+    namelist["microphysics"]["rain_formation_scheme"] = "clima_1m_default"
+    namelist["microphysics"]["prescribed_Nd"] = 1e8
     namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
     namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
     namelist["microphysics"]["precip_fraction_limiter"] = 0.3
@@ -537,6 +541,8 @@ function DYCOMS_RF02(namelist_defaults)
     namelist["time_stepping"]["dt_min"] = 1.0
 
     namelist["microphysics"]["precipitation_model"] = "clima_1m" #"cutoff"
+    namelist["microphysics"]["rain_formation_scheme"] = "clima_1m_default"
+    namelist["microphysics"]["prescribed_Nd"] = 1e8
     namelist["microphysics"]["precip_fraction_model"] = "prescribed" # "prescribed" or "cloud_cover"
     namelist["microphysics"]["prescribed_precip_frac_value"] = 1.0
     namelist["microphysics"]["precip_fraction_limiter"] = 0.3

--- a/integration_tests/cli_options.jl
+++ b/integration_tests/cli_options.jl
@@ -53,23 +53,35 @@ function parse_commandline()
         default = ""
         "--n_up"           # Number of updrafts
         arg_type = Int
-        "--moisture_model" # Moisture model (equilibrium or nonequilibrium)
+        "--moisture_model"
+        help = "Cloud condensate formation model [`equilibrium` (default), `nonequilibrium`]"
         arg_type = String
-        "--precipitation_model" # Precipitation model (None, cutoff or clima_1m)
+        "--precipitation_model"
+        help = "Precipitation model [`None` (default), `cutoff` or `clima_1m`]"
         arg_type = String
-        "--precip_fraction_model" # Precipitation model (prescribed or cloud_cover)
+        "--rain_formation_scheme"
+        help = "Rain autoconversion and accretion scheme [`clima_1m_default` (default) , `KK2000`, `B1994`, `TC1980`, `LD2004`]"
         arg_type = String
-        "--prescribed_precip_frac_value" # Value of the precipitation fraction, if prescribed
+        "--prescribed_Nd"
+        help = "Prescribed cloud droplet number concentration. Valid when rain_formation_scheme is `KK2000`, `B1994`, `TC1980` or `LD2004`]"
         arg_type = Float64
-        "--precip_fraction_limiter" # Minimum precipitation fraction, if diagnostic
+        "--precip_fraction_model"
+        help = "Assumed (constant with height) precipitation fraction [`prescribed` (default), `cloud_cover`]"
+        arg_type = String
+        "--prescribed_precip_frac_value"
+        help = "Value of the precipitation fraction, if prescribed."
         arg_type = Float64
-        "--thermo_covariance_model" # covariance model (prognostic or diagnostic)
+        "--precip_fraction_limiter"
+        help = "Minimum precipitation fraction, if diagnostic."
+        arg_type = Float64
+        "--thermo_covariance_model"
+        help = "The type of equation for the sgs covariance [`prognostic`, `diagnostic` (default)]"
         arg_type = String
         "--float_type"
         arg_type = String
         default = "Float64"
         "--config"
-        help = "Spatial configuration [`sphere` (default), `column`]"
+        help = "Spatial configuration [`sphere`, `column` (default)]"
         arg_type = String
         default = "column"
         "--set_src_seed"

--- a/integration_tests/overwrite_namelist.jl
+++ b/integration_tests/overwrite_namelist.jl
@@ -19,6 +19,8 @@ function overwrite_namelist!(namelist, parsed_args)
     "n_up"                         => (nl, pa, key) -> (nl["turbulence"]["EDMF_PrognosticTKE"]["updraft_number"] = pa[key]),
     "moisture_model"               => (nl, pa, key) -> (nl["thermodynamics"]["moisture_model"] = pa[key]),
     "precipitation_model"          => (nl, pa, key) -> (nl["microphysics"]["precipitation_model"] = pa[key]),
+    "rain_formation_scheme"        => (nl, pa, key) -> (nl["microphysics"]["rain_formation_scheme"] = pa[key]),
+    "prescribed_Nd"                => (nl, pa, key) -> (nl["microphysics"]["prescribed_Nd"] = pa[key]),
     "precip_fraction_model"        => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_model"] = pa[key]),
     "prescribed_precip_frac_value" => (nl, pa, key) -> (nl["microphysics"]["prescribed_precip_frac_value"] = pa[key]),
     "precip_fraction_limiter"      => (nl, pa, key) -> (nl["microphysics"]["precip_fraction_limiter"] = pa[key]),

--- a/src/EDMF_Environment.jl
+++ b/src/EDMF_Environment.jl
@@ -4,6 +4,7 @@ function microphysics(
     state::State,
     edmf::EDMFModel,
     precip_model::AbstractPrecipitationModel,
+    rain_formation_model::AbstractRainFormationModel,
     Δt::Real,
     param_set::APS,
 )
@@ -34,6 +35,7 @@ function microphysics(
         mph = precipitation_formation(
             param_set,
             precip_model,
+            rain_formation_model,
             prog_pr.q_rai[k],
             prog_pr.q_sno[k],
             aux_en.area[k],
@@ -72,7 +74,7 @@ function microphysics(
     return nothing
 end
 
-function quad_loop(en_thermo::SGSQuadrature, precip_model, vars, param_set, Δt::Real)
+function quad_loop(en_thermo::SGSQuadrature, precip_model, rain_formation_model, vars, param_set, Δt::Real)
 
     env_len = 8
     src_len = 8
@@ -168,8 +170,18 @@ function quad_loop(en_thermo::SGSQuadrature, precip_model, vars, param_set, Δt:
             q_ice_en = TD.ice_specific_humidity(thermo_params, ts)
             T = TD.air_temperature(thermo_params, ts)
             # autoconversion and accretion
-            mph =
-                precipitation_formation(param_set, precip_model, q_rai, q_sno, subdomain_area, ρ_c, Δt, ts, precip_frac)
+            mph = precipitation_formation(
+                param_set,
+                precip_model,
+                rain_formation_model,
+                q_rai,
+                q_sno,
+                subdomain_area,
+                ρ_c,
+                Δt,
+                ts,
+                precip_frac,
+            )
 
             # environmental variables
             inner_env[i_ql] += q_liq_en * weights[m_h] * sqpi_inv
@@ -231,6 +243,7 @@ function microphysics(
     state::State,
     edmf::EDMFModel,
     precip_model,
+    rain_formation_model,
     Δt::Real,
     param_set::APS,
 )
@@ -284,7 +297,7 @@ function microphysics(
                 precip_frac = precip_fraction,
                 zc = FT(grid.zc[k].z),
             )
-            outer_env, outer_src = quad_loop(en_thermo, precip_model, vars, param_set, Δt)
+            outer_env, outer_src = quad_loop(en_thermo, precip_model, rain_formation_model, vars, param_set, Δt)
 
             # update environmental variables
 
@@ -339,6 +352,7 @@ function microphysics(
             mph = precipitation_formation(
                 param_set,
                 precip_model,
+                rain_formation_model,
                 prog_pr.q_rai[k],
                 prog_pr.q_sno[k],
                 aux_en.area[k],

--- a/src/EDMF_Updrafts.jl
+++ b/src/EDMF_Updrafts.jl
@@ -49,6 +49,7 @@ function compute_precipitation_formation_tendencies(
     state::State,
     edmf::EDMFModel,
     precip_model::AbstractPrecipitationModel,
+    rain_formation_model::AbstractRainFormationModel,
     Δt::Real,
     param_set::APS,
 )
@@ -87,6 +88,7 @@ function compute_precipitation_formation_tendencies(
             mph = precipitation_formation(
                 param_set,
                 precip_model,
+                rain_formation_model,
                 prog_pr.q_rai[k],
                 prog_pr.q_sno[k],
                 aux_up[i].area[k],

--- a/src/TurbulenceConvection.jl
+++ b/src/TurbulenceConvection.jl
@@ -18,6 +18,7 @@ import CloudMicrophysics as CM
 import CloudMicrophysics.MicrophysicsNonEq as CMNe
 import CloudMicrophysics.Microphysics0M as CM0
 import CloudMicrophysics.Microphysics1M as CM1
+import CloudMicrophysics.Microphysics2M as CM2
 import UnPack
 import Random
 import StochasticDiffEq as SDE

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -150,7 +150,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
         aux_en.RH[k] = TD.relative_humidity(thermo_params, ts_en)
     end
 
-    microphysics(edmf.en_thermo, grid, state, edmf, edmf.precip_model, Δt, param_set)
+    microphysics(edmf.en_thermo, grid, state, edmf, edmf.precip_model, edmf.rain_formation_model, Δt, param_set)
 
     @inbounds for k in real_center_indices(grid)
         a_bulk_c = aux_bulk.area[k]
@@ -498,6 +498,14 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
         aux_en.QTvar[kc_surf] = ae_surf * get_surface_variance(flux2 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
         aux_en.HQTcov[kc_surf] = ae_surf * get_surface_variance(flux1 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
     end
-    compute_precipitation_formation_tendencies(grid, state, edmf, edmf.precip_model, Δt, param_set)
+    compute_precipitation_formation_tendencies(
+        grid,
+        state,
+        edmf,
+        edmf.precip_model,
+        edmf.rain_formation_model,
+        Δt,
+        param_set,
+    )
     return nothing
 end


### PR DESCRIPTION
Co-authored-by: lynnyang <lynnyang@caltech.edu>

# PULL REQUEST

## Purpose and Content

This PR makes use of 2-moment, prescribed cloud droplet number concentration microphysics schemes in the new release of CloudMicrophysics.jl. On the TC.jl side we are creating a rain model that accepts the prescribed droplet number concentration as argument. The default scheme is unchanged. 

The new keyword options are:
`--rain_formation_scheme` (valid options: `clima_1m_default`, `KK2000`, `B1994`, `TC1980`, `LD2004`)
`--prescribed_Nd` (number of droplets per m3)

See the 2-moment CloudMicrophysics.jl [docs](https://clima.github.io/CloudMicrophysics.jl/dev/Microphysics2M/) for details. 

## Benefits and Risks
We will now have more microphysics options. (Uncertain if its a benefit or risk).