### PR TITLE
Include prognostic and closure options for surface area BC

### DIFF
--- a/driver/compute_diagnostics.jl
+++ b/driver/compute_diagnostics.jl
@@ -303,16 +303,14 @@ function compute_diagnostics!(
         end
     end
 
-    a_bulk_bcs = TC.a_bulk_boundary_conditions(surf, edmf)
-    Ifabulk = CCO.InterpolateC2F(; a_bulk_bcs...)
+    Ifabulk = CCO.InterpolateC2F()
     a_up_bulk_f = TC.face_aux_turbconv(state).bulk.a_up
     @. a_up_bulk_f = Ifabulk(a_up_bulk)
 
     RB_precip = CCO.RightBiasedC2F(; top = CCO.SetValue(FT(0)))
 
     @inbounds for i in 1:N_up
-        a_up_bcs = TC.a_up_boundary_conditions(surf, edmf, i)
-        Ifaup = CCO.InterpolateC2F(; a_up_bcs...)
+        Ifaup = CCO.InterpolateC2F()
         a_up_f = aux_up_f[i].area
         @. a_up_f = Ifaup(aux_up[i].area)
         @inbounds for k in TC.real_face_indices(grid)

--- a/driver/generate_namelist.jl
+++ b/driver/generate_namelist.jl
@@ -88,6 +88,8 @@ function default_namelist(
 
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"] = Dict()
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area"] = 0.1
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area_bc"] = "Fixed" #{"Fixed", "Prognostic", "Closure"}
+    namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["surface_area_bc_params"] = [1e-3, 1e-3, 1e-3]
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["max_area"] = 0.9
     namelist_defaults["turbulence"]["EDMF_PrognosticTKE"]["min_area"] = 1e-5
 

--- a/integration_tests/Artifacts.toml
+++ b/integration_tests/Artifacts.toml
@@ -5,4 +5,4 @@ git-tree-sha1 = "3d6bb62d803fb01908ffe85469a89933f28ced45"
 git-tree-sha1 = "c2d323fb412d1250182be3aeadf9d94e816550a0"
 
 [SCAMPy_output]
-git-tree-sha1 = "6b82611f969d3cf99102baa7d898e3c759cf014c"
+git-tree-sha1 = "f725942089ff0d0fa8138dcbd1349996c746a4f9"

--- a/src/closures/perturbation_pressure.jl
+++ b/src/closures/perturbation_pressure.jl
@@ -54,9 +54,8 @@ function compute_nh_pressure!(state::State, grid::Grid, edmf::EDMFModel, surf)
         w_en = aux_en_f.w
 
         b_bcs = (; bottom = CCO.SetValue(b_up[kc_surf]), top = CCO.SetValue(b_up[kc_toa]))
-        a_bcs = a_up_boundary_conditions(surf, edmf, i)
         Ifb = CCO.InterpolateC2F(; b_bcs...)
-        Ifa = CCO.InterpolateC2F(; a_bcs...)
+        Ifa = CCO.InterpolateC2F()
 
         nh_press_buoy = aux_up_f[i].nh_pressure_b
         nh_press_adv = aux_up_f[i].nh_pressure_adv

--- a/src/update_aux.jl
+++ b/src/update_aux.jl
@@ -240,10 +240,9 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     ##### face variables: diagnose primitive, diagnose env and compute bulk
     #####
     # TODO: figure out why `ifelse` is allocating
+    # clip updraft w below minimum area threshold
     @inbounds for i in 1:N_up
-        a_surf = area_surface_bc(surf, edmf, i)
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
-        If = CCO.InterpolateC2F(; a_up_bcs...)
+        If = CCO.InterpolateC2F()
         a_min = edmf.minimum_area
         a_up = aux_up[i].area
         @. aux_up_f[i].w = ifelse(If(a_up) >= a_min, max(prog_up_f[i].ρaw / (ρ_f * If(a_up)), 0), FT(0))
@@ -253,12 +252,10 @@ function update_aux!(edmf::EDMFModel, grid::Grid, state::State, surf::SurfaceBas
     end
 
     parent(aux_tc_f.bulk.w) .= 0
-    a_bulk_bcs = a_bulk_boundary_conditions(surf, edmf)
-    Ifb = CCO.InterpolateC2F(; a_bulk_bcs...)
+    Ifb = CCO.InterpolateC2F()
     @inbounds for i in 1:N_up
         a_up = aux_up[i].area
-        a_up_bcs = a_up_boundary_conditions(surf, edmf, i)
-        Ifu = CCO.InterpolateC2F(; a_up_bcs...)
+        Ifu = CCO.InterpolateC2F()
         @. aux_tc_f.bulk.w += ifelse(Ifb(aux_bulk.area) > 0, Ifu(a_up) * aux_up_f[i].w / Ifb(aux_bulk.area), FT(0))
     end
     # Assuming w_gm = 0!


### PR DESCRIPTION
- Adds options for prognostic and closure-based determination of bottom boundary condition on area. For prognostic option, surface area is prognostically determined in the bottom cell center, instead of prescribed as surface_area parameter. For closure option, bottom area determined as a linear function of surface heat fluxes.
-  Initial conditions for prognostic surface area: area fraction and updraft w set to nonzero values in bottom cell center and top face, along with the associated prognostic variables. This initialization is to break symmetry and prevent trivial a = 0, w = 0 solution.
- Swaps order of set_edmf_surface_bc and filter_updraft_vars, since updraft variables are used to compute surface theta and qt fluxes.