### PR TITLE
seprate turb entr

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -36,8 +36,6 @@ Base.@kwdef struct EntrDetr{FT}
     ε_dyn::FT
     "Fractional dynamical detrainment [1/m]"
     δ_dyn::FT
-    "Turbulent entrainment"
-    ε_turb::FT
     "Nondimensional fractional dynamical entrainment"
     ε_nondim::FT
     "Nondimensional fractional dynamical detrainment"

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -278,6 +278,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     if edmf.moisture_model isa NonEquilibriumMoisture
         compute_nonequilibrium_moisture_tendencies!(grid, state, edmf, Δt, param_set)
     end
+    compute_turb_entr!(state, grid, edmf)
     compute_entr_detr!(state, grid, edmf, param_set, surf, Δt, edmf.entr_closure)
     compute_nh_pressure!(state, grid, edmf, surf)
 


### PR DESCRIPTION
separate turb entr to facilitate using two dynamical entr models in a follow up PR (i.e. physical and ml entrainment) 