### PR TITLE
Modify Pi groups and include in stats file output

### DIFF
--- a/src/closures/nondimensional_exchange_functions.jl
+++ b/src/closures/nondimensional_exchange_functions.jl
@@ -12,14 +12,13 @@ function non_dimensional_groups(εδ_model, εδ_model_vars)
     Δw = get_Δw(εδ_model, εδ_model_vars.w_up, εδ_model_vars.w_en)
     Δb = εδ_model_vars.b_up - εδ_model_vars.b_en
     Π_norm = εδ_params(εδ_model).Π_norm
-    Π₁ = (εδ_model_vars.zc_i * Δb) / (Δw^2 + εδ_model_vars.wstar^2) / Π_norm[1]
-    Π₂ =
-        (εδ_model_vars.tke_gm - εδ_model_vars.a_en * εδ_model_vars.tke_en) / (εδ_model_vars.tke_gm + eps(FT)) /
-        Π_norm[2]
+    Π₁ = (εδ_model_vars.zc_i * Δb) / (Δw^2 + eps(FT)) / Π_norm[1]
+    Π₂ = εδ_model_vars.tke_en / (Δw^2 + eps(FT)) / Π_norm[2]
     Π₃ = √(εδ_model_vars.a_up) / Π_norm[3]
     Π₄ = (εδ_model_vars.RH_up - εδ_model_vars.RH_en) / Π_norm[4]
     Π₅ = εδ_model_vars.zc_i / εδ_model_vars.H_up / Π_norm[5]
     Π₆ = εδ_model_vars.zc_i / εδ_model_vars.ref_H / Π_norm[6]
+
     Π_groups = (Π₁, Π₂, Π₃, Π₄, Π₅, Π₆)
 
     return map(i -> Π_groups[i], εδ_model_vars.entr_Π_subset)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -105,6 +105,8 @@ function io_dictionary_aux()
         "updraft_qt_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).qt_tendency_precip_formation),
         "updraft_thetal_precip" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_bulk(state).θ_liq_ice_tendency_precip_formation),
 
+        "massflux_grad" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).∂M∂z),
+        "ln_massflux_grad" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).∂lnM∂z),
         "massflux_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_h),
         "massflux_tendency_qt" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).massflux_tendency_qt),
         "diffusive_tendency_h" => (; dims = ("zc", "t"), group = "profiles", field = state -> center_aux_turbconv(state).diffusive_tendency_h),

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,6 +132,9 @@ struct BuoyVelEntrDimScale <: EntrDimScale end
 struct InvScaleHeightEntrDimScale <: EntrDimScale end
 struct InvZEntrDimScale <: EntrDimScale end
 struct InvMeterEntrDimScale <: EntrDimScale end
+struct PosMassFluxGradDimScale <: EntrDimScale end
+struct NegMassFluxGradDimScale <: EntrDimScale end
+struct AbsMassFluxGradDimScale <: EntrDimScale end
 
 """
     GradBuoy
@@ -683,7 +686,15 @@ function EDMFModel(::Type{FT}, namelist, precip_model, rain_formation_model) whe
         "EDMF_PrognosticTKE",
         "entr_dim_scale";
         default = "buoy_vel",
-        valid_options = ["buoy_vel", "inv_scale_height", "inv_z", "none"],
+        valid_options = [
+            "buoy_vel",
+            "inv_scale_height",
+            "inv_z",
+            "pos_massflux",
+            "neg_massflux",
+            "abs_massflux",
+            "none",
+        ],
     )
 
     pressure_model_params = PressureModelParams{FT}(;
@@ -712,6 +723,12 @@ function EDMFModel(::Type{FT}, namelist, precip_model, rain_formation_model) whe
         InvScaleHeightEntrDimScale()
     elseif entr_dim_scale == "inv_z"
         InvZEntrDimScale()
+    elseif entr_dim_scale == "pos_massflux"
+        PosMassFluxGradDimScale()
+    elseif entr_dim_scale == "neg_massflux"
+        NegMassFluxGradDimScale()
+    elseif entr_dim_scale == "abs_massflux"
+        AbsMassFluxGradDimScale()
     elseif entr_dim_scale == "none"
         InvMeterEntrDimScale()
     else
@@ -724,7 +741,15 @@ function EDMFModel(::Type{FT}, namelist, precip_model, rain_formation_model) whe
         "EDMF_PrognosticTKE",
         "detr_dim_scale";
         default = "buoy_vel",
-        valid_options = ["buoy_vel", "inv_scale_height", "inv_z", "none"],
+        valid_options = [
+            "buoy_vel",
+            "inv_scale_height",
+            "inv_z",
+            "pos_massflux",
+            "neg_massflux",
+            "abs_massflux",
+            "none",
+        ],
     )
 
     detr_dim_scale = if detr_dim_scale == "buoy_vel"
@@ -733,6 +758,12 @@ function EDMFModel(::Type{FT}, namelist, precip_model, rain_formation_model) whe
         InvScaleHeightEntrDimScale()
     elseif detr_dim_scale == "inv_z"
         InvZEntrDimScale()
+    elseif detr_dim_scale == "pos_massflux"
+        PosMassFluxGradDimScale()
+    elseif detr_dim_scale == "neg_massflux"
+        NegMassFluxGradDimScale()
+    elseif detr_dim_scale == "abs_massflux"
+        AbsMassFluxGradDimScale()
     elseif detr_dim_scale == "none"
         InvMeterEntrDimScale()
     else

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -144,6 +144,7 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         KH = FT(0),
         KQ = FT(0),
         mixing_length = FT(0),
+        massflux = FT(0),
         massflux_tendency_h = FT(0),
         massflux_tendency_qt = FT(0),
         diffusive_tendency_h = FT(0),
@@ -158,6 +159,8 @@ cent_aux_vars_edmf(::Type{FT}, local_geometry, edmf) where {FT} = (;
         w_up_c = FT(0),
         w_en_c = FT(0),
         Shear² = FT(0),
+        ∂M∂z = FT(0),
+        ∂lnM∂z = FT(0),
         ∂θv∂z = FT(0),
         ∂qt∂z = FT(0),
         ∂θl∂z = FT(0),
@@ -227,6 +230,13 @@ cent_diagnostic_vars_edmf(FT, local_geometry, edmf) = (;
         δ_ml_nondim = FT(0),
         massflux = FT(0),
         frac_turb_entr = FT(0),
+        Π_groups = ntuple(i -> FT(0), n_Π_groups(edmf)),
+        Π₁ = FT(0),
+        Π₂ = FT(0),
+        Π₃ = FT(0),
+        Π₄ = FT(0),
+        Π₅ = FT(0),
+        Π₆ = FT(0),
     )
 )
 


### PR DESCRIPTION
Add massflux gradient entr dimensional scales and modify Pi group definitions. Save pi groups to stats file output and ensure computation for every entr closure type.
