### PR TITLE
Remove TRMM from allocs analysis

### DIFF
--- a/perf/allocs.jl
+++ b/perf/allocs.jl
@@ -70,7 +70,7 @@ all_cases = [
     # "Nieuwstadt",
     "Rico",
     # "Soares",
-    "TRMM_LBA",
+    # "TRMM_LBA",
     "LES_driven_SCM",
 ]
 


### PR DESCRIPTION
Our allocation analysis is one of the most expensive jobs, and the different cases point to the same locations for allocations, so the job removed is not really showing us anything new.