### PR TITLE
Add Lewis number scaling for mass diffusivity.

### DIFF
--- a/driver/callbacks.jl
+++ b/driver/callbacks.jl
@@ -114,6 +114,7 @@ function compute_dt_max(state::TC.State, edmf::TC.EDMFModel, dt_max::FT, CFL_lim
     aux_en_f = TC.face_aux_environment(state)
     KM = aux_tc.KM
     KH = aux_tc.KH
+    KQ = aux_tc.KQ
 
     # helper to calculate the rain velocity
     # TODO: assuming w_gm = 0
@@ -134,7 +135,7 @@ function compute_dt_max(state::TC.State, edmf::TC.EDMFModel, dt_max::FT, CFL_lim
         # Check terminal rain/snow velocity CFL
         dt_max = min(dt_max, CFL_limit * Δzc[k] / (vel_max + ε))
         # Check diffusion CFL (i.e., Fourier number)
-        dt_max = min(dt_max, CFL_limit * Δzc[k]^2 / (max(KH[k], KM[k]) + ε))
+        dt_max = min(dt_max, CFL_limit * Δzc[k]^2 / (max(KH[k], KM[k], KQ[k]) + ε))
     end
     return dt_max
 end

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -99,6 +99,7 @@ function default_namelist(
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_scale"] = 53.0 / 13.0
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Prandtl_number_0"] = 0.74
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Ri_crit"] = 0.25
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["Lewis_number"] = 1.0
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_ub"] = 0.1
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["smin_rm"] = 1.5
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["l_max"] = 1.0e6

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -34,7 +34,7 @@ microphysics_params(ps::ATCP) = ps.microphys_params
 Base.eltype(::TurbulenceConvectionParameters{FT}) where {FT} = FT
 Omega(ps::ATCP) = ps.Omega
 planet_radius(ps::ATCP) = ps.planet_radius
-# TODO - microph_scaling is the factor for adjusting evapoartion.
+# TODO - microph_scaling is the factor for adjusting evaporation.
 # The name will be fixed in CLIMAParameters first.
 microph_scaling(ps::ATCP) = ps.microph_scaling
 microph_scaling_dep_sub(ps::ATCP) = ps.microph_scaling_dep_sub

--- a/src/types.jl
+++ b/src/types.jl
@@ -208,6 +208,7 @@ Base.@kwdef struct MixingLengthParams{FT}
     κ_star²::FT # Ratio of TKE to squared friction velocity in surface layer
     Pr_n::FT # turbulent Prandtl number in neutral conditions
     Ri_c::FT # critical Richardson number
+    Le::FT # Lewis number
     smin_ub::FT # lower limit for smin function
     smin_rm::FT # upper ratio limit for smin function
     l_max::FT
@@ -658,6 +659,7 @@ function EDMFModel(::Type{FT}, namelist, precip_model, rain_formation_model) whe
         κ_star² = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "tke_surf_scale"),
         Pr_n = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Prandtl_number_0"),
         Ri_c = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Ri_crit"),
+        Le = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "Lewis_number"; default = 1.0),
         smin_ub = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_ub"),
         smin_rm = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "smin_rm"),
         l_max = parse_namelist(namelist, "turbulence", "EDMF_PrognosticTKE", "l_max"; default = 1.0e6),

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -9,8 +9,10 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     kf_surf = kf_surface(grid)
     kc_toa = kc_top_of_atmos(grid)
     c_m = mixing_length_params(edmf).c_m
+    Le = mixing_length_params(edmf).Le
     KM = center_aux_turbconv(state).KM
     KH = center_aux_turbconv(state).KH
+    KQ = center_aux_turbconv(state).KQ
     obukhov_length = surf.obukhov_length
     FT = float_type(state)
     prog_gm = center_prog_grid_mean(state)
@@ -418,6 +420,7 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
 
         KM[k] = c_m * ml.mixing_length * sqrt(max(aux_en.tke[k], 0))
         KH[k] = KM[k] / aux_tc.prandtl_nvec[k]
+        KQ[k] = KH[k] / Le
 
         aux_en_2m.tke.buoy[k] = -aux_en.area[k] * ρ_c[k] * KH[k] * bg.∂b∂z
     end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -80,6 +80,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
     turbconv = (;
         ϕ_temporary = FT(0),
         ψ_temporary = FT(0),
+        φ_temporary = FT(0),
         bulk = (;
             area = FT(0),
             θ_liq_ice = FT(0),
@@ -140,6 +141,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         term_vel_snow = FT(0),
         KM = FT(0),
         KH = FT(0),
+        KQ = FT(0),
         mixing_length = FT(0),
         massflux_tendency_h = FT(0),
         massflux_tendency_qt = FT(0),
@@ -191,6 +193,7 @@ face_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         bulk = (; w = FT(0)),
         ρ_ae_KM = FT(0),
         ρ_ae_KH = FT(0),
+        ρ_ae_KQ = FT(0),
         ρ_ae_K = FT(0),
         en = (; w = FT(0)),
         up = ntuple(i -> face_aux_vars_up(FT, local_geometry), Val(n_updrafts(edmf))),


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

Adds a [Lewis](https://en.wikipedia.org/wiki/Lewis_number) number scaling to the moisture diffusivity.

## Benefits and Risks

Easy way to make model more flexible, by relaxing the assumption of heat and moisture diffusivity being equal. Instead, we now assume they are proportional.
