### PR TITLE
Add more LES cases for LES_driven_SCM()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TurbulenceConvection"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 authors = ["Climate Modeling Alliance"]
-version = "0.34.3"
+version = "0.34.4"
 
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"


### PR DESCRIPTION
# PULL REQUEST

- Enables the use of CNRM-CM5 LES runs,
- Splits the LES libraries into a shallow library (published in Shen et al 2022), and a bigger library including the experimental deep convection cases.