### PR TITLE
remove surface area boundary condition

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -303,7 +303,7 @@ function compute_diagnostics!(
         end
     end
 
-    a_bulk_bcs = TC.a_bulk_boundary_conditions(surf, edmf)
+    a_bulk_bcs = TC.a_bulk_boundary_conditions(surf)
     Ifabulk = CCO.InterpolateC2F(; a_bulk_bcs...)
     a_up_bulk_f = TC.face_aux_turbconv(state).bulk.a_up
     @. a_up_bulk_f = Ifabulk(a_up_bulk)
@@ -311,7 +311,7 @@ function compute_diagnostics!(
     RB_precip = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
 
     @inbounds for i in 1:N_up
-        a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = TC.a_up_boundary_conditions(surf)
         Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
         a_up_f = aux_up_f[i].area
         @. a_up_f = Ifaup(aux_up[i].area)

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -87,7 +87,7 @@ function default_namelist(
     namelist_defaults["turbulence"] = Dict()
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"] = Dict()
-    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.5
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["max_area"] = 0.9
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["min_area"] = 1e-5
 

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -81,9 +81,9 @@ function initialize_updrafts(edmf, grid, state, surf)
             @. prog_up[i].δ_nondim = 0
         end
 
-        a_surf = TC.area_surface_bc(surf, edmf, i)
-        aux_up[i].area[kc_surf] = a_surf
-        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
+        a_up_initial = TC.bottom_cell_a_up_initial(edmf)
+        aux_up[i].area[kc_surf] = a_up_initial
+        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_up_initial
     end
     return
 end

--- a/driver/initial_conditions.jl
+++ b/driver/initial_conditions.jl
@@ -48,14 +48,17 @@ end
 function initialize_updrafts(edmf, grid, state, surf)
     N_up = TC.n_updrafts(edmf)
     kc_surf = TC.kc_surface(grid)
+    kf_surf = TC.kf_surface(grid)
     aux_up = TC.center_aux_updrafts(state)
     prog_gm = TC.center_prog_grid_mean(state)
     aux_up = TC.center_aux_updrafts(state)
     aux_up_f = TC.face_aux_updrafts(state)
     aux_gm = TC.center_aux_grid_mean(state)
+    aux_gm_f = TC.face_aux_grid_mean(state)
     prog_up = TC.center_prog_updrafts(state)
     prog_up_f = TC.face_prog_updrafts(state)
     ρ_c = prog_gm.ρ
+    ρ_f = aux_gm_f.ρ
     @inbounds for i in 1:N_up
         @inbounds for k in TC.real_face_indices(grid)
             aux_up_f[i].w[k] = 0
@@ -84,6 +87,13 @@ function initialize_updrafts(edmf, grid, state, surf)
         a_up_initial = TC.bottom_cell_a_up_initial(edmf)
         aux_up[i].area[kc_surf] = a_up_initial
         prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_up_initial
+
+        aux_up_f[i].w[kf_surf + 1] = 0.01
+        prog_up_f[i].ρaw[kf_surf + 1] = ρ_f[kf_surf + 1] * a_up_initial * 0.01
+
+        prog_up[i].ρaq_tot[kc_surf] = ρ_c[kc_surf] * a_up_initial * aux_gm.q_tot[kc_surf]
+        prog_up[i].ρaθ_liq_ice[kc_surf] = ρ_c[kc_surf] * a_up_initial * aux_gm.θ_liq_ice[kc_surf]
+        
     end
     return
 end

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -601,6 +601,7 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
 
         @. tends_ρaw = -(∇f(wvec(LBC(ρaw * w_up))))
         @. tends_ρaw += (ρaw * (I0f(entr_w) * w_en - I0f(detr_w) * w_up)) + (ρ_f * Iaf(a_up) * I0f(buoy)) + nh_pressure
+        tends_ρaw[kf_surf] = 0
     end
 
     return nothing
@@ -681,6 +682,9 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
 
     Ic = CCO.InterpolateF2C()
     @inbounds for i in 1:N_up
+        @. prog_up[i].ρarea = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρarea)
+        @. prog_up[i].ρaθ_liq_ice = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaθ_liq_ice)
+        @. prog_up[i].ρaq_tot = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_tot)
         θ_surf = θ_surface_bc(surf, grid, state, edmf, i)
         q_surf = q_surface_bc(surf, grid, state, edmf, i)
         prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -63,7 +63,7 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     θ_liq_ice_gm = aux_gm.θ_liq_ice
     q_tot_gm = aux_gm.q_tot
     q_tot_en = aux_en.q_tot
-    a_en_bcs = a_en_boundary_conditions(surf, edmf)
+    a_en_bcs = a_en_boundary_conditions(surf)
     Ifae = CCO.InterpolateC2F(; a_en_bcs...)
     If = CCO.InterpolateC2F(; bottom = CCO.SetValue(FT(0)), top = CCO.SetValue(FT(0)))
 
@@ -74,7 +74,7 @@ function compute_sgs_flux!(edmf::EDMFModel, grid::Grid, state::State, surf::Surf
     @inbounds for i in 1:N_up
         aux_up_f_i = aux_up_f[i]
         aux_up_i = aux_up[i]
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf)
         Ifau = CCO.InterpolateC2F(; a_up_bcs...)
         a_up = aux_up[i].area
         w_up_i = aux_up_f[i].w
@@ -274,12 +274,12 @@ function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::Su
     cp = TD.cp_m(thermo_params, ts_gm[kc_surf])
     ρ_c = prog_gm.ρ
     ρ_f = aux_gm_f.ρ
-    ae_surf::FT = 1
+    ρa_env_surf::FT = ρ_c[kc_surf]
     @inbounds for i in 1:N_up
         θ_surf = θ_surface_bc(surf, grid, state, edmf, i)
         q_surf = q_surface_bc(surf, grid, state, edmf, i)
-        a_surf = area_surface_bc(surf, edmf, i)
-        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
+
+        ρa_surf = prog_up[i].ρarea[kc_surf]
         prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
         prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
         if edmf.moisture_model isa NonEquilibriumMoisture
@@ -289,8 +289,9 @@ function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::Su
             prog_up[i].ρaq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * q_ice_surf
         end
         prog_up_f[i].ρaw[kf_surf] = ρ_f[kf_surf] * w_surface_bc(surf)
-        ae_surf -= a_surf
+        ρa_env_surf -= ρa_surf
     end
+
 
     flux1 = surf.ρθ_liq_ice_flux
     flux2 = surf.ρq_tot_flux
@@ -298,13 +299,12 @@ function set_edmf_surface_bc(edmf::EDMFModel, grid::Grid, state::State, surf::Su
     ustar = surf.ustar
     oblength = surf.obukhov_length
     ρLL = prog_gm.ρ[kc_surf]
-    ρ_ae = ρ_c[kc_surf] * ae_surf
     mix_len_params = mixing_length_params(edmf)
-    prog_en.ρatke[kc_surf] = ρ_ae * get_surface_tke(mix_len_params, surf.ustar, zLL, surf.obukhov_length)
+    prog_en.ρatke[kc_surf] = ρa_env_surf * get_surface_tke(mix_len_params, surf.ustar, zLL, surf.obukhov_length)
     if edmf.thermo_covariance_model isa PrognosticThermoCovariances
-        prog_en.ρaHvar[kc_surf] = ρ_ae * get_surface_variance(flux1 / ρLL, flux1 / ρLL, ustar, zLL, oblength)
-        prog_en.ρaQTvar[kc_surf] = ρ_ae * get_surface_variance(flux2 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
-        prog_en.ρaHQTcov[kc_surf] = ρ_ae * get_surface_variance(flux1 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+        prog_en.ρaHvar[kc_surf] = ρa_env_surf * get_surface_variance(flux1 / ρLL, flux1 / ρLL, ustar, zLL, oblength)
+        prog_en.ρaQTvar[kc_surf] = ρa_env_surf * get_surface_variance(flux2 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
+        prog_en.ρaHQTcov[kc_surf] = ρa_env_surf * get_surface_variance(flux1 / ρLL, flux2 / ρLL, ustar, zLL, oblength)
     end
     return nothing
 end
@@ -320,26 +320,21 @@ function surface_helper(surf::SurfaceBase, grid::Grid, state::State)
     return (; ustar, zLL, oblength, ρLL)
 end
 
-function a_up_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel, i::Int)
-    a_surf = area_surface_bc(surf, edmf, i)
-    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+function a_up_boundary_conditions(surf::SurfaceBase{FT}) where {FT}
+    return (; bottom = CCO.SetValue(FT(0)), top = CCO.Extrapolate())
 end
 
-function a_bulk_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel)
-    N_up = n_updrafts(edmf)
-    a_surf = sum(i -> area_surface_bc(surf, edmf, i), 1:N_up)
-    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+function a_bulk_boundary_conditions(surf::SurfaceBase{FT}) where {FT}
+    return a_up_boundary_conditions(surf)
 end
 
-function a_en_boundary_conditions(surf::SurfaceBase, edmf::EDMFModel)
-    N_up = n_updrafts(edmf)
-    a_surf = 1 - sum(i -> area_surface_bc(surf, edmf, i), 1:N_up)
-    return (; bottom = CCO.SetValue(a_surf), top = CCO.Extrapolate())
+function a_en_boundary_conditions(surf::SurfaceBase{FT}) where {FT}
+    return (; bottom = CCO.SetValue(FT(1)), top = CCO.Extrapolate())
 end
 
-function area_surface_bc(surf::SurfaceBase{FT}, edmf::EDMFModel, i::Int)::FT where {FT}
+function bottom_cell_a_up_initial(edmf::EDMFModel)
     N_up = n_updrafts(edmf)
-    return surf.bflux > 0 ? edmf.surface_area / N_up : FT(0)
+    return edmf.surface_area / N_up
 end
 
 function w_surface_bc(::SurfaceBase{FT})::FT where {FT}
@@ -351,14 +346,16 @@ end
 function θ_surface_bc(surf::SurfaceBase{FT}, grid::Grid, state::State, edmf::EDMFModel, i::Int)::FT where {FT}
     aux_gm = center_aux_grid_mean(state)
     prog_gm = center_prog_grid_mean(state)
+    prog_up = center_prog_updrafts(state)
     ρ_c = prog_gm.ρ
     kc_surf = kc_surface(grid)
     ts_gm = aux_gm.ts
     UnPack.@unpack ustar, zLL, oblength, ρLL = surface_helper(surf, grid, state)
+    N_up = n_updrafts(edmf)
 
     surf.bflux > 0 || return FT(0)
-    a_total = edmf.surface_area
-    a_ = area_surface_bc(surf, edmf, i)
+    a_total = sum(i -> prog_up[i].ρarea[kc_surf] / ρ_c[kc_surf], 1:N_up)
+    a_ = prog_up[i].ρarea[kc_surf] / ρ_c[kc_surf]
     ρθ_liq_ice_flux = surf.ρθ_liq_ice_flux # assuming no ql,qi flux
     h_var = get_surface_variance(ρθ_liq_ice_flux / ρLL, ρθ_liq_ice_flux / ρLL, ustar, zLL, oblength)
     surface_scalar_coeff = percentile_bounds_mean_norm(1 - a_total + (i - 1) * a_, 1 - a_total + i * a_)
@@ -367,11 +364,14 @@ end
 function q_surface_bc(surf::SurfaceBase{FT}, grid::Grid, state::State, edmf::EDMFModel, i::Int)::FT where {FT}
     aux_gm = center_aux_grid_mean(state)
     prog_gm = center_prog_grid_mean(state)
+    prog_up = center_prog_updrafts(state)
     ρ_c = prog_gm.ρ
     kc_surf = kc_surface(grid)
+    N_up = n_updrafts(edmf)
+
     surf.bflux > 0 || return aux_gm.q_tot[kc_surf]
-    a_total = edmf.surface_area
-    a_ = area_surface_bc(surf, edmf, i)
+    a_total = sum(i -> prog_up[i].ρarea[kc_surf] / ρ_c[kc_surf], 1:N_up)
+    a_ = prog_up[i].ρarea[kc_surf] / ρ_c[kc_surf]
     UnPack.@unpack ustar, zLL, oblength, ρLL = surface_helper(surf, grid, state)
     ρq_tot_flux = surf.ρq_tot_flux
     qt_var = get_surface_variance(ρq_tot_flux / ρLL, ρq_tot_flux / ρLL, ustar, zLL, oblength)
@@ -516,7 +516,6 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
         tends_ρarea = tendencies_up[i].ρarea
         tends_ρaθ_liq_ice = tendencies_up[i].ρaθ_liq_ice
         tends_ρaq_tot = tendencies_up[i].ρaq_tot
-
         @. tends_ρarea =
             -∇c(wvec(LBF(Ic(w_up) * ρarea))) + (ρarea * Ic(w_up) * entr_turb_dyn) - (ρarea * Ic(w_up) * detr_turb_dyn)
 
@@ -573,7 +572,6 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
             @. tends_δ_nondim = δ_λ * (mean_detr - δ_nondim)
         end
 
-        tends_ρarea[kc_surf] = 0
         tends_ρaθ_liq_ice[kc_surf] = 0
         tends_ρaq_tot[kc_surf] = 0
     end
@@ -589,7 +587,7 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
     ∇f = CCO.DivergenceC2F(; adv_bcs...)
 
     @inbounds for i in 1:N_up
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf)
         Iaf = CCO.InterpolateC2F(; a_up_bcs...)
         ρaw = prog_up_f[i].ρaw
         tends_ρaw = tendencies_up_f[i].ρaw
@@ -603,7 +601,6 @@ function compute_up_tendencies!(edmf::EDMFModel, grid::Grid, state::State, param
 
         @. tends_ρaw = -(∇f(wvec(LBC(ρaw * w_up))))
         @. tends_ρaw += (ρaw * (I0f(entr_w) * w_en - I0f(detr_w) * w_up)) + (ρ_f * Iaf(a_up) * I0f(buoy)) + nh_pressure
-        tends_ρaw[kf_surf] = 0
     end
 
     return nothing
@@ -645,10 +642,10 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
             prog_up[i].ρaq_ice .= max.(prog_up[i].ρaq_ice, 0)
         end
     end
-
+    # apply clipping at 0 and minimum area to ρaw
     @inbounds for i in 1:N_up
         @. prog_up_f[i].ρaw = max.(prog_up_f[i].ρaw, 0)
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf)
         If = CCO.InterpolateC2F(; a_up_bcs...)
         @. prog_up_f[i].ρaw = Int(If(prog_up[i].ρarea) >= ρ_f * a_min) * prog_up_f[i].ρaw
     end
@@ -684,13 +681,8 @@ function filter_updraft_vars(edmf::EDMFModel, grid::Grid, state::State, surf::Su
 
     Ic = CCO.InterpolateF2C()
     @inbounds for i in 1:N_up
-        @. prog_up[i].ρarea = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρarea)
-        @. prog_up[i].ρaθ_liq_ice = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaθ_liq_ice)
-        @. prog_up[i].ρaq_tot = ifelse(Ic(prog_up_f[i].ρaw) <= 0, FT(0), prog_up[i].ρaq_tot)
         θ_surf = θ_surface_bc(surf, grid, state, edmf, i)
         q_surf = q_surface_bc(surf, grid, state, edmf, i)
-        a_surf = area_surface_bc(surf, edmf, i)
-        prog_up[i].ρarea[kc_surf] = ρ_c[kc_surf] * a_surf
         prog_up[i].ρaθ_liq_ice[kc_surf] = prog_up[i].ρarea[kc_surf] * θ_surf
         prog_up[i].ρaq_tot[kc_surf] = prog_up[i].ρarea[kc_surf] * q_surf
     end

--- a/src/EDMF_functions.jl
+++ b/src/EDMF_functions.jl
@@ -242,8 +242,9 @@ function affect_filter!(edmf::EDMFModel, grid::Grid, state::State, param_set::AP
     ###
     ### Filters
     ###
-    set_edmf_surface_bc(edmf, grid, state, surf, param_set)
+
     filter_updraft_vars(edmf, grid, state, surf)
+    set_edmf_surface_bc(edmf, grid, state, surf, param_set)
 
     @inbounds for k in real_center_indices(grid)
         prog_en.ρatke[k] = max(prog_en.ρatke[k], 0.0)

--- a/src/closures/perturbation_pressure.jl
+++ b/src/closures/perturbation_pressure.jl
@@ -54,7 +54,7 @@ function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
         w_en = aux_en_f.w
 
         b_bcs = (; bottom = CCO.SetValue(b_up[kc_surf]), top = CCO.SetValue(b_up[kc_toa]))
-        a_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_bcs = a_up_boundary_conditions(surf)
         Ifb = CCO.InterpolateC2F(; b_bcs...)
         Ifa = CCO.InterpolateC2F(; a_bcs...)
 

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -240,9 +240,9 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     ##### face variables: diagnose primitive, diagnose env and compute bulk
     #####
     # TODO: figure out why `ifelse` is allocating
+    # clip updraft w below minimum area threshold
     @inbounds for i in 1:N_up
-        a_surf = area_surface_bc(surf, edmf, i)
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf)
         If = CCO.InterpolateC2F(; a_up_bcs...)
         a_min = edmf.minimum_area
         a_up = aux_up[i].area
@@ -253,11 +253,11 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     end
 
     parent(aux_tc_f.bulk.w) .= 0
-    a_bulk_bcs = a_bulk_boundary_conditions(surf, edmf)
+    a_bulk_bcs = a_bulk_boundary_conditions(surf)
     Ifb = CCO.InterpolateC2F(; a_bulk_bcs...)
     @inbounds for i in 1:N_up
         a_up = aux_up[i].area
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
+        a_up_bcs = a_up_boundary_conditions(surf)
         Ifu = CCO.InterpolateC2F(; a_up_bcs...)
         @. aux_tc_f.bulk.w += ifelse(Ifb(aux_bulk.area) > 0, Ifu(a_up) * aux_up_f[i].w / Ifb(aux_bulk.area), FT(0))
     end


### PR DESCRIPTION
- Allow surface area to be prognostically determined in the bottom cell center, instead of prescribed as `surface_area` parameter. In initial conditions, area fraction and updraft w set to nonzero values in bottom cell center and top face, respectively, along with the associated prognostic variables for these variables. This initialization is to break symmetry and prevent trivial a = 0, w = 0 solution. 
- At bottom cell face, `a_up` = 0 & `a_en` = 1. At bottom cell center and above -> `a` prognostically determined. Note: `a_en`  at surface bottom face is needed to compute diffusive fluxes.
- Swap order of `set_edmf_surface_bc` and `filter_updraft_vars`, since updraft variables are used to compute surface `theta` and `qt` fluxes.