### PR TITLE
Updates to LES_driven_SCM cases 

### DIFF
--- a/driver/Cases.jl
+++ b/driver/Cases.jl
@@ -1177,7 +1177,7 @@ function initialize_profiles(::LES_driven_SCM, grid::Grid, param_set, state; LES
         imax = time_interval_bool[end]
         zc_les = Array(TC.get_nc_data(data, "zc"))
 
-        getvar(var) = pyinterp(vec(grid.zc.z), zc_les, TC.mean_nc_data(data, "profiles", var, imin, imax))
+        getvar(var) = pyinterp(vec(grid.zc.z), zc_les, TC.init_nc_data(data, "profiles", var))
 
         θ_liq_ice_gm = getvar("thetali_mean")
         q_tot_gm = getvar("qt_mean")

--- a/post_processing/mse_tables.jl
+++ b/post_processing/mse_tables.jl
@@ -158,12 +158,12 @@ all_best_mse["TRMM_LBA"]["Hvar_mean"] = 446332.29960805096
 all_best_mse["TRMM_LBA"]["QTvar_mean"] = 6279.987008045119
 #
 all_best_mse["LES_driven_SCM"] = OrderedCollections.OrderedDict()
-all_best_mse["LES_driven_SCM"]["qt_mean"] = 3.1245243580973274
-all_best_mse["LES_driven_SCM"]["v_mean"] = 0.6312894226846458
-all_best_mse["LES_driven_SCM"]["u_mean"] = 0.19168439308615623
-all_best_mse["LES_driven_SCM"]["temperature_mean"] = 0.0012149531297031915
-all_best_mse["LES_driven_SCM"]["ql_mean"] = 5645.4805762575825
-all_best_mse["LES_driven_SCM"]["thetal_mean"] = 0.0013525039758698536
+all_best_mse["LES_driven_SCM"]["qt_mean"] = 0.1816324057400173
+all_best_mse["LES_driven_SCM"]["v_mean"] = 0.32293581806860794
+all_best_mse["LES_driven_SCM"]["u_mean"] = 0.07547494635765321
+all_best_mse["LES_driven_SCM"]["temperature_mean"] = 5.497077391865199e-5
+all_best_mse["LES_driven_SCM"]["ql_mean"] = 27662.597548577323
+all_best_mse["LES_driven_SCM"]["thetal_mean"] = 6.008525349326801e-5
 #
 #################################
 #################################

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -116,7 +116,7 @@ and experiments.
 """
 function get_shallow_LES_library()
     LES_library = Dict("HadGEM2-A" => Dict(), "CNRM-CM5" => Dict(), "CNRM-CM6-1" => Dict())
-    Shen_et_al_sites = collect(2:15)
+    Shen_et_al_sites = collect(4:15)
     append!(Shen_et_al_sites, collect(17:23))
 
     # HadGEM2-A model (76 AMIP-AMIP4K pairs)


### PR DESCRIPTION
Remove cfsites 2,3 from shallow les library. These 2 cfSites are not in steady-state (height of SC clouds continue to grow throughout the LES simulation + cause many TC crashes)
Use first timestep (GCM profile) in LES stats file to initalize thetali, qt, u, and v instead of mean LES profiles. 

