### PR TITLE
Include CNRM-CM6-1 in the acceptable LES_driven_SCM requests.

### DIFF
--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -105,8 +105,8 @@ function get_LES_library()
     append!(LES_library["HadGEM2-A"]["10"]["cfsite_numbers"], sites_10)
 
     LES_library_full = deepcopy(LES_library)
-    for month in ["01", "04", "07", "10"]
-        for model in ["HadGEM2-A", "CNRM-CM5"]
+    for model in keys(LES_library_full)
+        for month in keys(LES_library_full[model])
             LES_library_full[model][month]["cfsite_numbers"] = Dict()
             for cfsite_number in LES_library[model][month]["cfsite_numbers"]
                 cfsite_number_str = string(cfsite_number, pad = 2)


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

This fix adds the CNRM-CM6-1 cases to the construction of the general LES dictionary (shallow+deep), which is necessary when assessing whether the requested path is a `valid_lespath`.